### PR TITLE
Fix types

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -145,8 +145,8 @@ class MCMCSamples(WeightedDataFrame):
                 raise NotImplementedError("plot_type is '%s', but must be in "
                                           "{'kde', 'scatter'}." % plot_type)
 
-            if ((paramname_x in self and paramname_y in self)
-               and plot_type is not None):
+            if (paramname_x in self and paramname_y in self
+                    and plot_type is not None):
                 x = self[paramname_x].compress(nsamples)
                 y = self[paramname_y].compress(nsamples)
             else:

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -122,10 +122,10 @@ class MCMCSamples(WeightedDataFrame):
                 plot = plot_1d
             elif plot_type == 'hist':
                 plot = hist_1d
-            else:
+            elif plot_type is not None:
                 raise NotImplementedError("plot_type is '%s', but must be in "
                                           "{'kde', 'hist'}." % plot_type)
-            if paramname_x in self:
+            if paramname_x in self and plot_type is not None:
                 x = self[paramname_x].compress()
             else:
                 x = []
@@ -142,11 +142,12 @@ class MCMCSamples(WeightedDataFrame):
             elif plot_type == 'scatter':
                 nsamples = 500
                 plot = scatter_plot_2d
-            else:
+            elif plot_type is not None:
                 raise NotImplementedError("plot_type is '%s', but must be in "
                                           "{'kde', 'scatter'}." % plot_type)
 
-            if paramname_x in self and paramname_y in self:
+            if ((paramname_x in self and paramname_y in self)
+               and plot_type is not None):
                 x = self[paramname_x].compress(nsamples)
                 y = self[paramname_y].compress(nsamples)
             else:
@@ -271,17 +272,19 @@ class MCMCSamples(WeightedDataFrame):
         else:
             fig = axes.values[~axes.isna()][0].figure
 
+        for pos in default_types:
+            if pos not in types:
+                types[pos] = None
+            if pos not in local_kwargs:
+                local_kwargs[pos] = {}
+
         for y, row in axes.iterrows():
             for x, ax in row.iteritems():
                 if ax is not None:
                     pos = ax.position
                     ax_ = ax.twin if x == y else ax
-                    if pos in types:
-                        self.plot(ax_, x, y, plot_type=types[pos], *args,
-                                  **local_kwargs[pos])
-                    else:  # need this to increment color cycle
-                        ax_.plot([], [])
-                        ax_.scatter([], [])
+                    self.plot(ax_, x, y, plot_type=types[pos], *args,
+                              **local_kwargs[pos])
 
         return fig, axes
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -136,13 +136,12 @@ class MCMCSamples(WeightedDataFrame):
             xmin, xmax = self._limits(paramname_x)
             ymin, ymax = self._limits(paramname_y)
 
-            if plot_type == 'kde':
-                nsamples = None
-                plot = contour_plot_2d
-            elif plot_type == 'scatter':
+            nsamples = None
+            plot = contour_plot_2d
+            if plot_type == 'scatter':
                 nsamples = 500
                 plot = scatter_plot_2d
-            elif plot_type is not None:
+            elif plot_type != 'kde' and plot_type is not None:
                 raise NotImplementedError("plot_type is '%s', but must be in "
                                           "{'kde', 'scatter'}." % plot_type)
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -276,8 +276,12 @@ class MCMCSamples(WeightedDataFrame):
                 if ax is not None:
                     pos = ax.position
                     ax_ = ax.twin if x == y else ax
-                    self.plot(ax_, x, y, plot_type=types[pos], *args,
-                              **local_kwargs[pos])
+                    if pos in types:
+                        self.plot(ax_, x, y, plot_type=types[pos], 
+                                  *args, **local_kwargs[pos])
+                    else:  # need this to increment color cycle
+                        ax_.plot([], [])
+                        ax_.scatter([], [])
 
         return fig, axes
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -237,7 +237,6 @@ class MCMCSamples(WeightedDataFrame):
         """
         default_types = {'diagonal': 'kde', 'lower': 'kde', 'upper': 'scatter'}
         types = kwargs.pop('types', default_types)
-
         diagonal = kwargs.pop('diagonal', True)
         if isinstance(types, list) or isinstance(types, str):
             from warnings import warn
@@ -261,7 +260,8 @@ class MCMCSamples(WeightedDataFrame):
 
         local_kwargs = {pos: kwargs.pop('%s_kwargs' % pos, {})
                         for pos in default_types}
-        for pos in default_types:
+
+        for pos in local_kwargs:
             local_kwargs[pos].update(kwargs)
 
         if not isinstance(axes, pandas.DataFrame):
@@ -275,8 +275,8 @@ class MCMCSamples(WeightedDataFrame):
         for y, row in axes.iterrows():
             for x, ax in row.iteritems():
                 if ax is not None:
-                    ax_ = ax.twin if x == y else ax
                     pos = ax.position
+                    ax_ = ax.twin if x == y else ax
                     plot_type = types.get(pos, None)
                     lkwargs = local_kwargs.get(pos, {})
                     self.plot(ax_, x, y, plot_type=plot_type, *args, **lkwargs)

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -236,6 +236,7 @@ class MCMCSamples(WeightedDataFrame):
         """
         default_types = {'diagonal': 'kde', 'lower': 'kde', 'upper': 'scatter'}
         types = kwargs.pop('types', default_types)
+
         diagonal = kwargs.pop('diagonal', True)
         if isinstance(types, list) or isinstance(types, str):
             from warnings import warn
@@ -258,24 +259,19 @@ class MCMCSamples(WeightedDataFrame):
                     types['diagonal'] = types['lower']
 
         local_kwargs = {pos: kwargs.pop('%s_kwargs' % pos, {})
-                        for pos in ['lower', 'upper', 'diagonal']}
-
-        for pos in local_kwargs:
+                        for pos in default_types}
+        for pos in default_types:
             local_kwargs[pos].update(kwargs)
+            if pos not in types:
+                types[pos] = None
 
         if not isinstance(axes, pandas.DataFrame):
             fig, axes = make_2d_axes(axes, tex=self.tex,
-                                     upper=('upper' in types),
-                                     lower=('lower' in types),
-                                     diagonal=('diagonal' in types))
+                                     upper=(types['upper'] is not None),
+                                     lower=(types['lower'] is not None),
+                                     diagonal=(types['diagonal'] is not None))
         else:
             fig = axes.values[~axes.isna()][0].figure
-
-        for pos in default_types:
-            if pos not in types:
-                types[pos] = None
-            if pos not in local_kwargs:
-                local_kwargs[pos] = {}
 
         for y, row in axes.iterrows():
             for x, ax in row.iteritems():

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -118,11 +118,11 @@ class MCMCSamples(WeightedDataFrame):
 
         if do_1d_plot:
             xmin, xmax = self._limits(paramname_x)
-            if plot_type == 'kde':
+            if plot_type == 'kde' or plot_type is None:
                 plot = plot_1d
             elif plot_type == 'hist':
                 plot = hist_1d
-            elif plot_type is not None:
+            else:
                 raise NotImplementedError("plot_type is '%s', but must be in "
                                           "{'kde', 'hist'}." % plot_type)
             if paramname_x in self and plot_type is not None:
@@ -136,12 +136,13 @@ class MCMCSamples(WeightedDataFrame):
             xmin, xmax = self._limits(paramname_x)
             ymin, ymax = self._limits(paramname_y)
 
-            nsamples = None
-            plot = contour_plot_2d
-            if plot_type == 'scatter':
+            if plot_type == 'kde' or plot_type is None:
+                nsamples = None
+                plot = contour_plot_2d
+            elif plot_type == 'scatter':
                 nsamples = 500
                 plot = scatter_plot_2d
-            elif plot_type != 'kde' and plot_type is not None:
+            else:
                 raise NotImplementedError("plot_type is '%s', but must be in "
                                           "{'kde', 'scatter'}." % plot_type)
 
@@ -260,16 +261,12 @@ class MCMCSamples(WeightedDataFrame):
 
         local_kwargs = {pos: kwargs.pop('%s_kwargs' % pos, {})
                         for pos in default_types}
-        for pos in default_types:
-            local_kwargs[pos].update(kwargs)
-            if pos not in types:
-                types[pos] = None
 
         if not isinstance(axes, pandas.DataFrame):
             fig, axes = make_2d_axes(axes, tex=self.tex,
-                                     upper=(types['upper'] is not None),
-                                     lower=(types['lower'] is not None),
-                                     diagonal=(types['diagonal'] is not None))
+                                     upper=('upper' in types),
+                                     lower=('lower' in types),
+                                     diagonal=('diagonal' in types))
         else:
             fig = axes.values[~axes.isna()][0].figure
 
@@ -278,8 +275,8 @@ class MCMCSamples(WeightedDataFrame):
                 if ax is not None:
                     pos = ax.position
                     ax_ = ax.twin if x == y else ax
-                    self.plot(ax_, x, y, plot_type=types[pos], *args,
-                              **local_kwargs[pos])
+                    self.plot(ax_, x, y, plot_type=types.get(pos, None),
+                              *args, **local_kwargs.get(pos, {}))
 
         return fig, axes
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -277,8 +277,8 @@ class MCMCSamples(WeightedDataFrame):
                     pos = ax.position
                     ax_ = ax.twin if x == y else ax
                     if pos in types:
-                        self.plot(ax_, x, y, plot_type=types[pos], 
-                                  *args, **local_kwargs[pos])
+                        self.plot(ax_, x, y, plot_type=types[pos], *args,
+                                  **local_kwargs[pos])
                     else:  # need this to increment color cycle
                         ax_.plot([], [])
                         ax_.scatter([], [])

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -261,6 +261,8 @@ class MCMCSamples(WeightedDataFrame):
 
         local_kwargs = {pos: kwargs.pop('%s_kwargs' % pos, {})
                         for pos in default_types}
+        for pos in default_types:
+            local_kwargs[pos].update(kwargs)
 
         if not isinstance(axes, pandas.DataFrame):
             fig, axes = make_2d_axes(axes, tex=self.tex,
@@ -273,10 +275,11 @@ class MCMCSamples(WeightedDataFrame):
         for y, row in axes.iterrows():
             for x, ax in row.iteritems():
                 if ax is not None:
-                    pos = ax.position
                     ax_ = ax.twin if x == y else ax
-                    self.plot(ax_, x, y, plot_type=types.get(pos, None),
-                              *args, **local_kwargs.get(pos, {}))
+                    pos = ax.position
+                    plot_type = types.get(pos, None)
+                    lkwargs = local_kwargs.get(pos, {})
+                    self.plot(ax_, x, y, plot_type=plot_type, *args, **lkwargs)
 
         return fig, axes
 

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -111,6 +111,7 @@ def test_different_parameters():
     ns.plot_2d(axes)
     fig, axes = make_2d_axes([params_x, params_y])
     ns.plot_2d(axes)
+    plt.close('all')
 
 
 def test_plot_2d_types():
@@ -145,3 +146,19 @@ def test_plot_2d_types():
                                           'upper': 'scatter'})
     assert((~axes.isnull()).sum().sum() == 12)
     plt.close("all")
+
+
+def test_plot_2d_types_multiple_calls():
+    ns = NestedSamples(root='./tests/example_data/pc')
+    params = ['x0', 'x1', 'x2', 'x3']
+
+    fig, axes = ns.plot_2d(params, types={'diagonal': 'kde',
+                                          'lower': 'kde',
+                                          'upper': 'scatter'})
+    ns.plot_2d(axes, types={'diagonal': 'hist'})
+
+    fig, axes = ns.plot_2d(params, types={'diagonal': 'hist'})
+    ns.plot_2d(axes, types={'diagonal': 'kde',
+                            'lower': 'kde',
+                            'upper': 'scatter'})
+    plt.close('all')


### PR DESCRIPTION
# Description

* Fixes problem No.1 in #13 but not yet No.2.
  - This means requesting fewer plots with `types` in a second call to
    `plot_2d` is now possible.
  - This fix could be probably further simplified.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
