### PR TITLE
First-order boundary correction

### DIFF
--- a/anesthetic/boundary.py
+++ b/anesthetic/boundary.py
@@ -1,0 +1,37 @@
+"""Boundary correction utilities."""
+
+import numpy
+from scipy.special import erf
+
+
+def cut_and_normalise_gaussian(x, p, sigma, xmin=None, xmax=None):
+    """Cut and normalise boundary correction for a Gaussian kernel.
+
+    Parameters
+    ----------
+    x: numpy.array
+        locations for normalisation correction
+
+    p: numpy.array
+        probability densities for normalisation correction
+
+    sigma: float
+        bandwidth of KDE
+
+    xmin, xmax: float
+        lower/upper prior bound
+        optional, default None
+
+    Returns
+    -------
+    p: numpy.array
+        corrected probabilities
+
+    """
+    correction = numpy.ones_like(x)
+
+    if xmin is not None and (x >= xmin).all():
+        correction *= 0.5*(1 + erf((x - xmin)/sigma/numpy.sqrt(2)))
+    if xmax is not None and (x <= xmax).all():
+        correction *= 0.5*(1 + erf((xmax - x)/sigma/numpy.sqrt(2)))
+    return p/correction


### PR DESCRIPTION
# Description

This implements a 'cut and normalise' boundary correction. Whilst [far better corrections are available](https://cosmologist.info/notes/GetDist.pdf), this is manifestly better than no correction, and has the advantage of being an extremely minor modification.

The below plots show that it slightly improves x2 and x4, and clearly improves x3.

Without boundary correction:
![Figure_1](https://user-images.githubusercontent.com/3708486/63051072-5d597a00-bed4-11e9-8fdb-13d661807a1c.png)

With boundary correction:
![Figure_2](https://user-images.githubusercontent.com/3708486/63051129-7e21cf80-bed4-11e9-86b2-e4dba71dde54.png)


Fixes #35 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
