### PR TITLE
Option of using 1D histograms instead of KDE plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ plikHM_TTTEEE_lowl_lowE_lensing_NS.tar.gz
 plikHM_TTTEEE_lowl_lowE_lensing_NS/
 .idea/*
 *~
+.pytest_cache/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ plikHM_TTTEEE_lowl_lowE_lensing.tar.gz
 plikHM_TTTEEE_lowl_lowE_lensing/
 plikHM_TTTEEE_lowl_lowE_lensing_NS.tar.gz
 plikHM_TTTEEE_lowl_lowE_lensing_NS/
+.idea/*
+*~

--- a/anesthetic/gui/plot.py
+++ b/anesthetic/gui/plot.py
@@ -101,7 +101,6 @@ class Temperature(Slider):
     def set_text(self, kT):
         """Set the text at end of slider.
 
-
         Parameters
         ----------
             kT: float

--- a/anesthetic/gui/plot.py
+++ b/anesthetic/gui/plot.py
@@ -101,7 +101,8 @@ class Temperature(Slider):
     def set_text(self, kT):
         """Set the text at end of slider.
 
-        Args:
+        Args
+        ----
             kT: float
                 Current temperature of posterior points stage
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -20,7 +20,6 @@ except ImportError:
     from matplotlib.pyplot import hist
 from anesthetic.kde import kde_1d, kde_2d
 from anesthetic.utils import check_bounds, nest_level, unique
-from anesthetic.utils import kwargs_in_func
 from scipy.interpolate import interp1d
 from matplotlib.ticker import MaxNLocator
 from matplotlib.colors import LinearSegmentedColormap
@@ -253,8 +252,7 @@ def plot_1d(ax, data, *args, **kwargs):
     p /= p.max()
     i = (p >= 1e-2)
 
-    plot_kwargs = kwargs_in_func(kwargs, plt.plot)
-    ans = ax.plot(x[i], p[i], *args, **plot_kwargs)
+    ans = ax.plot(x[i], p[i], *args, **kwargs)
     ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
     return ans
 
@@ -302,10 +300,8 @@ def hist_1d(ax, data, *args, **kwargs):
         xmax = data.max()
     histtype = kwargs.pop('histtype', 'bar')
 
-    hist_kwargs = kwargs_in_func(kwargs, plt.hist)
-    hist_kwargs.update(kwargs_in_func(kwargs, hist))
     h, edges, bars = hist(data, ax=ax, range=(xmin, xmax), histtype=histtype,
-                          *args, **hist_kwargs)
+                          *args, **kwargs)
     # As the y-axis on the diagonal 1D plots of the triangle plot won't
     # be labelled, we set the maximum bar height to 1:
     if histtype == 'bar':
@@ -377,17 +373,15 @@ def contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     cmap = basic_cmap(color)
     zorder = max([child.zorder for child in ax.get_children()])
 
-    contourf_kwargs = kwargs_in_func(kwargs, plt.contourf)
     cbar = ax.contourf(x[i], y[j], pdf[numpy.ix_(j, i)], contours,
                        vmin=0, vmax=1.0, cmap=cmap, zorder=zorder+1,
-                       *args, **contourf_kwargs)
+                       *args, **kwargs)
     for c in cbar.collections:
         c.set_cmap(cmap)
 
-    contour_kwargs = kwargs_in_func(kwargs, plt.contour)
     ax.contour(x[i], y[j], pdf[numpy.ix_(j, i)], contours,
                vmin=0, vmax=1.2, linewidths=0.5, colors='k', zorder=zorder+2,
-               *args, **contour_kwargs)
+               *args, **kwargs)
     ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
     ax.set_ylim(*check_bounds(y[j], ymin, ymax), auto=True)
     return cbar
@@ -424,8 +418,7 @@ def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ymin = kwargs.pop('ymin', None)
     ymax = kwargs.pop('ymax', None)
 
-    plot_kwargs = kwargs_in_func(kwargs, plt.plot)
-    points = ax.plot(data_x, data_y, 'o', markersize=1, *args, **plot_kwargs)
+    points = ax.plot(data_x, data_y, 'o', markersize=1, *args, **kwargs)
     ax.set_xlim(*check_bounds(data_x, xmin, xmax), auto=True)
     ax.set_ylim(*check_bounds(data_y, ymin, ymax), auto=True)
     return points

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -166,7 +166,7 @@ def make_2d_axes(params, **kwargs):
             if x == y and not diagonal:
                 continue
 
-            if upper == lower and x != y and not diagonal:
+            if upper == lower and x != y:
                 continue
 
             if axes[x][y] is None:
@@ -176,12 +176,6 @@ def make_2d_axes(params, **kwargs):
                 sy = sy[0] if sy else None
                 axes[x][y] = fig.add_subplot(grid[j, i],
                                              sharex=sx, sharey=sy)
-
-            if upper == lower and x != y and diagonal:
-                axes[x][y].axis('off')
-                axes[x][y]._upper = None
-                continue
-
             if x == y:
                 axes[x][y].twin = axes[x][y].twinx()
                 axes[x][y].twin.set_yticks([])

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -87,7 +87,7 @@ def make_1d_axes(params, **kwargs):
     return fig, axes
 
 
-def make_2d_axes(params, types={'1d': 'kde', '2d':['kde', 'scatter']},
+def make_2d_axes(params, types={'1d': 'kde', '2d': ['kde', 'scatter']},
                  **kwargs):
     """Create a set of axes for plotting 2D marginalised posteriors.
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -88,8 +88,7 @@ def make_1d_axes(params, **kwargs):
     return fig, axes
 
 
-def make_2d_axes(params, types={'1d': 'kde', '2d': ['kde', 'scatter']},
-                 **kwargs):
+def make_2d_axes(params, **kwargs):
     """Create a set of axes for plotting 2D marginalised posteriors.
 
     Parameters
@@ -147,6 +146,7 @@ def make_2d_axes(params, types={'1d': 'kde', '2d': ['kde', 'scatter']},
         grid = GS(*axes.shape, hspace=0, wspace=0)
 
     upper = kwargs.pop('upper', None)
+    diagonal = kwargs.pop('diagonal', True)
 
     if kwargs:
         raise TypeError('Unexpected **kwargs: %r' % kwargs)
@@ -164,10 +164,10 @@ def make_2d_axes(params, types={'1d': 'kde', '2d': ['kde', 'scatter']},
             lower = not (x in axes.index and y in axes.columns
                          and all_params.index(x) > all_params.index(y))
 
-            if x == y and '1d' not in types:
+            if x == y and not diagonal:
                 continue
 
-            if upper == lower and x != y and '1d' not in types:
+            if upper == lower and x != y and not diagonal:
                 continue
 
             if axes[x][y] is None:
@@ -178,7 +178,7 @@ def make_2d_axes(params, types={'1d': 'kde', '2d': ['kde', 'scatter']},
                 axes[x][y] = fig.add_subplot(grid[j, i],
                                              sharex=sx, sharey=sy)
 
-            if upper == lower and x != y and '1d' in types:
+            if upper == lower and x != y and diagonal:
                 axes[x][y].axis('off')
                 axes[x][y]._upper = None
                 continue
@@ -300,7 +300,7 @@ def hist_1d(ax, data, *args, **kwargs):
         xmin = data.min()
     if xmax is None:
         xmax = data.max()
-    histtype = kwargs.pop('histtype', 'step')
+    histtype = kwargs.pop('histtype', 'bar')
 
     hist_kwargs = kwargs_in_func(kwargs, plt.hist)
     hist_kwargs.update(kwargs_in_func(kwargs, hist))

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -14,6 +14,7 @@ import numpy
 import pandas
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec as GS, GridSpecFromSubplotSpec as SGS
+from astropy.visualization import hist
 from anesthetic.kde import kde_1d, kde_2d
 from anesthetic.utils import check_bounds, nest_level, unique
 from scipy.interpolate import interp1d
@@ -244,6 +245,40 @@ def plot_1d(ax, data, *args, **kwargs):
     ans = ax.plot(x[i], p[i], *args, **kwargs)
     ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
     return ans
+
+def hist_1d(ax, data, *args, **kwargs):
+    """Plot a 1d histogram"""
+    if data.max()-data.min() <= 0:
+        return
+
+    xmin = kwargs.pop('xmin', data.min())
+    xmax = kwargs.pop('xmax', data.max())
+    if xmin is None:
+        xmin = data.min()
+    if xmax is None:
+        xmax = data.max()
+    bins = kwargs.pop('bins', 'knuth')
+    histtype = kwargs.pop('histtype', 'step')
+    density = kwargs.pop('density', True)
+
+    not_hist_kwargs = ['s', 'filled', 'linestyles']
+    for key in not_hist_kwargs:
+        _ = kwargs.pop(key, None)
+
+    h, edges, bars = hist(data, bins=bins, ax=ax, max_bins=1000,
+                          range=(xmin, xmax), histtype=histtype, density=density,
+                          alpha=alpha, **kwargs)
+    # As the y-axis on the diagonal 1D plots of the triangle plot won't
+    # be labelled, we set the maximum bar height to 1:
+    if histtype=='bar':
+        for b in bars:
+            b.set_height(b.get_height() / h.max())
+    elif histtype=='step' or histtype=='stepfilled':
+        trans = Affine2D().scale(sx=1, sy=1./h.max()) + ax.transData
+        bars[0].set_transform(trans)
+    ax.set_xlim(*check_bounds(edges, xmin, xmax), auto=True)
+    ax.set_ylim(0, 1.1)
+    return bars
 
 
 def contour_plot_2d(ax, data_x, data_y, *args, **kwargs):

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -87,7 +87,8 @@ def make_1d_axes(params, **kwargs):
     return fig, axes
 
 
-def make_2d_axes(params, types={'1d': 'kde', '2d':['kde', 'scatter']}, **kwargs):
+def make_2d_axes(params, types={'1d': 'kde', '2d':['kde', 'scatter']},
+                 **kwargs):
     """Create a set of axes for plotting 2D marginalised posteriors.
 
     Parameters

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -140,8 +140,8 @@ class MCMCSamples(WeightedDataFrame):
             nsamples = 500
             plot = scatter_plot_2d
         else:
-            raise ValueError("plot_type is '%s', but must be in "
-                             "{'kde', 'scatter'}." % plot_type)
+            raise NotImplementedError("plot_type is '%s', but must be in "
+                                      "{'kde', 'scatter'}." % plot_type)
 
         return plot(ax, self[paramname_x].compress(nsamples),
                     self[paramname_y].compress(nsamples),

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -207,15 +207,11 @@ class MCMCSamples(WeightedDataFrame):
             What type (or types) of plots to produce. Takes the keys 'diagonal'
             for the 1D plots and 'lower' and 'upper' for the 2D plots.
             The options for 'diagonal are either:
-
                 - 'kde'
                 - 'hist.
-
             The options for 'lower' and 'upper' are either:
-
                 - 'kde'
                 - 'scatter'
-
             Default: {'diagonal': 'kde', 'lower': 'kde'}
 
         diagonal_kwargs: dict, optional

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -7,7 +7,7 @@ import numpy
 import pandas
 from scipy.special import logsumexp
 from anesthetic.plot import (make_1d_axes, make_2d_axes, plot_1d,
-                             scatter_plot_2d, contour_plot_2d)
+                             hist_1d, scatter_plot_2d, contour_plot_2d)
 from anesthetic.read.getdist import GetDistReader
 from anesthetic.read.nested import NestedReader
 from anesthetic.utils import compute_nlive
@@ -118,9 +118,14 @@ class MCMCSamples(WeightedDataFrame):
 
         if paramname_y is None or paramname_x == paramname_y:
             xmin, xmax = self._limits(paramname_x)
-            return plot_1d(ax, self[paramname_x].compress(),
-                           xmin=xmin, xmax=xmax,
-                           *args, **kwargs)
+            plot_type_1d = kwargs.pop('plot_type_1d', 'kde')
+            if plot_type_1d == 'kde':
+                plot = plot_1d
+            elif plot_type_1d == 'hist':
+                plot = hist_1d
+            return plot(ax, self[paramname_x].compress(),
+                        xmin=xmin, xmax=xmax,
+                        *args, **kwargs)
 
         xmin, xmax = self._limits(paramname_x)
         ymin, ymax = self._limits(paramname_y)

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -3,7 +3,6 @@
 - ``MCMCSamples``
 - ``NestedSamples``
 """
-from copy import copy
 import numpy
 import pandas
 from scipy.special import logsumexp
@@ -231,6 +230,15 @@ class MCMCSamples(WeightedDataFrame):
         types = kwargs.pop('types', {'diagonal': 'kde', 'lower': 'kde'})
         diagonal = kwargs.pop('diagonal', True)
         if isinstance(types, list) or isinstance(types, str):
+            from warnings import warn
+            warn("MCMCSamples.plot_2d's argument 'types' might stop accepting "
+                 "str or list(str) as input in the future. It takes a "
+                 "dictionary as input, now, with keys 'diagonal' for the 1D "
+                 "plots and 'lower' and 'upper' for the 2D plots. 'diagonal' "
+                 "accepts the values 'kde' or 'hist' and both 'lower' and "
+                 "'upper' accept the values 'kde' or 'scatter'. "
+                 "Default: {'diagonal': 'kde', 'lower': 'kde'}.",
+                 FutureWarning)
             if isinstance(types, str) and diagonal:
                 types = {'diagonal': types, 'lower': types}
             elif isinstance(types, list) and diagonal:

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -218,6 +218,21 @@ class MCMCSamples(WeightedDataFrame):
 
             Default: {'diagonal': 'kde', 'lower': 'kde'}
 
+        diagonal_kwargs: dict, optional
+            kwargs only for the diagonal (1D) plots. This is useful when there
+            is a conflict of kwargs for different types of plots.
+            Default: {}
+
+        lower_kwargs: dict, optional
+            kwargs only for the lower 2D plots. This is useful when there
+            is a conflict of kwargs for different types of plots.
+            Default: {}
+
+        upper_kwargs: dict, optional
+            kwargs only for the upper 2D plots. This is useful when there
+            is a conflict of kwargs for different types of plots.
+            Default: {}
+
         Returns
         -------
         fig: matplotlib.figure.Figure
@@ -247,6 +262,12 @@ class MCMCSamples(WeightedDataFrame):
                          'upper': types[-1]}
             else:
                 types = {'lower': types[0], 'upper': types[-1]}
+        diagonal_kwargs = kwargs.pop('diagonal_kwargs', {})
+        lower_kwargs = kwargs.pop('lower_kwargs', {})
+        upper_kwargs = kwargs.pop('upper_kwargs', {})
+        diagonal_kwargs.update(kwargs)
+        lower_kwargs.update(kwargs)
+        upper_kwargs.update(kwargs)
 
         if not isinstance(axes, pandas.DataFrame):
             upper = None if 'upper' in types else False
@@ -262,11 +283,14 @@ class MCMCSamples(WeightedDataFrame):
                     ax_ = ax
                     if x == y:
                         plot_type = types['diagonal']
+                        kwargs = diagonal_kwargs
                         ax_ = ax.twin
                     elif ax._upper:
                         plot_type = types['upper']
+                        kwargs = upper_kwargs
                     else:
                         plot_type = types['lower']
+                        kwargs = lower_kwargs
                     self.plot(ax_, x, y, plot_type=plot_type, *args, **kwargs)
 
         return fig, axes

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -231,9 +231,13 @@ class MCMCSamples(WeightedDataFrame):
 
         for y, row in axes.iterrows():
             for x, ax in row.iteritems():
-                if ax is not None and x in self and y in self and ax._upper is not None:
+                if (ax is not None and x in self and y in self
+                        and ax._upper is not None):
                     plot_type = copy(types)
-                    plot_type['2d'] = types['2d'][-1] if ax._upper else types['2d'][0]
+                    if ax._upper:
+                        plot_type['2d'] = types['2d'][-1]
+                    else:
+                        plot_type['2d'] = types['2d'][0]
                     ax_ = ax.twin if x == y else ax
                     self.plot(ax_, x, y, plot_type=plot_type, *args, **kwargs)
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -217,16 +217,22 @@ class MCMCSamples(WeightedDataFrame):
         diagonal_kwargs: dict, optional
             kwargs only for the diagonal (1D) plots. This is useful when there
             is a conflict of kwargs for different types of plots.
+            Note that any kwargs directly passed to plot_2d will overwrite any
+            kwarg with the same key passed to diagonal_kwargs.
             Default: {}
 
         lower_kwargs: dict, optional
             kwargs only for the lower 2D plots. This is useful when there
             is a conflict of kwargs for different types of plots.
+            Note that any kwargs directly passed to plot_2d will overwrite any
+            kwarg with the same key passed to lower_kwargs.
             Default: {}
 
         upper_kwargs: dict, optional
             kwargs only for the upper 2D plots. This is useful when there
             is a conflict of kwargs for different types of plots.
+            Note that any kwargs directly passed to plot_2d will overwrite any
+            kwarg with the same key passed to upper_kwargs.
             Default: {}
 
         Returns

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -104,7 +104,8 @@ class MCMCSamples(WeightedDataFrame):
             If not provided, or the same as paramname_x, then 1D plot produced.
 
         plot_type: str, optional
-            Must be in {'kde','scatter'}. (Default: 'kde')
+            Must be in {'kde', 'scatter'} for 2D plots and in {'kde', 'hist'}
+            for 1D plots. (Default: 'kde')
 
         Returns
         -------
@@ -203,11 +204,20 @@ class MCMCSamples(WeightedDataFrame):
             this is used for creating the plot. Otherwise a new set of axes are
             created using the list or lists of strings.
 
-        types: list(str) or str, optional
-            What type (or types) of plots to produce. If two types are provided
-            then pairs of parameters 'above the diagonal' have the second type.
-            each string must be one of {'kde', 'scatter'}.
-            Default: ['kde', 'scatter']
+        types: dict, optional
+            What type (or types) of plots to produce. Takes the keys 'diagonal'
+            for the 1D plots and 'lower' and 'upper' for the 2D plots.
+            The options for 'diagonal are either:
+
+                - 'kde'
+                - 'hist.
+
+            The options for 'lower' and 'upper' are either:
+
+                - 'kde'
+                - 'scatter'
+
+            Default: {'diagonal': 'kde', 'lower': 'kde'}
 
         Returns
         -------

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -157,9 +157,3 @@ def unique(a):
         if x not in b:
             b.append(x)
     return b
-
-
-def kwargs_in_func(kwargs_dict, func):
-    """Find all kwargs that will be used by func."""
-    aspec = inspect.getargspec(func)
-    return {key: kwargs_dict[key] for key in kwargs_dict if key in aspec.args}

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -1,4 +1,5 @@
 """Data-processing utility functions."""
+import inspect
 import numpy
 import pandas
 from scipy.interpolate import interp1d
@@ -156,3 +157,9 @@ def unique(a):
         if x not in b:
             b.append(x)
     return b
+
+
+def kwargs_in_func(kwargs_dict, func):
+    """ Find all kwargs that will be used by func. """
+    argspec = inspect.getargspec(func)
+    return {key: kwargs_dict[key] for key in kwargs_dict if key in argspec.args}

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -161,5 +161,5 @@ def unique(a):
 
 def kwargs_in_func(kwargs_dict, func):
     """ Find all kwargs that will be used by func. """
-    argspec = inspect.getargspec(func)
-    return {key: kwargs_dict[key] for key in kwargs_dict if key in argspec.args}
+    aspec = inspect.getargspec(func)
+    return {key: kwargs_dict[key] for key in kwargs_dict if key in aspec.args}

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -1,5 +1,4 @@
 """Data-processing utility functions."""
-import inspect
 import numpy
 import pandas
 from scipy.interpolate import interp1d

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -160,6 +160,6 @@ def unique(a):
 
 
 def kwargs_in_func(kwargs_dict, func):
-    """ Find all kwargs that will be used by func. """
+    """Find all kwargs that will be used by func."""
     aspec = inspect.getargspec(func)
     return {key: kwargs_dict[key] for key in kwargs_dict if key in aspec.args}

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -48,8 +48,8 @@ def quantile(a, q, w):
         w = numpy.ones_like(a)
     i = numpy.argsort(a)
     c = numpy.cumsum(w[i])
-    c /= c[-1]
-    icdf = interp1d(c/c[-1], a[i])
+    c /= c.values[-1]
+    icdf = interp1d(c/c.values[-1], a[i])
     return icdf(q)
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(name='anesthetic',
       setup_requires=['pytest-runner'],
       extras_require={
           'docs': ['sphinx', 'sphinx_rtd_theme', 'numpydoc'],
+          'automated bins calculation': ['astropy'],
           },
       tests_require=['pytest'],
       include_package_data=True,


### PR DESCRIPTION
Provides part of the enhancement for #2 "Option for histograms as alternative to KDE".

# Changes overview

* Appended `.gitignore`

* Created function `hist_1d()` in plot.py to be called instead of the KDE plot from the function `plot_1d()`.
  - Uses (optionally) astropy's `hist` function which has the same functionality as matplotlib's own hist function with the extension of moresophisticated algorithms for determining bins. The bins keyword e.g. can be set to 'knuth' (default) or 'blocks' (even better but less reliable). Reverts to matplotlib's `hist` if astropy is not installed.
  - The histograms are renormalised such that the highest bar has a height of unity. This simplifies the choice of y-limits and since the y-axis isn't labelled in the diagonal 1D plots of the triangle plots, the absolute height isn't of much interest.
  - added documentation to the hist_1d function
  - cleaned code to make it pep8 conform

* In sampler.py in `MCMCSamples.plot_2d` the argument `types` is now accepting a dictionary specifying the plot types for the `diagonal`, `lower` and `upper` plots. `plot_2d` now also accepts `diagonal_kwargs`, `lower_kwargs` and `upper_kwargs` as kwargs for the different types of sub-plots.

* added a bugfix to utils.py



# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
