### PR TITLE
Pip caching and parallelisation to speed up travis builds

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit =anesthetic/gui/_matplotlib.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ install:
       else
           pip install -r requirements_minimal.txt;
       fi
-    - pip install pytest-cov pytest-xdist codecov;
+    - pip install pytest-cov codecov;
     - pip install flake8 pydocstyle sphinx sphinx_rtd_theme;
 
 before_script:
@@ -106,8 +106,7 @@ before_script:
 
 # Run tests
 script:
-    - CPU_COUNT=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
-    - python -m pytest -n $CPU_COUNT tests --cov=anesthetic
+      python -m pytest -n 2 tests --cov=anesthetic;
 
 # Run coverage summary
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ before_script:
 
 # Run tests
 script:
-      python -m pytest --cov=anesthetic -n 2 tests/;
+      python -m pytest --cov=anesthetic -n auto tests/;
 
 # Run coverage summary
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ before_script:
 
 # Run tests
 script:
-      python -m pytest -n 2 tests --cov=anesthetic;
+      python -m pytest --cov=anesthetic -n 2 tests/;
 
 # Run coverage summary
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ install:
       else
           pip install -r requirements_minimal.txt;
       fi
-    - pip install pytest-cov codecov;
+    - pip install pytest-cov pytest-xdist codecov;
     - pip install flake8 pydocstyle sphinx sphinx_rtd_theme;
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,8 +106,8 @@ before_script:
 
 # Run tests
 script:
-    - CPU_COUNT=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())'); echo $(CPU_COUNT)
-    - python -m pytest -n $(CPU_COUNT) tests --cov=anesthetic; echo $(CPU_COUNT)
+    - CPU_COUNT=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())'); echo $CPU_COUNT
+    - python -m pytest -n $CPU_COUNT tests --cov=anesthetic; echo $CPU_COUNT
 
 # Run coverage summary
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ install:
       else
           pip install -r requirements_minimal.txt;
       fi
-    - pip install pytest-cov codecov;
+    - pip install pytest-cov pytest-xdist codecov;
     - pip install flake8 pydocstyle sphinx sphinx_rtd_theme;
 
 before_script:
@@ -106,7 +106,8 @@ before_script:
 
 # Run tests
 script:
-      python -m pytest tests --cov=anesthetic;
+    - CPU_COUNT=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())'); echo $(CPU_COUNT)
+    - python -m pytest -n $(CPU_COUNT) tests --cov=anesthetic; echo $(CPU_COUNT)
 
 # Run coverage summary
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,8 +106,8 @@ before_script:
 
 # Run tests
 script:
-    - CPU_COUNT=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())'); echo $CPU_COUNT
-    - python -m pytest -n $CPU_COUNT tests --cov=anesthetic; echo $CPU_COUNT
+    - CPU_COUNT=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
+    - python -m pytest -n $CPU_COUNT tests --cov=anesthetic
 
 # Run coverage summary
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - "3.5"
     - "2.7"
     - "3.7"
+cache: pip
 env:
     - 
     - CONDA=1
@@ -18,6 +19,7 @@ matrix:
         # OSX
         - os: osx
           language: generic
+          cache: pip
         # OSX conda
         - os: osx
           language: generic
@@ -25,18 +27,22 @@ matrix:
         # OSX extras
         - os: osx
           language: generic
+          cache: pip
           env: EXTRAS=1
         # OSX conda + extras
         - os: osx
           language: generic
+          cache: pip
           env: CONDA=1 EXTRAS=1
         # MontePython master branch check
         - os: linux
           python: 2.7
+          cache: pip
           env: EXTRAS=1 MONTEPYTHONMASTER=1
     allow_failures:
         - os: linux
           python: 2.7
+          cache: pip
           env: EXTRAS=1 MONTEPYTHONMASTER=1
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,31 +14,37 @@ env:
     - EXTRAS=1
     - CONDA=1 EXTRAS=1
 
+# OSX and MontePython master
 matrix:
     include:
         # OSX
         - os: osx
           language: generic
           cache: pip
+
         # OSX conda
         - os: osx
           language: generic
           env: CONDA=1 
+
         # OSX extras
         - os: osx
           language: generic
           cache: pip
           env: EXTRAS=1
+
         # OSX conda + extras
         - os: osx
           language: generic
           cache: pip
           env: CONDA=1 EXTRAS=1
+
         # MontePython master branch check
         - os: linux
           python: 2.7
           cache: pip
           env: EXTRAS=1 MONTEPYTHONMASTER=1
+
     allow_failures:
         - os: linux
           python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,7 @@ install:
       else
           pip install -r requirements_minimal.txt;
       fi
+    - pip install --upgrade pytest;
     - pip install pytest-cov pytest-xdist codecov;
     - pip install flake8 pydocstyle sphinx sphinx_rtd_theme;
 

--- a/run_tests
+++ b/run_tests
@@ -7,5 +7,4 @@ echo "Running docstring checks"
 pydocstyle --convention=numpy anesthetic
 
 echo "Running code tests"
-CPU_COUNT=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
-python -m pytest -n $CPU_COUNT
+python -m pytest -n auto

--- a/run_tests
+++ b/run_tests
@@ -7,4 +7,5 @@ echo "Running docstring checks"
 pydocstyle --convention=numpy anesthetic
 
 echo "Running code tests"
-python -m pytest
+CPU_COUNT=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
+python -m pytest -n $CPU_COUNT


### PR DESCRIPTION
The build matrix is large, and testing times are now getting quite long. It
would be nice if we didn't burn a lot of unecessary time installing via pip
over and over again