### PR TITLE
set matplotlib.use('Agg') in test*.py files to avoide ImportError for Tkinter

### DIFF
--- a/tests/matplotlib_agg.py
+++ b/tests/matplotlib_agg.py
@@ -1,0 +1,3 @@
+import matplotlib
+matplotlib.use('Agg')
+

--- a/tests/matplotlib_agg.py
+++ b/tests/matplotlib_agg.py
@@ -1,3 +1,2 @@
 import matplotlib
 matplotlib.use('Agg')
-

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use('Agg')
 from anesthetic import NestedSamples
 
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,4 +1,4 @@
-import matplotlib_agg
+import matplotlib_agg  # noqa: F401
 from anesthetic import NestedSamples
 
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,5 +1,4 @@
-import matplotlib
-matplotlib.use('Agg')
+import matplotlib_agg
 from anesthetic import NestedSamples
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use('Agg')
 import pytest
 import numpy
 import matplotlib.pyplot as plt

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,5 +1,4 @@
-import matplotlib
-matplotlib.use('Agg')
+import matplotlib_agg
 import pytest
 import numpy
 import matplotlib.pyplot as plt

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,4 +1,4 @@
-import matplotlib_agg
+import matplotlib_agg  # noqa: F401
 import pytest
 import numpy
 import matplotlib.pyplot as plt

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1,4 +1,4 @@
-import matplotlib_agg
+import matplotlib_agg  # noqa: F401
 import numpy
 from anesthetic import MCMCSamples, NestedSamples
 from numpy.testing import assert_array_equal

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1,5 +1,4 @@
-import matplotlib
-matplotlib.use('Agg')
+import matplotlib_agg
 import numpy
 from anesthetic import MCMCSamples, NestedSamples
 from numpy.testing import assert_array_equal

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use('Agg')
 import numpy
 from anesthetic import MCMCSamples, NestedSamples
 from numpy.testing import assert_array_equal


### PR DESCRIPTION
# Description

Using `matplotlib.pyplot` when running pytest will throw 
```python
ImportError: No module named Tkinter
```
for many people (particularly people using jupyter notebooks?). All this requires to fix it is to put the lines
```python
import matplotlib
matplotlib.use('Agg')
```
at the head of the `test/test*.py` files.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
