### PR TITLE
Make legend handling more intuitive and consistent with `matplotlib`

### DIFF
--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -351,6 +351,7 @@ def contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     xmax = kwargs.pop('xmax', None)
     ymin = kwargs.pop('ymin', None)
     ymax = kwargs.pop('ymax', None)
+    label = kwargs.pop('label')
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
     if len(data_x) == 0 or len(data_y) == 0:
         return numpy.zeros(0), numpy.zeros(0), numpy.zeros((0, 0))
@@ -389,6 +390,9 @@ def contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ax.contour(x[i], y[j], pdf[numpy.ix_(j, i)], contours,
                vmin=0, vmax=1.2, linewidths=0.5, colors='k', zorder=zorder+2,
                *args, **kwargs)
+    ax.patches += [plt.Rectangle((0, 0), 1, 1, fc=cmap(0.999), ec=cmap(0.33),
+                                 lw=2, label=label)]
+
     ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
     ax.set_ylim(*check_bounds(y[j], ymin, ymax), auto=True)
     return cbar

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -351,7 +351,7 @@ def contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     xmax = kwargs.pop('xmax', None)
     ymin = kwargs.pop('ymin', None)
     ymax = kwargs.pop('ymax', None)
-    label = kwargs.pop('label')
+    label = kwargs.pop('label', None)
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
     if len(data_x) == 0 or len(data_y) == 0:
         return numpy.zeros(0), numpy.zeros(0), numpy.zeros((0, 0))

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -352,6 +352,7 @@ def contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ymin = kwargs.pop('ymin', None)
     ymax = kwargs.pop('ymax', None)
     label = kwargs.pop('label', None)
+    zorder = kwargs.pop('zorder', 1)
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
     if len(data_x) == 0 or len(data_y) == 0:
         return numpy.zeros(0), numpy.zeros(0), numpy.zeros((0, 0))
@@ -380,12 +381,12 @@ def contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
 
     cmap = basic_cmap(color)
 
-    cbar = ax.contourf(x[i], y[j], pdf[numpy.ix_(j, i)], contours,
-                       vmin=0, vmax=1.0, cmap=cmap, *args, **kwargs)
+    cbar = ax.contourf(x[i], y[j], pdf[numpy.ix_(j, i)], contours, cmap=cmap,
+                       zorder=zorder, vmin=0, vmax=1.0, *args, **kwargs)
     for c in cbar.collections:
         c.set_cmap(cmap)
 
-    ax.contour(x[i], y[j], pdf[numpy.ix_(j, i)], contours,
+    ax.contour(x[i], y[j], pdf[numpy.ix_(j, i)], contours, zorder=zorder,
                vmin=0, vmax=1.2, linewidths=0.5, colors='k', *args, **kwargs)
     ax.patches += [plt.Rectangle((0, 0), 1, 1, fc=cmap(0.999), ec=cmap(0.33),
                                  lw=2, label=label)]

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -184,6 +184,10 @@ def make_2d_axes(params, **kwargs):
                     axes[x][y].twin.set_yticks([])
                     axes[x][y].twin.set_ylim(0, 1.1)
                     axes[x][y].set_zorder(axes[x][y].twin.get_zorder() + 1)
+                    axes[x][y].lines = axes[x][y].twin.lines
+                    axes[x][y].patches = axes[x][y].twin.patches
+                    axes[x][y].collections = axes[x][y].twin.collections
+                    axes[x][y].containers = axes[x][y].twin.containers
                     axes[x][y].position = 'diagonal'
                 elif position[x][y] == 1:
                     axes[x][y].position = 'upper'

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -183,6 +183,7 @@ def make_2d_axes(params, **kwargs):
                     axes[x][y].twin = axes[x][y].twinx()
                     axes[x][y].twin.set_yticks([])
                     axes[x][y].twin.set_ylim(0, 1.1)
+                    axes[x][y].set_zorder(axes[x][y].twin.get_zorder() + 1)
                     axes[x][y].position = 'diagonal'
                 elif position[x][y] == 1:
                     axes[x][y].position = 'upper'
@@ -378,17 +379,14 @@ def contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     j = (pdf >= 1e-2).any(axis=1)
 
     cmap = basic_cmap(color)
-    zorder = max([child.zorder for child in ax.get_children()])
 
     cbar = ax.contourf(x[i], y[j], pdf[numpy.ix_(j, i)], contours,
-                       vmin=0, vmax=1.0, cmap=cmap, zorder=zorder+1,
-                       *args, **kwargs)
+                       vmin=0, vmax=1.0, cmap=cmap, *args, **kwargs)
     for c in cbar.collections:
         c.set_cmap(cmap)
 
     ax.contour(x[i], y[j], pdf[numpy.ix_(j, i)], contours,
-               vmin=0, vmax=1.2, linewidths=0.5, colors='k', zorder=zorder+2,
-               *args, **kwargs)
+               vmin=0, vmax=1.2, linewidths=0.5, colors='k', *args, **kwargs)
     ax.patches += [plt.Rectangle((0, 0), 1, 1, fc=cmap(0.999), ec=cmap(0.33),
                                  lw=2, label=label)]
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -451,6 +451,12 @@ def get_legend_proxy(fig):
             Figure to extract colors from.
 
     """
+    from warnings import warn
+    warn("`get_legend_proxy` is deprecated and might be deleted in the "
+         "future. You can now simply use `axes[x][y].legend()` or do "
+         "`handles, labels = axes[x][y].get_legend_handles_labels()` "
+         "and pass the handles and labels to the figure legend "
+         "`fig.legend(handles, labels)`.", FutureWarning)
     cmaps = [coll.get_cmap() for ax in fig.axes for coll in ax.collections
              if isinstance(coll.get_cmap(), LinearSegmentedColormap)]
     cmaps = unique(cmaps)

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -183,6 +183,7 @@ def make_2d_axes(params, **kwargs):
                     axes[x][y].twin = axes[x][y].twinx()
                     axes[x][y].twin.set_yticks([])
                     axes[x][y].twin.set_ylim(0, 1.1)
+                    axes[x][y].twin.position = 'diagonal'
                     axes[x][y].position = 'diagonal'
                 elif position[x][y] == 1:
                     axes[x][y].position = 'upper'

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -183,7 +183,6 @@ def make_2d_axes(params, **kwargs):
                     axes[x][y].twin = axes[x][y].twinx()
                     axes[x][y].twin.set_yticks([])
                     axes[x][y].twin.set_ylim(0, 1.1)
-                    axes[x][y].twin.position = 'diagonal'
                     axes[x][y].position = 'diagonal'
                 elif position[x][y] == 1:
                     axes[x][y].position = 'upper'

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -281,6 +281,12 @@ class MCMCSamples(WeightedDataFrame):
                     lkwargs = local_kwargs.get(pos, {})
                     self.plot(ax_, x, y, plot_type=plot_type, *args, **lkwargs)
 
+        for y, row in axes.iterrows():
+            for x, ax in row.iteritems():
+                if x == y:
+                    axes[x][y] = axes[x][y].twin
+                    axes[x][y].twin = axes[x][y]
+
         return fig, axes
 
     def _limits(self, paramname):

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -283,7 +283,7 @@ class MCMCSamples(WeightedDataFrame):
 
         for y, row in axes.iterrows():
             for x, ax in row.iteritems():
-                if x == y:
+                if x == y and ax is not None:
                     axes[x][y] = axes[x][y].twin
                     axes[x][y].twin = axes[x][y]
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -286,6 +286,8 @@ class MCMCSamples(WeightedDataFrame):
                 if x == y and ax is not None:
                     ax.lines = ax.twin.lines
                     ax.patches = ax.twin.patches
+                    ax.collections = ax.twin.collections
+                    ax.containers = ax.twin.containers
 
         return fig, axes
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -281,14 +281,6 @@ class MCMCSamples(WeightedDataFrame):
                     lkwargs = local_kwargs.get(pos, {})
                     self.plot(ax_, x, y, plot_type=plot_type, *args, **lkwargs)
 
-        for y, row in axes.iterrows():
-            for x, ax in row.iteritems():
-                if x == y and ax is not None:
-                    ax.lines = ax.twin.lines
-                    ax.patches = ax.twin.patches
-                    ax.collections = ax.twin.collections
-                    ax.containers = ax.twin.containers
-
         return fig, axes
 
     def _limits(self, paramname):

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -284,8 +284,8 @@ class MCMCSamples(WeightedDataFrame):
         for y, row in axes.iterrows():
             for x, ax in row.iteritems():
                 if x == y and ax is not None:
-                    axes[x][y] = axes[x][y].twin
-                    axes[x][y].twin = axes[x][y]
+                    ax.lines = ax.twin.lines
+                    ax.patches = ax.twin.patches
 
         return fig, axes
 

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -102,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mcmc.plot_2d(['omegabh2','omegach2','H0'], types=['kde']);"
+    "mcmc.plot_2d(['omegabh2','omegach2','H0'], types={'lower':'kde','diagonal':'kde'});"
    ]
   },
   {
@@ -366,12 +366,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from anesthetic import get_legend_proxy\n",
     "prior = nested.set_beta(0)\n",
-    "fig, axes = prior.plot_2d(['ns','tau'])\n",
-    "nested.plot_2d(axes=axes)\n",
-    "proxy = get_legend_proxy(fig)\n",
-    "fig.legend(proxy, ['prior', 'posterior'])"
+    "fig, axes = prior.plot_2d(['ns','tau'], label='prior')\n",
+    "nested.plot_2d(axes=axes, label='posterior')\n",
+    "handles, labels = axes['ns']['tau'].get_legend_handles_labels()\n",
+    "leg = fig.legend(handles, labels)\n",
+    "fig.tight_layout()"
    ]
   },
   {

--- a/demo.py
+++ b/demo.py
@@ -39,7 +39,7 @@ fig.tight_layout()
 
 #| ... triangle plots ...
 
-mcmc.plot_2d(['omegabh2','omegach2','H0'], types=['kde']);
+mcmc.plot_2d(['omegabh2','omegach2','H0'], types={'lower':'kde','diagonal':'kde'});
 
 #| ... triangle plots (with the equivalent scatter plot filling up the left hand side) ...
 
@@ -123,12 +123,12 @@ nested.plot_2d(axes=axes);
 #| passing beta=0. We also introduce here the helper function ``get_legend_proxy``
 #| for creating figure legends.
 
-from anesthetic import get_legend_proxy
 prior = nested.set_beta(0)
-fig, axes = prior.plot_2d(['ns','tau'])
-nested.plot_2d(axes=axes)
-proxy = get_legend_proxy(fig)
-fig.legend(proxy, ['prior', 'posterior'])
+fig, axes = prior.plot_2d(['ns','tau'], label='prior')
+nested.plot_2d(axes=axes, label='posterior')
+handles, labels = axes['ns']['tau'].get_legend_handles_labels()
+leg = fig.legend(handles, labels)
+fig.tight_layout()
 
 #| We can also set up an interactive plot, which allows us to replay a nested
 #| sampling run after the fact.

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -3,6 +3,9 @@ import sys
 import pytest
 import numpy
 import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+from matplotlib.patches import Rectangle
+from matplotlib.collections import PathCollection
 from anesthetic import MCMCSamples, NestedSamples, make_1d_axes, make_2d_axes
 from numpy.testing import assert_array_equal
 try:
@@ -161,4 +164,41 @@ def test_plot_2d_types_multiple_calls():
     ns.plot_2d(axes, types={'diagonal': 'kde',
                             'lower': 'kde',
                             'upper': 'scatter'})
+    plt.close('all')
+
+
+def test_plot_2d_legend():
+    ns1 = NestedSamples(root='./tests/example_data/pc')
+    ns2 = NestedSamples(root='./tests/example_data/pc')
+    params = ['x0', 'x1', 'x2', 'x3']
+
+    fig, axes = make_2d_axes(params, upper=False)
+    ns1.plot_2d(axes, label='l1', types=dict(diagonal='kde', lower='kde'))
+    ns2.plot_2d(axes, label='l2', types=dict(diagonal='kde', lower='kde'))
+
+    for y, row in axes.iterrows():
+        for x, ax in row.iteritems():
+            if ax is not None:
+                handles, labels = ax.get_legend_handles_labels()
+                assert(labels == ['l1', 'l2'])
+                if x == y:
+                    assert(all([isinstance(h, Line2D) for h in handles]))
+                else:
+                    assert(all([isinstance(h, Rectangle) for h in handles]))
+    plt.close('all')
+
+    fig, axes = make_2d_axes(params, lower=False)
+    ns1.plot_2d(axes, label='l1', types=dict(diagonal='hist', upper='scatter'))
+    ns2.plot_2d(axes, label='l2', types=dict(diagonal='hist', upper='scatter'))
+
+    for y, row in axes.iterrows():
+        for x, ax in row.iteritems():
+            if ax is not None:
+                handles, labels = ax.get_legend_handles_labels()
+                assert(labels == ['l1', 'l2'])
+                if x == y:
+                    assert(all([isinstance(h, Rectangle) for h in handles]))
+                else:
+                    assert(all([isinstance(h, PathCollection)
+                                for h in handles]))
     plt.close('all')


### PR DESCRIPTION
# Description

Legend handling is now more intuitive, i.e. can be done in the usual matplotlib fashion.

* Make the link `axes[x][x] = axes[x][x].twin` such that the user has direct access to the diagonal axes that have actually been drawn in.
  - `axes[x][x].legend()` now automatically makes a legend in the diagonal axes.

* Create the legend proxy already in `contour_plot_2d` and pass it to `ax.patches`.
  - `axes[x][y].legend()` now automatically makes a legend in the 2D 'kde' axes.
  - No need for `get_legend_proxy` anymore, because matplotlib's own functions can handle this, now:
  ```python
  handles, labels = axes[x][y].get_legend_handles_labels()
  leg = fig.legend(handles, labels)
  ```
  - Flagged `get_legend_proxy` as deprecated.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
