### PR TITLE
change plot to scatter for 2D scatter plot option

### DIFF
--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -384,7 +384,7 @@ def contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
 def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
     """Plot samples from a 2d marginalised distribution.
 
-    This functions as a wrapper around matplotlib.axes.Axes.plot, enforcing any
+    This functions as a wrapper around matplotlib.axes.Axes.scatter, enforcing any
     prior bounds. All remaining keyword arguments are passed onwards.
 
     Parameters
@@ -402,17 +402,18 @@ def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
 
     Returns
     -------
-    lines: matplotlib.lines.Line2D
-        A list of line objects representing the plotted data (same as
-        matplotlib matplotlib.axes.Axes.plot command)
+    matplotlib.collections.PathCollection object
+        A PathCollection object representing the plotted data (same as
+        matplotlib matplotlib.axes.Axes.scatter command)
 
     """
     xmin = kwargs.pop('xmin', None)
     xmax = kwargs.pop('xmax', None)
     ymin = kwargs.pop('ymin', None)
     ymax = kwargs.pop('ymax', None)
+    s = kwargs.pop('s', 3)
 
-    points = ax.plot(data_x, data_y, 'o', markersize=1, *args, **kwargs)
+    points = ax.scatter(data_x, data_y, s=s, *args, **kwargs)
     ax.set_xlim(*check_bounds(data_x, xmin, xmax), auto=True)
     ax.set_ylim(*check_bounds(data_y, ymin, ymax), auto=True)
     return points

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -384,8 +384,8 @@ def contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
 def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
     """Plot samples from a 2d marginalised distribution.
 
-    This functions as a wrapper around matplotlib.axes.Axes.scatter, enforcing any
-    prior bounds. All remaining keyword arguments are passed onwards.
+    This functions as a wrapper around matplotlib.axes.Axes.scatter, enforcing
+    any prior bounds. All remaining keyword arguments are passed onwards.
 
     Parameters
     ----------

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_array_equal
 
 from matplotlib.contour import QuadContourSet
 from matplotlib.lines import Line2D
+from matplotlib.collections import PatchCollection
 from matplotlib.figure import Figure
 from pandas.core.series import Series
 from pandas.core.frame import DataFrame
@@ -208,26 +209,26 @@ def test_scatter_plot_2d():
     numpy.random.seed(2)
     data_x = numpy.random.randn(1000)
     data_y = numpy.random.randn(1000)
-    lines, = scatter_plot_2d(ax, data_x, data_y)
-    assert(isinstance(lines, Line2D))
+    points = scatter_plot_2d(ax, data_x, data_y)
+    assert(isinstance(points, PatchCollection))
 
     xmin, xmax, ymin, ymax = -0.5, 0.5, -0.5, 0.5
     ax = plt.gca()
-    contour_plot_2d(ax, data_x, data_y, xmin=xmin)
+    scatter_plot_2d(ax, data_x, data_y, xmin=xmin)
     assert(ax.get_xlim()[0] >= xmin)
     plt.close()
 
     ax = plt.gca()
-    contour_plot_2d(ax, data_x, data_y, xmax=xmax)
+    scatter_plot_2d(ax, data_x, data_y, xmax=xmax)
     assert(ax.get_xlim()[1] <= xmax)
     plt.close()
 
     ax = plt.gca()
-    contour_plot_2d(ax, data_x, data_y, ymin=ymin)
+    scatter_plot_2d(ax, data_x, data_y, ymin=ymin)
     assert(ax.get_ylim()[0] >= ymin)
     plt.close()
 
     ax = plt.gca()
-    contour_plot_2d(ax, data_x, data_y, ymax=ymax)
+    scatter_plot_2d(ax, data_x, data_y, ymax=ymax)
     assert(ax.get_ylim()[1] <= ymax)
     plt.close()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_equal
 
 from matplotlib.contour import QuadContourSet
 from matplotlib.lines import Line2D
-from matplotlib.collections import PatchCollection
+from matplotlib.collections import PathCollection
 from matplotlib.figure import Figure
 from pandas.core.series import Series
 from pandas.core.frame import DataFrame
@@ -210,7 +210,7 @@ def test_scatter_plot_2d():
     data_x = numpy.random.randn(1000)
     data_y = numpy.random.randn(1000)
     points = scatter_plot_2d(ax, data_x, data_y)
-    assert(isinstance(points, PatchCollection))
+    assert(isinstance(points, PathCollection))
 
     xmin, xmax, ymin, ymax = -0.5, 0.5, -0.5, 0.5
     ax = plt.gca()


### PR DESCRIPTION
* Change `ax.plot` to `ax.scatter` in `scatter_plot_2d` in plot.py
  - This is more true to the intention of the plots and provides the
    additional functionalities of a scatter plot (could be expanded to
    make so-to-speak '3D' plots using a colormap).
  - Change default markersize to s=3 as the matplotlib default is
    typically too large for the amount of points we are dealing with
    here.
  - Documentation adapted accordingly.

Changes to be committed:
* modified:   anesthetic/plot.py


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
