### PR TITLE
allow masking of MCMCSamples and NestedSamples instances

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -85,6 +85,7 @@ class MCMCSamples(WeightedDataFrame):
             super(MCMCSamples, self).__init__(*args, **kwargs)
 
             self.u = numpy.random.rand(len(self))
+            self['rand'] = self.u
 
             if self.w is not None:
                 self['weight'] = self.w
@@ -142,7 +143,7 @@ class MCMCSamples(WeightedDataFrame):
                     if ncompress is None:
                         ncompress = 1000
                     return kde_plot_1d(ax, self[paramname_x],
-                                       weights=self['weight'],
+                                       weights=self.weight,
                                        ncompress=ncompress,
                                        xmin=xmin, xmax=xmax,
                                        *args, **kwargs)
@@ -152,7 +153,7 @@ class MCMCSamples(WeightedDataFrame):
                                            *args, **kwargs)
                 elif plot_type == 'hist':
                     return hist_plot_1d(ax, self[paramname_x],
-                                        weights=self['weight'],
+                                        weights=self.weight,
                                         xmin=xmin, xmax=xmax, *args, **kwargs)
                 elif plot_type == 'astropyhist':
                     x = self[paramname_x].compress(ncompress)
@@ -177,7 +178,7 @@ class MCMCSamples(WeightedDataFrame):
                     x = self[paramname_x]
                     y = self[paramname_y]
                     return kde_contour_plot_2d(ax, x, y,
-                                               weights=self['weight'],
+                                               weights=self.weight,
                                                ncompress=ncompress,
                                                xmin=xmin, xmax=xmax,
                                                ymin=ymin, ymax=ymax,
@@ -200,7 +201,7 @@ class MCMCSamples(WeightedDataFrame):
                 elif plot_type == 'hist':
                     x = self[paramname_x]
                     y = self[paramname_y]
-                    return hist_plot_2d(ax, x, y, weights=self['weight'],
+                    return hist_plot_2d(ax, x, y, weights=self.weight,
                                         xmin=xmin, xmax=xmax,
                                         ymin=ymin, ymax=ymax,
                                         *args, **kwargs)

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -141,7 +141,8 @@ class MCMCSamples(WeightedDataFrame):
                 if plot_type == 'kde':
                     if ncompress is None:
                         ncompress = 1000
-                    return kde_plot_1d(ax, self[paramname_x], weights=self.w,
+                    return kde_plot_1d(ax, self[paramname_x],
+                                       weights=self['weight'],
                                        ncompress=ncompress,
                                        xmin=xmin, xmax=xmax,
                                        *args, **kwargs)
@@ -150,7 +151,8 @@ class MCMCSamples(WeightedDataFrame):
                     return fastkde_plot_1d(ax, x, xmin=xmin, xmax=xmax,
                                            *args, **kwargs)
                 elif plot_type == 'hist':
-                    return hist_plot_1d(ax, self[paramname_x], weights=self.w,
+                    return hist_plot_1d(ax, self[paramname_x],
+                                        weights=self['weight'],
                                         xmin=xmin, xmax=xmax, *args, **kwargs)
                 elif plot_type == 'astropyhist':
                     x = self[paramname_x].compress(ncompress)
@@ -174,10 +176,11 @@ class MCMCSamples(WeightedDataFrame):
                         ncompress = 1000
                     x = self[paramname_x]
                     y = self[paramname_y]
-                    return kde_contour_plot_2d(ax, x, y, weights=self.w,
+                    return kde_contour_plot_2d(ax, x, y,
+                                               weights=self['weight'],
+                                               ncompress=ncompress,
                                                xmin=xmin, xmax=xmax,
                                                ymin=ymin, ymax=ymax,
-                                               ncompress=ncompress,
                                                *args, **kwargs)
                 elif plot_type == 'fastkde':
                     x = self[paramname_x].compress(ncompress)
@@ -197,8 +200,9 @@ class MCMCSamples(WeightedDataFrame):
                 elif plot_type == 'hist':
                     x = self[paramname_x]
                     y = self[paramname_y]
-                    return hist_plot_2d(ax, x, y, weights=self.w, xmin=xmin,
-                                        xmax=xmax, ymin=ymin, ymax=ymax,
+                    return hist_plot_2d(ax, x, y, weights=self['weight'],
+                                        xmin=xmin, xmax=xmax,
+                                        ymin=ymin, ymax=ymax,
                                         *args, **kwargs)
                 else:
                     raise NotImplementedError("plot_type is '%s', but must be"

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -218,7 +218,7 @@ def triangular_sample_compression_2d(x, y, w=None, n=1000):
     x, y: array-like
         x and y coordinates of samples for compressing
 
-    w: array-like, optional
+    w: pandas.Series, optional
         weights of samples
 
     n: int, optional
@@ -231,13 +231,13 @@ def triangular_sample_compression_2d(x, y, w=None, n=1000):
 
     """
     if w is None:
-        w = numpy.ones_like(x)
+        w = pandas.Series(numpy.ones_like(x))
 
     # Select samples for triangulation
     if sum(w != 0) < n:
-        i = numpy.arange(len(w))
+        i = w.index
     else:
-        i = numpy.random.choice(len(w), size=n, replace=False, p=w/w.sum())
+        i = numpy.random.choice(w.index, size=n, replace=False, p=w/w.sum())
 
     # Generate triangulation
     cov = numpy.cov(x, y, aweights=w)
@@ -266,7 +266,7 @@ def triangular_sample_compression_2d(x, y, w=None, n=1000):
         numpy.add.at(w_, k[:, i], w[j != -1])
 
     x_, y_ = L.dot([x_, y_])
-    return (x_, y_, w_, tri.get_masked_triangles())
+    return x_, y_, w_, tri.get_masked_triangles()
 
 
 def sample_compression_1d(x, w=None, n=1000):
@@ -279,7 +279,7 @@ def sample_compression_1d(x, w=None, n=1000):
     x: array-like
         x coordinate of samples for compressing
 
-    w: array-like, optional
+    w: pandas.Series, optional
         weights of samples
 
     n: int, optional
@@ -291,13 +291,13 @@ def sample_compression_1d(x, w=None, n=1000):
         Compressed samples and weights
     """
     if w is None:
-        w = numpy.ones_like(x)
+        w = pandas.Series(numpy.ones_like(x))
 
     # Select inner samples for triangulation
     if sum(w != 0) < n:
-        i = numpy.arange(len(w))
+        i = w.index
     else:
-        i = numpy.random.choice(len(w), size=n, replace=False, p=w/w.sum())
+        i = numpy.random.choice(w.index, size=n, replace=False, p=w/w.sum())
 
     # Define sub-samples
     x_ = numpy.sort(x[i])

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -62,7 +62,7 @@ class WeightedSeries(pandas.Series):
             compression). If <=0, then compress so that all weights are unity.
 
         """
-        i = compress_weights(self.w, self.u, nsamples)
+        i = compress_weights(self.w[self.index], self.u[self.index], nsamples)
         return self.repeat(i)
 
 

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -380,10 +380,14 @@ def test_masking():
     pc = NestedSamples(root="./tests/example_data/pc")
     mask = pc['x0'] > 0
 
-    for ptype in ['kde', 'fastkde', 'hist']:
+    plot_types = ['kde', 'hist']
+    if 'fastkde' in sys.modules:
+        plot_types += ['fastkde']
+
+    for ptype in plot_types:
         fig, axes = make_1d_axes(['x0', 'x1', 'x2'])
         pc[mask].plot_1d(axes=axes, plot_type=ptype)
 
-    for ptype in ['kde', 'fastkde', 'hist', 'scatter']:
+    for ptype in plot_types + ['scatter']:
         fig, axes = make_2d_axes(['x0', 'x1', 'x2'], upper=False)
         pc[mask].plot_2d(axes=axes, types=dict(lower=ptype, diagonal='hist'))

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -374,3 +374,16 @@ def test_ns_output():
     numpy.random.seed(3)
     pc = NestedSamples(root='./tests/example_data/pc')
     pc.ns_output(1000)
+
+
+def test_masking():
+    pc = NestedSamples(root="./tests/example_data/pc")
+    mask = pc['x0'] > 0
+
+    for ptype in ['kde', 'fastkde', 'hist']:
+        fig, axes = make_1d_axes(['x0', 'x1', 'x2'])
+        pc[mask].plot_1d(axes=axes, plot_type=ptype)
+
+    for ptype in ['kde', 'fastkde', 'hist', 'scatter']:
+        fig, axes = make_2d_axes(['x0', 'x1', 'x2'], upper=False)
+        pc[mask].plot_2d(axes=axes, types=dict(lower=ptype, diagonal='hist'))


### PR DESCRIPTION
# Allow masking

This addresses issue #53.

```python
ns = NestedSamples(root="/scratch/Projects/AnestheticPrj/anesthetic/tests/example_data/pc")
mask = ns['x0'] > 0
fig = plt.figure(figsize=(5, 5))
fig, axes = make_2d_axes(['x0', 'x1'], fig=fig, upper=False)
ns[mask].plot_2d(axes=axes, label='foo')
axes.iloc[-1, 0].legend(bbox_to_anchor=(len(axes), len(axes)), loc='upper right')
```
![image](https://user-images.githubusercontent.com/18258042/64562260-85f25980-d344-11e9-9a33-189241901e31.png)

See [159ecd1](https://github.com/williamjameshandley/anesthetic/commit/159ecd149b3d722c9f58e1059b4ec9feb0178a46) for more detailed description of the changes.

Fixes #53 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
