### PR TITLE
Fix to colouring for missing plots

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -181,9 +181,6 @@ class MCMCSamples(WeightedDataFrame):
             this is used for creating the plot. Otherwise a new set of axes are
             created using the list or lists of strings.
 
-        types: str
-            What types of plots to produce. Options are {'kde', 'hist'}
-
         Returns
         -------
         fig: matplotlib.figure.Figure
@@ -193,15 +190,13 @@ class MCMCSamples(WeightedDataFrame):
             Pandas array of axes objects
 
         """
-        plot_type = kwargs.pop('types', 'kde')
-
         if not isinstance(axes, pandas.Series):
             fig, axes = make_1d_axes(axes, tex=self.tex)
         else:
             fig = axes.values[~axes.isna()][0].figure
 
         for x, ax in axes.iteritems():
-            self.plot(ax, x, plot_type=plot_type, *args, **kwargs)
+            self.plot(ax, x, *args, **kwargs)
 
         return fig, axes
 

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -311,31 +311,32 @@ def test_plot_1d_colours():
     mn = NestedSamples(root="./tests/example_data/mn")
     mn.drop(columns='x2', inplace=True)
 
-    fig = plt.figure()
-    fig, axes = make_1d_axes(['x0', 'x1', 'x2', 'x3', 'x4'], fig=fig)
-    gd.plot_1d(axes, label="gd")
-    pc.plot_1d(axes, label="pc")
-    mn.plot_1d(axes, label="mn")
-    gd_colors = []
-    pc_colors = []
-    mn_colors = []
-    for x, ax in axes.iteritems():
-        handles, labels = ax.get_legend_handles_labels()
-        for handle, label in zip(handles, labels):
-            if isinstance(handle, Rectangle):
-                color = to_hex(handle.get_facecolor())
-            elif isinstance(handle, PathCollection):
-                color = to_hex(handle.get_facecolor()[0])
-            else:
-                color = handle.get_color()
+    for types in ['kde', 'hist']:
+        fig = plt.figure()
+        fig, axes = make_1d_axes(['x0', 'x1', 'x2', 'x3', 'x4'], fig=fig)
+        gd.plot_1d(axes, types=types, label="gd")
+        pc.plot_1d(axes, types=types, label="pc")
+        mn.plot_1d(axes, types=types, label="mn")
+        gd_colors = []
+        pc_colors = []
+        mn_colors = []
+        for x, ax in axes.iteritems():
+            handles, labels = ax.get_legend_handles_labels()
+            for handle, label in zip(handles, labels):
+                if isinstance(handle, Rectangle):
+                    color = to_hex(handle.get_facecolor())
+                elif isinstance(handle, PathCollection):
+                    color = to_hex(handle.get_facecolor()[0])
+                else:
+                    color = handle.get_color()
 
-            if label == 'gd':
-                gd_colors.append(color)
-            elif label == 'pc':
-                pc_colors.append(color)
-            elif label == 'mn':
-                mn_colors.append(color)
+                if label == 'gd':
+                    gd_colors.append(color)
+                elif label == 'pc':
+                    pc_colors.append(color)
+                elif label == 'mn':
+                    mn_colors.append(color)
 
-    assert(len(set(gd_colors)) == 1)
-    assert(len(set(mn_colors)) == 1)
-    assert(len(set(pc_colors)) == 1)
+        assert(len(set(gd_colors)) == 1)
+        assert(len(set(mn_colors)) == 1)
+        assert(len(set(pc_colors)) == 1)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -8,6 +8,7 @@ from matplotlib.patches import Rectangle
 from matplotlib.collections import PathCollection
 from anesthetic import MCMCSamples, NestedSamples, make_1d_axes, make_2d_axes
 from numpy.testing import assert_array_equal
+from matplotlib.colors import to_hex
 try:
     import montepython  # noqa: F401
 except ImportError:
@@ -64,6 +65,7 @@ def test_build_mcmc():
 
 
 def test_read_getdist():
+    numpy.random.seed(3)
     mcmc = MCMCSamples(root='./tests/example_data/gd')
     mcmc.plot_2d(['x0', 'x1', 'x2', 'x3'])
     mcmc.plot_1d(['x0', 'x1', 'x2', 'x3'])
@@ -78,6 +80,7 @@ def test_read_getdist():
                    raises=ImportError,
                    reason="requires montepython package")
 def test_read_montepython():
+    numpy.random.seed(3)
     mcmc = MCMCSamples(root='./tests/example_data/mp')
     mcmc.plot_2d(['x0', 'x1', 'x2', 'x3'])
     mcmc.plot_1d(['x0', 'x1', 'x2', 'x3'])
@@ -85,6 +88,7 @@ def test_read_montepython():
 
 
 def test_read_multinest():
+    numpy.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/mn')
     ns.plot_2d(['x0', 'x1', 'x2', 'x3'])
     ns.plot_1d(['x0', 'x1', 'x2', 'x3'])
@@ -96,6 +100,7 @@ def test_read_multinest():
 
 
 def test_read_polychord():
+    numpy.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     ns.plot_2d(['x0', 'x1', 'x2', 'x3'])
     ns.plot_1d(['x0', 'x1', 'x2', 'x3'])
@@ -103,6 +108,7 @@ def test_read_polychord():
 
 
 def test_different_parameters():
+    numpy.random.seed(3)
     params_x = ['x0', 'x1', 'x2', 'x3', 'x4']
     params_y = ['x0', 'x1', 'x2']
     fig, axes = make_1d_axes(params_x)
@@ -118,6 +124,7 @@ def test_different_parameters():
 
 
 def test_plot_2d_types():
+    numpy.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     params_x = ['x0', 'x1', 'x2', 'x3']
     params_y = ['x0', 'x1', 'x2']
@@ -152,6 +159,7 @@ def test_plot_2d_types():
 
 
 def test_plot_2d_types_multiple_calls():
+    numpy.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     params = ['x0', 'x1', 'x2', 'x3']
 
@@ -168,6 +176,7 @@ def test_plot_2d_types_multiple_calls():
 
 
 def test_root_and_label():
+    numpy.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     assert(ns.root == './tests/example_data/pc')
     assert(ns.label == 'pc')
@@ -186,6 +195,7 @@ def test_root_and_label():
 
 
 def test_plot_2d_legend():
+    numpy.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     mc = MCMCSamples(root='./tests/example_data/gd')
     params = ['x0', 'x1', 'x2', 'x3']
@@ -250,3 +260,33 @@ def test_plot_2d_legend():
                 handles, labels = ax.get_legend_handles_labels()
                 assert(labels == ['l1', 'l2'])
     plt.close('all')
+
+
+def test_plot_colours():
+    numpy.random.seed(3)
+    mp = MCMCSamples(root="./tests/example_data/mp/2019-01-24_200000_")
+    pc = NestedSamples(root="./tests/example_data/pc")
+    fig = plt.figure()
+    fig, axes = make_2d_axes(['x0', 'x1', 'x2', 'x3', 'x4'], fig=fig)
+    mp.plot_2d(axes, label="mp")
+    pc.plot_2d(axes, label="pc")
+    mp_colors = []
+    pc_colors = []
+    for y, rows in axes.iterrows():
+        for x, ax in rows.iteritems():
+            handles, labels = ax.get_legend_handles_labels()
+            for handle, label in zip(handles, labels):
+                if isinstance(handle, Rectangle):
+                    color = to_hex(handle.get_facecolor())
+                elif isinstance(handle, PathCollection):
+                    color = to_hex(handle.get_facecolor()[0])
+                else:
+                    color = handle.get_color()
+
+                if label == 'pc':
+                    pc_colors.append(color)
+                elif label == 'mp':
+                    mp_colors.append(color)
+
+    assert(len(set(pc_colors)) == 1)
+    assert(len(set(mp_colors)) == 1)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -311,12 +311,12 @@ def test_plot_1d_colours():
     mn = NestedSamples(root="./tests/example_data/mn")
     mn.drop(columns='x2', inplace=True)
 
-    for types in ['kde', 'hist']:
+    for plot_type in ['kde', 'hist']:
         fig = plt.figure()
         fig, axes = make_1d_axes(['x0', 'x1', 'x2', 'x3', 'x4'], fig=fig)
-        gd.plot_1d(axes, types=types, label="gd")
-        pc.plot_1d(axes, types=types, label="pc")
-        mn.plot_1d(axes, types=types, label="mn")
+        gd.plot_1d(axes, plot_type=plot_type, label="gd")
+        pc.plot_1d(axes, plot_type=plot_type, label="pc")
+        mn.plot_1d(axes, plot_type=plot_type, label="mn")
         gd_colors = []
         pc_colors = []
         mn_colors = []

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -264,14 +264,20 @@ def test_plot_2d_legend():
 
 def test_plot_colours():
     numpy.random.seed(3)
-    mp = MCMCSamples(root="./tests/example_data/mp/2019-01-24_200000_")
+    gd = MCMCSamples(root="./tests/example_data/gd")
+    gd.drop(columns='x3',inplace=True)
     pc = NestedSamples(root="./tests/example_data/pc")
+    pc.drop(columns='x4',inplace=True)
+    mn = NestedSamples(root="./tests/example_data/mn")
+    mn.drop(columns='x2',inplace=True)
     fig = plt.figure()
     fig, axes = make_2d_axes(['x0', 'x1', 'x2', 'x3', 'x4'], fig=fig)
-    mp.plot_2d(axes, label="mp")
+    gd.plot_2d(axes, label="gd")
     pc.plot_2d(axes, label="pc")
-    mp_colors = []
+    mn.plot_2d(axes, label="mn")
+    gd_colors = []
     pc_colors = []
+    mn_colors = []
     for y, rows in axes.iterrows():
         for x, ax in rows.iteritems():
             handles, labels = ax.get_legend_handles_labels()
@@ -283,10 +289,13 @@ def test_plot_colours():
                 else:
                     color = handle.get_color()
 
-                if label == 'pc':
+                if label == 'gd':
+                    gd_colors.append(color)
+                elif label == 'pc':
                     pc_colors.append(color)
-                elif label == 'mp':
-                    mp_colors.append(color)
+                elif label == 'mn':
+                    mn_colors.append(color)
 
+    assert(len(set(gd_colors)) == 1)
+    assert(len(set(mn_colors)) == 1)
     assert(len(set(pc_colors)) == 1)
-    assert(len(set(mp_colors)) == 1)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -265,11 +265,11 @@ def test_plot_2d_legend():
 def test_plot_colours():
     numpy.random.seed(3)
     gd = MCMCSamples(root="./tests/example_data/gd")
-    gd.drop(columns='x3',inplace=True)
+    gd.drop(columns='x3', inplace=True)
     pc = NestedSamples(root="./tests/example_data/pc")
-    pc.drop(columns='x4',inplace=True)
+    pc.drop(columns='x4', inplace=True)
     mn = NestedSamples(root="./tests/example_data/mn")
-    mn.drop(columns='x2',inplace=True)
+    mn.drop(columns='x2', inplace=True)
     fig = plt.figure()
     fig, axes = make_2d_axes(['x0', 'x1', 'x2', 'x3', 'x4'], fig=fig)
     gd.plot_2d(axes, label="gd")
@@ -295,6 +295,35 @@ def test_plot_colours():
                     pc_colors.append(color)
                 elif label == 'mn':
                     mn_colors.append(color)
+
+    assert(len(set(gd_colors)) == 1)
+    assert(len(set(mn_colors)) == 1)
+    assert(len(set(pc_colors)) == 1)
+
+    fig = plt.figure()
+    fig, axes = make_1d_axes(['x0', 'x1', 'x2', 'x3', 'x4'], fig=fig)
+    gd.plot_1d(axes, label="gd")
+    pc.plot_1d(axes, label="pc")
+    mn.plot_1d(axes, label="mn")
+    gd_colors = []
+    pc_colors = []
+    mn_colors = []
+    for x, ax in axes.iteritems():
+        handles, labels = ax.get_legend_handles_labels()
+        for handle, label in zip(handles, labels):
+            if isinstance(handle, Rectangle):
+                color = to_hex(handle.get_facecolor())
+            elif isinstance(handle, PathCollection):
+                color = to_hex(handle.get_facecolor()[0])
+            else:
+                color = handle.get_color()
+
+            if label == 'gd':
+                gd_colors.append(color)
+            elif label == 'pc':
+                pc_colors.append(color)
+            elif label == 'mn':
+                mn_colors.append(color)
 
     assert(len(set(gd_colors)) == 1)
     assert(len(set(mn_colors)) == 1)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -262,7 +262,7 @@ def test_plot_2d_legend():
     plt.close('all')
 
 
-def test_plot_colours():
+def test_plot_2d_colours():
     numpy.random.seed(3)
     gd = MCMCSamples(root="./tests/example_data/gd")
     gd.drop(columns='x3', inplace=True)
@@ -270,6 +270,7 @@ def test_plot_colours():
     pc.drop(columns='x4', inplace=True)
     mn = NestedSamples(root="./tests/example_data/mn")
     mn.drop(columns='x2', inplace=True)
+
     fig = plt.figure()
     fig, axes = make_2d_axes(['x0', 'x1', 'x2', 'x3', 'x4'], fig=fig)
     gd.plot_2d(axes, label="gd")
@@ -299,6 +300,16 @@ def test_plot_colours():
     assert(len(set(gd_colors)) == 1)
     assert(len(set(mn_colors)) == 1)
     assert(len(set(pc_colors)) == 1)
+
+
+def test_plot_1d_colours():
+    numpy.random.seed(3)
+    gd = MCMCSamples(root="./tests/example_data/gd")
+    gd.drop(columns='x3', inplace=True)
+    pc = NestedSamples(root="./tests/example_data/pc")
+    pc.drop(columns='x4', inplace=True)
+    mn = NestedSamples(root="./tests/example_data/mn")
+    mn.drop(columns='x2', inplace=True)
 
     fig = plt.figure()
     fig, axes = make_1d_axes(['x0', 'x1', 'x2', 'x3', 'x4'], fig=fig)


### PR DESCRIPTION
# Description

This PR added a failing test that shows the issue noted in #19. It now fixes that test by reordering the 'blank plots' in `MCMCSamples.plot`

Fixes #19 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works