### PR TITLE
Automatic labelling

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -43,10 +43,13 @@ class MCMCSamples(WeightedDataFrame):
         loglikelihoods of samples.
 
     tex: dict
-        mapping from coloumns to tex labels for plotting
+        mapping from columns to tex labels for plotting
 
     limits: dict
-        mapping from coloumns to prior limits
+        mapping from columns to prior limits
+
+    label: str
+        Legend label
 
     """
 
@@ -57,18 +60,20 @@ class MCMCSamples(WeightedDataFrame):
         return MCMCSamples
 
     def __init__(self, *args, **kwargs):
-        self.root = kwargs.pop('root', None)
-        if self.root is not None:
-            reader = SampleReader(self.root)
+        root = kwargs.pop('root', None)
+        if root is not None:
+            reader = SampleReader(root)
             w, logL, samples = reader.samples()
             params, tex = reader.paramnames()
             limits = reader.limits()
             self.__init__(data=samples, columns=params, w=w, logL=logL,
                           tex=tex, limits=limits)
+            self.root = root
         else:
             logL = kwargs.pop('logL', None)
             self.tex = kwargs.pop('tex', {})
             self.limits = kwargs.pop('limits', {})
+            self.root = None
             self.u = None
 
             super(MCMCSamples, self).__init__(*args, **kwargs)
@@ -335,17 +340,18 @@ class NestedSamples(MCMCSamples):
         return NestedSamples
 
     def __init__(self, *args, **kwargs):
-        self.root = kwargs.pop('root', None)
-        self._beta = kwargs.pop('beta', 1.)
-        if self.root is not None:
-            reader = SampleReader(self.root)
+        root = kwargs.pop('root', None)
+        if root is not None:
+            reader = SampleReader(root)
             samples, logL, logL_birth = reader.samples()
             params, tex = reader.paramnames()
             limits = reader.limits()
             self.__init__(data=samples, columns=params,
                           logL=logL, logL_birth=logL_birth,
                           tex=tex, limits=limits)
+            self.root = root
         else:
+            self._beta = kwargs.pop('beta', 1.)
             logL_birth = kwargs.pop('logL_birth', None)
             super(NestedSamples, self).__init__(*args, **kwargs)
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -328,10 +328,10 @@ class NestedSamples(MCMCSamples):
         birth loglikelihoods, or number of live points.
 
     tex: dict
-        mapping from coloumns to tex labels for plotting
+        mapping from columns to tex labels for plotting
 
     limits: dict
-        mapping from coloumns to prior limits
+        mapping from columns to prior limits
 
     label: str
         Legend label

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -3,6 +3,7 @@
 - ``MCMCSamples``
 - ``NestedSamples``
 """
+import os
 import numpy
 import pandas
 from scipy.special import logsumexp
@@ -53,7 +54,8 @@ class MCMCSamples(WeightedDataFrame):
 
     """
 
-    _metadata = WeightedDataFrame._metadata + ['tex', 'limits', 'u', 'root']
+    _metadata = WeightedDataFrame._metadata + ['tex', 'limits', 'u',
+                                               'root', 'label']
 
     @property
     def _constructor(self):
@@ -66,13 +68,15 @@ class MCMCSamples(WeightedDataFrame):
             w, logL, samples = reader.samples()
             params, tex = reader.paramnames()
             limits = reader.limits()
+            kwargs['label'] = kwargs.get('label', os.path.basename(root))
             self.__init__(data=samples, columns=params, w=w, logL=logL,
-                          tex=tex, limits=limits)
+                          tex=tex, limits=limits, *args, **kwargs)
             self.root = root
         else:
             logL = kwargs.pop('logL', None)
             self.tex = kwargs.pop('tex', {})
             self.limits = kwargs.pop('limits', {})
+            self.label = kwargs.pop('label', None)
             self.root = None
             self.u = None
 
@@ -120,6 +124,7 @@ class MCMCSamples(WeightedDataFrame):
         """
         plot_type = kwargs.pop('plot_type', 'kde')
         do_1d_plot = paramname_y is None or paramname_x == paramname_y
+        kwargs['label'] = kwargs.get('label', self.label)
 
         if do_1d_plot:
             xmin, xmax = self._limits(paramname_x)
@@ -328,6 +333,9 @@ class NestedSamples(MCMCSamples):
     limits: dict
         mapping from coloumns to prior limits
 
+    label: str
+        Legend label
+
     beta: float
         thermodynamic temperature
 
@@ -346,9 +354,10 @@ class NestedSamples(MCMCSamples):
             samples, logL, logL_birth = reader.samples()
             params, tex = reader.paramnames()
             limits = reader.limits()
+            kwargs['label'] = kwargs.get('label', os.path.basename(root))
             self.__init__(data=samples, columns=params,
                           logL=logL, logL_birth=logL_birth,
-                          tex=tex, limits=limits)
+                          tex=tex, limits=limits, *args, **kwargs)
             self.root = root
         else:
             self._beta = kwargs.pop('beta', 1.)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -206,7 +206,7 @@ def test_plot_2d_legend():
                     assert(all([isinstance(h, Rectangle) for h in handles]))
     plt.close('all')
 
-    # Test label kwarg label kwarg for hist and scatter
+    # Test label kwarg for hist and scatter
     fig, axes = make_2d_axes(params, lower=False)
     ns.plot_2d(axes, label='l1', types=dict(diagonal='hist', upper='scatter'))
     mc.plot_2d(axes, label='l2', types=dict(diagonal='hist', upper='scatter'))

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -167,14 +167,33 @@ def test_plot_2d_types_multiple_calls():
     plt.close('all')
 
 
+def test_root_and_label():
+    ns = NestedSamples(root='./tests/example_data/pc')
+    assert(ns.root == './tests/example_data/pc')
+    assert(ns.label == 'pc')
+
+    ns = NestedSamples()
+    assert(ns.root is None)
+    assert(ns.label is None)
+
+    mc = MCMCSamples(root='./tests/example_data/gd')
+    assert (mc.root == './tests/example_data/gd')
+    assert(mc.label == 'gd')
+
+    mc = MCMCSamples()
+    assert(mc.root is None)
+    assert(mc.label is None)
+
+
 def test_plot_2d_legend():
-    ns1 = NestedSamples(root='./tests/example_data/pc')
-    ns2 = NestedSamples(root='./tests/example_data/pc')
+    ns = NestedSamples(root='./tests/example_data/pc')
+    mc = MCMCSamples(root='./tests/example_data/gd')
     params = ['x0', 'x1', 'x2', 'x3']
 
+    # Test label kwarg for kde
     fig, axes = make_2d_axes(params, upper=False)
-    ns1.plot_2d(axes, label='l1', types=dict(diagonal='kde', lower='kde'))
-    ns2.plot_2d(axes, label='l2', types=dict(diagonal='kde', lower='kde'))
+    ns.plot_2d(axes, label='l1', types=dict(diagonal='kde', lower='kde'))
+    mc.plot_2d(axes, label='l2', types=dict(diagonal='kde', lower='kde'))
 
     for y, row in axes.iterrows():
         for x, ax in row.iteritems():
@@ -187,9 +206,10 @@ def test_plot_2d_legend():
                     assert(all([isinstance(h, Rectangle) for h in handles]))
     plt.close('all')
 
+    # Test label kwarg label kwarg for hist and scatter
     fig, axes = make_2d_axes(params, lower=False)
-    ns1.plot_2d(axes, label='l1', types=dict(diagonal='hist', upper='scatter'))
-    ns2.plot_2d(axes, label='l2', types=dict(diagonal='hist', upper='scatter'))
+    ns.plot_2d(axes, label='l1', types=dict(diagonal='hist', upper='scatter'))
+    mc.plot_2d(axes, label='l2', types=dict(diagonal='hist', upper='scatter'))
 
     for y, row in axes.iterrows():
         for x, ax in row.iteritems():
@@ -201,4 +221,32 @@ def test_plot_2d_legend():
                 else:
                     assert(all([isinstance(h, PathCollection)
                                 for h in handles]))
+    plt.close('all')
+
+    # test default labelling
+    fig, axes = make_2d_axes(params, upper=False)
+    ns.plot_2d(axes)
+    mc.plot_2d(axes)
+
+    for y, row in axes.iterrows():
+        for x, ax in row.iteritems():
+            if ax is not None:
+                handles, labels = ax.get_legend_handles_labels()
+                assert(labels == ['pc', 'gd'])
+    plt.close('all')
+
+    # Test label kwarg to constructors
+    ns = NestedSamples(root='./tests/example_data/pc', label='l1')
+    mc = MCMCSamples(root='./tests/example_data/gd', label='l2')
+    params = ['x0', 'x1', 'x2', 'x3']
+
+    fig, axes = make_2d_axes(params, upper=False)
+    ns.plot_2d(axes)
+    mc.plot_2d(axes)
+
+    for y, row in axes.iterrows():
+        for x, ax in row.iteritems():
+            if ax is not None:
+                handles, labels = ax.get_legend_handles_labels()
+                assert(labels == ['l1', 'l2'])
     plt.close('all')


### PR DESCRIPTION
# Description

Added a `label` attribute to `MCMCSamples`, which provides a default for the plots. Labels are defined to be the basename of the root if loaded from file, None otherwise.

Fixes #42

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works