### PR TITLE
Linking of x and y axis limits in triangle plots

### DIFF
--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -188,6 +188,7 @@ def make_2d_axes(params, **kwargs):
                     axes[x][y].patches = axes[x][y].twin.patches
                     axes[x][y].collections = axes[x][y].twin.collections
                     axes[x][y].containers = axes[x][y].twin.containers
+                    make_diagonal(axes[x][y])
                     axes[x][y].position = 'diagonal'
                 elif position[x][y] == 1:
                     axes[x][y].position = 'upper'
@@ -489,3 +490,26 @@ def get_legend_proxy(fig):
 def basic_cmap(color):
     """Construct basic colormap a single color."""
     return LinearSegmentedColormap.from_list(color, ['#ffffff', color])
+
+
+def make_diagonal(ax):
+    """Link x and y axes limits."""
+    class DiagonalAxes(type(ax)):
+        def set_xlim(self, left=None, right=None, emit=True, auto=False,
+                     xmin=None, xmax=None):
+            super(type(ax), self).set_ylim(bottom=left, top=right,
+                                           emit=True, auto=auto,
+                                           ymin=xmin, ymax=xmax)
+            return super(type(ax), self).set_xlim(left=left, right=right,
+                                                  emit=emit, auto=auto,
+                                                  xmin=xmin, xmax=xmax)
+
+        def set_ylim(self, bottom=None, top=None, emit=True, auto=False,
+                     ymin=None, ymax=None):
+            super(type(ax), self).set_xlim(left=bottom, right=top,
+                                           emit=True, auto=auto,
+                                           xmin=ymin, xmax=ymax)
+            return super(type(ax), self).set_ylim(bottom=bottom, top=top,
+                                                  emit=emit, auto=auto,
+                                                  ymin=ymin, ymax=ymax)
+    ax.__class__ = DiagonalAxes

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -10,6 +10,7 @@ wish to use.
 to create a set of axes and legend proxies.
 
 """
+import sys
 import numpy
 import pandas
 import matplotlib.pyplot as plt
@@ -492,24 +493,47 @@ def basic_cmap(color):
     return LinearSegmentedColormap.from_list(color, ['#ffffff', color])
 
 
-def make_diagonal(ax):
-    """Link x and y axes limits."""
-    class DiagonalAxes(type(ax)):
-        def set_xlim(self, left=None, right=None, emit=True, auto=False,
-                     xmin=None, xmax=None):
-            super(type(ax), self).set_ylim(bottom=left, top=right,
-                                           emit=True, auto=auto,
-                                           ymin=xmin, ymax=xmax)
-            return super(type(ax), self).set_xlim(left=left, right=right,
-                                                  emit=emit, auto=auto,
-                                                  xmin=xmin, xmax=xmax)
+if sys.version_info > (3, 0):
+    def make_diagonal(ax):
+        """Link x and y axes limits."""
+        class DiagonalAxes(type(ax)):
+            def set_xlim(self, left=None, right=None, emit=True, auto=False,
+                         xmin=None, xmax=None):
+                super(type(ax), self).set_ylim(bottom=left, top=right,
+                                               emit=True, auto=auto,
+                                               ymin=xmin, ymax=xmax)
+                return super(type(ax), self).set_xlim(left=left, right=right,
+                                                      emit=emit, auto=auto,
+                                                      xmin=xmin, xmax=xmax)
 
-        def set_ylim(self, bottom=None, top=None, emit=True, auto=False,
-                     ymin=None, ymax=None):
-            super(type(ax), self).set_xlim(left=bottom, right=top,
-                                           emit=True, auto=auto,
-                                           xmin=ymin, xmax=ymax)
-            return super(type(ax), self).set_ylim(bottom=bottom, top=top,
-                                                  emit=emit, auto=auto,
-                                                  ymin=ymin, ymax=ymax)
-    ax.__class__ = DiagonalAxes
+            def set_ylim(self, bottom=None, top=None, emit=True, auto=False,
+                         ymin=None, ymax=None):
+                super(type(ax), self).set_xlim(left=bottom, right=top,
+                                               emit=True, auto=auto,
+                                               xmin=ymin, xmax=ymax)
+                return super(type(ax), self).set_ylim(bottom=bottom, top=top,
+                                                      emit=emit, auto=auto,
+                                                      ymin=ymin, ymax=ymax)
+        ax.__class__ = DiagonalAxes
+else:
+    def make_diagonal(ax):
+        """Link x and y axes limits."""
+        class DiagonalAxes(type(ax)):
+            def set_xlim(self, left=None, right=None, emit=True, auto=False,
+                         **kwargs):
+                super(type(ax), self).set_ylim(bottom=left, top=right,
+                                               emit=True, auto=auto,
+                                               **kwargs)
+                return super(type(ax), self).set_xlim(left=left, right=right,
+                                                      emit=emit, auto=auto,
+                                                      **kwargs)
+
+            def set_ylim(self, bottom=None, top=None, emit=True, auto=False,
+                         **kwargs):
+                super(type(ax), self).set_xlim(left=bottom, right=top,
+                                               emit=True, auto=auto,
+                                               **kwargs)
+                return super(type(ax), self).set_ylim(bottom=bottom, top=top,
+                                                      emit=emit, auto=auto,
+                                                      **kwargs)
+        ax.__class__ = DiagonalAxes

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -166,6 +166,24 @@ def test_make_2d_axes_behaviour():
         plt.close("all")
 
 
+def test_2d_axes_limits():
+    numpy.random.seed(0)
+    paramnames = ['A', 'B', 'C', 'D']
+    fig, axes = make_2d_axes(paramnames)
+    for x in paramnames:
+        for y in paramnames:
+            a, b, c, d = numpy.random.rand(4)
+            axes[x][y].set_xlim(a, b)
+            for z in paramnames:
+                assert(axes[x][z].get_xlim() == (a, b))
+                assert(axes[z][x].get_ylim() == (a, b))
+
+            axes[x][y].set_ylim(c, d)
+            for z in paramnames:
+                assert(axes[y][z].get_xlim() == (c, d))
+                assert(axes[z][y].get_ylim() == (c, d))
+
+
 def test_plot_1d():
     fig, ax = plt.subplots()
     numpy.random.seed(0)


### PR DESCRIPTION
# Description

As noted in #25, triangle plots were not linking the x and y axes limits of subplots with the same parameter.

This pull request implements this with a single function and a bit of python function magic.

It even works with ipython inline plot resizing


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works