### PR TITLE
Weighted dataframe slicing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,3 +153,4 @@ script:
 # Run coverage summary
 after_success:
     - codecov
+    - bash <(curl -s https://codecov.io/bash)

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley
-:Version: 1.1.0
+:Version: 1.2.0
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 
@@ -149,6 +149,7 @@ or using the BibTeX:
        publisher = {The Open Journal},
        volume = {4},
        number = {37},
+       pages = {1414},
        author = {Will Handley},
        title = {anesthetic: nested sampling visualisation},
        journal = {The Journal of Open Source Software}

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley
-:Version: 1.2.0
+:Version: 1.2.1
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -56,7 +56,7 @@ class MCMCSamples(WeightedDataFrame):
 
     """
 
-    _metadata = WeightedDataFrame._metadata + ['tex', 'limits', 'u',
+    _metadata = WeightedDataFrame._metadata + ['tex', 'limits',
                                                'root', 'label']
 
     @property
@@ -80,15 +80,7 @@ class MCMCSamples(WeightedDataFrame):
             self.limits = kwargs.pop('limits', {})
             self.label = kwargs.pop('label', None)
             self.root = None
-            self.u = None
-
             super(MCMCSamples, self).__init__(*args, **kwargs)
-
-            self.u = numpy.random.rand(len(self))
-
-            if self.w is not None:
-                self['weight'] = self.w
-                self.tex['weight'] = r'MCMC weight'
 
             if logL is not None:
                 self['logL'] = logL
@@ -425,10 +417,6 @@ class NestedSamples(MCMCSamples):
             if 'nlive' in self:
                 self.beta = self._beta
 
-            if self.w is not None:
-                self['weight'] = self.w
-                self.tex['weight'] = r'MCMC weight'
-
     @property
     def beta(self):
         """Thermodynamic inverse temperature."""
@@ -438,7 +426,7 @@ class NestedSamples(MCMCSamples):
     def beta(self, beta):
         self._beta = beta
         logw = self._dlogX() + self.beta*self.logL
-        self.w = numpy.exp(logw - logw.max())
+        self._w = numpy.exp(logw - logw.max())
 
     def set_beta(self, beta, inplace=False):
         """Change the inverse temperature.

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -56,13 +56,6 @@ class MCMCSamples(WeightedDataFrame):
 
     """
 
-    _metadata = WeightedDataFrame._metadata + ['tex', 'limits',
-                                               'root', 'label']
-
-    @property
-    def _constructor(self):
-        return MCMCSamples
-
     def __init__(self, *args, **kwargs):
         root = kwargs.pop('root', None)
         if root is not None:
@@ -343,6 +336,13 @@ class MCMCSamples(WeightedDataFrame):
         self.__init__(root=self.root)
         return self
 
+    _metadata = WeightedDataFrame._metadata + ['tex', 'limits',
+                                               'root', 'label']
+
+    @property
+    def _constructor(self):
+        return MCMCSamples
+
 
 class NestedSamples(MCMCSamples):
     """Storage and plotting tools for Nested Sampling samples.
@@ -383,12 +383,6 @@ class NestedSamples(MCMCSamples):
         thermodynamic temperature
 
     """
-
-    _metadata = MCMCSamples._metadata + ['_beta']
-
-    @property
-    def _constructor(self):
-        return NestedSamples
 
     def __init__(self, *args, **kwargs):
         root = kwargs.pop('root', None)
@@ -437,7 +431,7 @@ class NestedSamples(MCMCSamples):
     def beta(self, beta):
         self._beta = beta
         logw = self._dlogX() + self.beta*self.logL
-        self._w = numpy.exp(logw - logw.max())
+        self._weight = numpy.exp(logw - logw.max())
 
     def set_beta(self, beta, inplace=False):
         """Change the inverse temperature.
@@ -532,3 +526,9 @@ class NestedSamples(MCMCSamples):
                           b=[numpy.ones_like(t), -numpy.ones_like(t)], axis=0)
         dlogX -= numpy.log(2)
         return numpy.squeeze(dlogX)
+
+    _metadata = MCMCSamples._metadata + ['_beta']
+
+    @property
+    def _constructor(self):
+        return NestedSamples

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -82,8 +82,8 @@ class MCMCSamples(WeightedDataFrame):
             self.root = None
             super(MCMCSamples, self).__init__(*args, **kwargs)
 
-            if self.w is not None:
-                self['weight'] = self.w
+            if self.weight is not None:
+                self['weight'] = self.weight
                 self.tex['weight'] = r'MCMC weight'
 
             if logL is not None:
@@ -137,7 +137,8 @@ class MCMCSamples(WeightedDataFrame):
                 if plot_type == 'kde':
                     if ncompress is None:
                         ncompress = 1000
-                    return kde_plot_1d(ax, self[paramname_x], weights=self.w,
+                    return kde_plot_1d(ax, self[paramname_x],
+                                       weights=self.weight,
                                        ncompress=ncompress,
                                        xmin=xmin, xmax=xmax,
                                        *args, **kwargs)
@@ -146,7 +147,8 @@ class MCMCSamples(WeightedDataFrame):
                     return fastkde_plot_1d(ax, x, xmin=xmin, xmax=xmax,
                                            *args, **kwargs)
                 elif plot_type == 'hist':
-                    return hist_plot_1d(ax, self[paramname_x], weights=self.w,
+                    return hist_plot_1d(ax, self[paramname_x],
+                                        weights=self.weight,
                                         xmin=xmin, xmax=xmax, *args, **kwargs)
                 elif plot_type == 'astropyhist':
                     x = self[paramname_x].compress(ncompress)
@@ -170,7 +172,7 @@ class MCMCSamples(WeightedDataFrame):
                         ncompress = 1000
                     x = self[paramname_x]
                     y = self[paramname_y]
-                    return kde_contour_plot_2d(ax, x, y, weights=self.w,
+                    return kde_contour_plot_2d(ax, x, y, weights=self.weight,
                                                xmin=xmin, xmax=xmax,
                                                ymin=ymin, ymax=ymax,
                                                ncompress=ncompress,
@@ -193,8 +195,9 @@ class MCMCSamples(WeightedDataFrame):
                 elif plot_type == 'hist':
                     x = self[paramname_x]
                     y = self[paramname_y]
-                    return hist_plot_2d(ax, x, y, weights=self.w, xmin=xmin,
-                                        xmax=xmax, ymin=ymin, ymax=ymax,
+                    return hist_plot_2d(ax, x, y, weights=self.weight,
+                                        xmin=xmin, xmax=xmax,
+                                        ymin=ymin, ymax=ymax,
                                         *args, **kwargs)
                 else:
                     raise NotImplementedError("plot_type is '%s', but must be"
@@ -421,8 +424,8 @@ class NestedSamples(MCMCSamples):
             if 'nlive' in self:
                 self.beta = self._beta
 
-            if self.w is not None:
-                self['weight'] = self.w
+            if self.weight is not None:
+                self['weight'] = self.weight
                 self.tex['weight'] = r'MCMC weight'
 
     @property

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -82,6 +82,10 @@ class MCMCSamples(WeightedDataFrame):
             self.root = None
             super(MCMCSamples, self).__init__(*args, **kwargs)
 
+            if self.w is not None:
+                self['weight'] = self.w
+                self.tex['weight'] = r'MCMC weight'
+
             if logL is not None:
                 self['logL'] = logL
                 self.tex['logL'] = r'$\log\mathcal{L}$'
@@ -416,6 +420,10 @@ class NestedSamples(MCMCSamples):
 
             if 'nlive' in self:
                 self.beta = self._beta
+
+            if self.w is not None:
+                self['weight'] = self.w
+                self.tex['weight'] = r'MCMC weight'
 
     @property
     def beta(self):

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -218,7 +218,7 @@ def triangular_sample_compression_2d(x, y, w=None, n=1000):
     x, y: array-like
         x and y coordinates of samples for compressing
 
-    w: array-like, optional
+    w: pandas.Series, optional
         weights of samples
 
     n: int, optional
@@ -231,13 +231,13 @@ def triangular_sample_compression_2d(x, y, w=None, n=1000):
 
     """
     if w is None:
-        w = numpy.ones_like(x)
+        w = pandas.Series(numpy.ones_like(x))
 
     # Select samples for triangulation
     if sum(w != 0) < n:
-        i = numpy.arange(len(w))
+        i = w.index
     else:
-        i = numpy.random.choice(len(w), size=n, replace=False, p=w/w.sum())
+        i = numpy.random.choice(w.index, size=n, replace=False, p=w/w.sum())
 
     # Generate triangulation
     cov = numpy.cov(x, y, aweights=w)
@@ -266,7 +266,7 @@ def triangular_sample_compression_2d(x, y, w=None, n=1000):
         numpy.add.at(w_, k[:, i], w[j != -1])
 
     x_, y_ = L.dot([x_, y_])
-    return (x_, y_, w_, tri.get_masked_triangles())
+    return x_, y_, w_, tri.get_masked_triangles()
 
 
 def sample_compression_1d(x, w=None, n=1000):
@@ -279,7 +279,7 @@ def sample_compression_1d(x, w=None, n=1000):
     x: array-like
         x coordinate of samples for compressing
 
-    w: array-like, optional
+    w: pandas.Series, optional
         weights of samples
 
     n: int, optional
@@ -291,13 +291,13 @@ def sample_compression_1d(x, w=None, n=1000):
         Compressed samples and weights
     """
     if w is None:
-        w = numpy.ones_like(x)
+        w = pandas.Series(numpy.ones_like(x))
 
     # Select inner samples for triangulation
     if sum(w != 0) < n:
-        i = numpy.arange(len(w))
+        i = w.index
     else:
-        i = numpy.random.choice(len(w), size=n, replace=False, p=w/w.sum())
+        i = numpy.random.choice(w.index, size=n, replace=False, p=w/w.sum())
 
     # Define sub-samples
     x_ = numpy.sort(x[i])

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -230,8 +230,9 @@ def triangular_sample_compression_2d(x, y, w=None, n=1000):
         Compressed samples and weights
 
     """
+    x = pandas.Series(x)
     if w is None:
-        w = pandas.Series(numpy.ones_like(x))
+        w = pandas.Series(index=x.index, data=numpy.ones_like(x))
 
     # Select samples for triangulation
     if sum(w != 0) < n:
@@ -290,8 +291,9 @@ def sample_compression_1d(x, w=None, n=1000):
     x, w, array-like
         Compressed samples and weights
     """
+    x = pandas.Series(x)
     if w is None:
-        w = pandas.Series(numpy.ones_like(x))
+        w = pandas.Series(index=x.index, data=numpy.ones_like(x))
 
     # Select inner samples for triangulation
     if sum(w != 0) < n:

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -8,7 +8,7 @@ from anesthetic.utils import (compress_weights, channel_capacity, quantile)
 class WeightedSeries(pandas.Series):
     """Weighted version of pandas.Series."""
 
-    _metadata = ['_w', '_u_']
+    _metadata = ['_w', '_rand_']
 
     @property
     def _constructor(self):
@@ -21,7 +21,8 @@ class WeightedSeries(pandas.Series):
             self._w = pandas.Series(index=self.index, data=w)
         else:
             self._w = None
-        self._u_ = numpy.random.rand(len(self))
+        self._rand_ = pandas.Series(index=self.index,
+                                    data=numpy.random.rand(len(self)))
 
     @property
     def weight(self):
@@ -32,9 +33,9 @@ class WeightedSeries(pandas.Series):
             return None
 
     @property
-    def _u(self):
+    def _rand(self):
         """Random number for consistent compression."""
-        return self._u_[self.index]
+        return self._rand_[self.index]
 
     def mean(self):
         """Weighted mean of the sampled distribution."""
@@ -79,20 +80,20 @@ class WeightedSeries(pandas.Series):
             compression). If <=0, then compress so that all weights are unity.
 
         """
-        i = compress_weights(self.weight, self._u, nsamples)
+        i = compress_weights(self.weight, self._rand, nsamples)
         return self.repeat(i)
 
 
 class WeightedDataFrame(pandas.DataFrame):
     """Weighted version of pandas.DataFrame."""
 
-    _metadata = ['_w', '_u_']
+    _metadata = ['_w', '_rand_']
 
     @property
     def _constructor_sliced(self):
         def __constructor_sliced(*args, **kwargs):
             series = WeightedSeries(*args, w=self._w, **kwargs)
-            series._u_ = self._u_
+            series._rand_ = self._rand_
             return series
         return __constructor_sliced
 
@@ -109,9 +110,9 @@ class WeightedDataFrame(pandas.DataFrame):
             return None
 
     @property
-    def _u(self):
+    def _rand(self):
         """Random number for consistent compression."""
-        return self._u_[self.index]
+        return self._rand_[self.index]
 
     def __init__(self, *args, **kwargs):
         w = kwargs.pop('w', None)
@@ -120,7 +121,8 @@ class WeightedDataFrame(pandas.DataFrame):
             self._w = pandas.Series(index=self.index, data=w)
         else:
             self._w = None
-        self._u_ = numpy.random.rand(len(self))
+        self._rand_ = pandas.Series(index=self.index,
+                                    data=numpy.random.rand(len(self)))
 
     def mean(self):
         """Weighted mean of the sampled distribution."""
@@ -177,7 +179,7 @@ class WeightedDataFrame(pandas.DataFrame):
             compression). If <=0, then compress so that all weights are unity.
 
         """
-        i = compress_weights(self.weight, self._u, nsamples)
+        i = compress_weights(self.weight, self._rand, nsamples)
         data = numpy.repeat(self.values, i, axis=0)
         index = numpy.repeat(self.index.values, i)
         return pandas.DataFrame(data=data, index=index, columns=self.columns)

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -15,8 +15,12 @@ class WeightedSeries(pandas.Series):
         return WeightedSeries
 
     def __init__(self, *args, **kwargs):
-        self._w = pandas.Series(kwargs.pop('w', None))
+        w = kwargs.pop('w', None)
         super(WeightedSeries, self).__init__(*args, **kwargs)
+        if w is not None:
+            self._w = pandas.Series(index=self.index, data=w)
+        else:
+            self._w = None
         self._u = numpy.random.rand(len(self))
 
     @property
@@ -112,10 +116,10 @@ class WeightedDataFrame(pandas.DataFrame):
     def __init__(self, *args, **kwargs):
         w = kwargs.pop('w', None)
         super(WeightedDataFrame, self).__init__(*args, **kwargs)
-        if w is None:
-            self._w = pandas.Series(numpy.ones(len(self)))
+        if w is not None:
+            self._w = pandas.Series(index=self.index, data=w)
         else:
-            self._w = pandas.Series(w)
+            self._w = None
         self._u = numpy.random.rand(len(self))
 
     def mean(self):

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -110,8 +110,12 @@ class WeightedDataFrame(pandas.DataFrame):
         return self._u[self.index]
 
     def __init__(self, *args, **kwargs):
-        self._w = pandas.Series(kwargs.pop('w', None))
+        w = kwargs.pop('w', None)
         super(WeightedDataFrame, self).__init__(*args, **kwargs)
+        if w is None:
+            self._w = pandas.Series(numpy.ones(len(self)))
+        else:
+            self._w = pandas.Series(w)
         self._u = numpy.random.rand(len(self))
 
     def mean(self):

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -24,7 +24,7 @@ class WeightedSeries(pandas.Series):
         self._u_ = numpy.random.rand(len(self))
 
     @property
-    def w(self):
+    def weight(self):
         """Sample weights."""
         if self._w is not None:
             return self._w[self.index]
@@ -38,7 +38,7 @@ class WeightedSeries(pandas.Series):
 
     def mean(self):
         """Weighted mean of the sampled distribution."""
-        return numpy.average(self, weights=self.w)
+        return numpy.average(self, weights=self.weight)
 
     def std(self):
         """Weighted standard deviation of the sampled distribution."""
@@ -46,7 +46,7 @@ class WeightedSeries(pandas.Series):
 
     def var(self):
         """Weighted variance of the sampled distribution."""
-        return numpy.average((self-self.mean())**2, weights=self.w)
+        return numpy.average((self-self.mean())**2, weights=self.weight)
 
     def median(self):
         """Weighted median of the sampled distribution."""
@@ -54,19 +54,19 @@ class WeightedSeries(pandas.Series):
 
     def quantile(self, q=0.5):
         """Weighted quantile of the sampled distribution."""
-        return quantile(self.values, q, self.w.values)
+        return quantile(self.values, q, self.weight.values)
 
     def hist(self, *args, **kwargs):
         """Weighted histogram of the sampled distribution."""
-        return super(WeightedSeries, self).hist(weights=self.w,
+        return super(WeightedSeries, self).hist(weights=self.weight,
                                                 *args, **kwargs)
 
     def neff(self):
         """Effective number of samples."""
-        if self.w is None:
+        if self.weight is None:
             return len(self)
         else:
-            return channel_capacity(self.w)
+            return channel_capacity(self.weight)
 
     def compress(self, nsamples=None):
         """Reduce the number of samples by discarding low-weights.
@@ -79,7 +79,7 @@ class WeightedSeries(pandas.Series):
             compression). If <=0, then compress so that all weights are unity.
 
         """
-        i = compress_weights(self.w, self._u, nsamples)
+        i = compress_weights(self.weight, self._u, nsamples)
         return self.repeat(i)
 
 
@@ -101,7 +101,7 @@ class WeightedDataFrame(pandas.DataFrame):
         return WeightedDataFrame
 
     @property
-    def w(self):
+    def weight(self):
         """Sample weights."""
         if self._w is not None:
             return self._w[self.index]
@@ -124,7 +124,7 @@ class WeightedDataFrame(pandas.DataFrame):
 
     def mean(self):
         """Weighted mean of the sampled distribution."""
-        return pandas.Series(numpy.average(self, weights=self.w, axis=0),
+        return pandas.Series(numpy.average(self, weights=self.weight, axis=0),
                              index=self.columns)
 
     def std(self):
@@ -134,12 +134,12 @@ class WeightedDataFrame(pandas.DataFrame):
     def var(self):
         """Weighted variance of the sampled distribution."""
         return pandas.Series(numpy.average((self-self.mean())**2,
-                                           weights=self.w, axis=0),
+                                           weights=self.weight, axis=0),
                              index=self.columns)
 
     def cov(self):
         """Weighted covariance of the sampled distribution."""
-        return pandas.DataFrame(numpy.cov(self.T, aweights=self.w),
+        return pandas.DataFrame(numpy.cov(self.T, aweights=self.weight),
                                 index=self.columns, columns=self.columns)
 
     def median(self):
@@ -156,15 +156,15 @@ class WeightedDataFrame(pandas.DataFrame):
 
     def hist(self, *args, **kwargs):
         """Weighted histogram of the sampled distribution."""
-        return super(WeightedDataFrame, self).hist(weights=self.w,
+        return super(WeightedDataFrame, self).hist(weights=self.weight,
                                                    *args, **kwargs)
 
     def neff(self):
         """Effective number of samples."""
-        if self.w is None:
+        if self.weight is None:
             return len(self)
         else:
-            return channel_capacity(self.w)
+            return channel_capacity(self.weight)
 
     def compress(self, nsamples=None):
         """Reduce the number of samples by discarding low-weights.
@@ -177,7 +177,7 @@ class WeightedDataFrame(pandas.DataFrame):
             compression). If <=0, then compress so that all weights are unity.
 
         """
-        i = compress_weights(self.w, self._u, nsamples)
+        i = compress_weights(self.weight, self._u, nsamples)
         data = numpy.repeat(self.values, i, axis=0)
         index = numpy.repeat(self.index.values, i)
         return pandas.DataFrame(data=data, index=index, columns=self.columns)

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -8,12 +8,6 @@ from anesthetic.utils import (compress_weights, channel_capacity, quantile)
 class WeightedSeries(pandas.Series):
     """Weighted version of pandas.Series."""
 
-    _metadata = ['_w', '_rand_']
-
-    @property
-    def _constructor(self):
-        return WeightedSeries
-
     def __init__(self, *args, **kwargs):
         w = kwargs.pop('w', None)
         super(WeightedSeries, self).__init__(*args, **kwargs)
@@ -83,23 +77,15 @@ class WeightedSeries(pandas.Series):
         i = compress_weights(self.weight, self._rand, nsamples)
         return self.repeat(i)
 
-
-class WeightedDataFrame(pandas.DataFrame):
-    """Weighted version of pandas.DataFrame."""
-
     _metadata = ['_w', '_rand_']
 
     @property
-    def _constructor_sliced(self):
-        def __constructor_sliced(*args, **kwargs):
-            series = WeightedSeries(*args, w=self._w, **kwargs)
-            series._rand_ = self._rand_
-            return series
-        return __constructor_sliced
-
-    @property
     def _constructor(self):
-        return WeightedDataFrame
+        return WeightedSeries
+
+
+class WeightedDataFrame(pandas.DataFrame):
+    """Weighted version of pandas.DataFrame."""
 
     def __init__(self, *args, **kwargs):
         w = kwargs.pop('w', None)
@@ -183,3 +169,17 @@ class WeightedDataFrame(pandas.DataFrame):
         data = numpy.repeat(self.values, i, axis=0)
         index = numpy.repeat(self.index.values, i)
         return pandas.DataFrame(data=data, index=index, columns=self.columns)
+
+    _metadata = ['_w', '_rand_']
+
+    @property
+    def _constructor_sliced(self):
+        def __constructor_sliced(*args, **kwargs):
+            series = WeightedSeries(*args, w=self._w, **kwargs)
+            series._rand_ = self._rand_
+            return series
+        return __constructor_sliced
+
+    @property
+    def _constructor(self):
+        return WeightedDataFrame

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -16,15 +16,20 @@ class WeightedSeries(pandas.Series):
 
     def __init__(self, *args, **kwargs):
         self._w = pandas.Series(kwargs.pop('w', None))
-        self._u = kwargs.pop('u', None)
         super(WeightedSeries, self).__init__(*args, **kwargs)
+        self._u = numpy.random.rand(len(self))
 
     @property
     def w(self):
-        return self._w[self.index]
+        """Sample weights."""
+        if self._w is not None:
+            return self._w[self.index]
+        else:
+            return None
 
     @property
     def u(self):
+        """Random number for consistent compression."""
         return self._u[self.index]
 
     def mean(self):
@@ -82,7 +87,9 @@ class WeightedDataFrame(pandas.DataFrame):
     @property
     def _constructor_sliced(self):
         def __constructor_sliced(*args, **kwargs):
-            return WeightedSeries(*args, w=self._w, u=self._u, **kwargs)
+            series = WeightedSeries(*args, w=self._w, **kwargs)
+            series._u = self._u
+            return series
         return __constructor_sliced
 
     @property
@@ -91,16 +98,21 @@ class WeightedDataFrame(pandas.DataFrame):
 
     @property
     def w(self):
-        return self._w[self.index]
+        """Sample weights."""
+        if self._w is not None:
+            return self._w[self.index]
+        else:
+            return None
 
     @property
     def u(self):
+        """Random number for consistent compression."""
         return self._u[self.index]
 
     def __init__(self, *args, **kwargs):
         self._w = pandas.Series(kwargs.pop('w', None))
-        self._u = kwargs.pop('u', None)
         super(WeightedDataFrame, self).__init__(*args, **kwargs)
+        self._u = numpy.random.rand(len(self))
 
     def mean(self):
         """Weighted mean of the sampled distribution."""

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -101,6 +101,16 @@ class WeightedDataFrame(pandas.DataFrame):
     def _constructor(self):
         return WeightedDataFrame
 
+    def __init__(self, *args, **kwargs):
+        w = kwargs.pop('w', None)
+        super(WeightedDataFrame, self).__init__(*args, **kwargs)
+        if w is not None:
+            self._w = pandas.Series(index=self.index, data=w)
+        else:
+            self._w = None
+        self._rand_ = pandas.Series(index=self.index,
+                                    data=numpy.random.rand(len(self)))
+
     @property
     def weight(self):
         """Sample weights."""
@@ -113,16 +123,6 @@ class WeightedDataFrame(pandas.DataFrame):
     def _rand(self):
         """Random number for consistent compression."""
         return self._rand_[self.index]
-
-    def __init__(self, *args, **kwargs):
-        w = kwargs.pop('w', None)
-        super(WeightedDataFrame, self).__init__(*args, **kwargs)
-        if w is not None:
-            self._w = pandas.Series(index=self.index, data=w)
-        else:
-            self._w = None
-        self._rand_ = pandas.Series(index=self.index,
-                                    data=numpy.random.rand(len(self)))
 
     def mean(self):
         """Weighted mean of the sampled distribution."""

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -12,17 +12,17 @@ class WeightedSeries(pandas.Series):
         w = kwargs.pop('w', None)
         super(WeightedSeries, self).__init__(*args, **kwargs)
         if w is not None:
-            self._w = pandas.Series(index=self.index, data=w)
+            self._weight = pandas.Series(index=self.index, data=w)
         else:
-            self._w = None
+            self._weight = None
         self._rand_ = pandas.Series(index=self.index,
                                     data=numpy.random.rand(len(self)))
 
     @property
     def weight(self):
         """Sample weights."""
-        if self._w is not None:
-            return self._w[self.index]
+        if self._weight is not None:
+            return self._weight[self.index]
         else:
             return None
 
@@ -77,7 +77,7 @@ class WeightedSeries(pandas.Series):
         i = compress_weights(self.weight, self._rand, nsamples)
         return self.repeat(i)
 
-    _metadata = ['_w', '_rand_']
+    _metadata = ['_weight', '_rand_']
 
     @property
     def _constructor(self):
@@ -91,17 +91,17 @@ class WeightedDataFrame(pandas.DataFrame):
         w = kwargs.pop('w', None)
         super(WeightedDataFrame, self).__init__(*args, **kwargs)
         if w is not None:
-            self._w = pandas.Series(index=self.index, data=w)
+            self._weight = pandas.Series(index=self.index, data=w)
         else:
-            self._w = None
+            self._weight = None
         self._rand_ = pandas.Series(index=self.index,
                                     data=numpy.random.rand(len(self)))
 
     @property
     def weight(self):
         """Sample weights."""
-        if self._w is not None:
-            return self._w[self.index]
+        if self._weight is not None:
+            return self._weight[self.index]
         else:
             return None
 
@@ -170,12 +170,12 @@ class WeightedDataFrame(pandas.DataFrame):
         index = numpy.repeat(self.index.values, i)
         return pandas.DataFrame(data=data, index=index, columns=self.columns)
 
-    _metadata = ['_w', '_rand_']
+    _metadata = ['_weight', '_rand_']
 
     @property
     def _constructor_sliced(self):
         def __constructor_sliced(*args, **kwargs):
-            series = WeightedSeries(*args, w=self._w, **kwargs)
+            series = WeightedSeries(*args, w=self._weight, **kwargs)
             series._rand_ = self._rand_
             return series
         return __constructor_sliced

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -374,3 +374,20 @@ def test_ns_output():
     numpy.random.seed(3)
     pc = NestedSamples(root='./tests/example_data/pc')
     pc.ns_output(1000)
+
+
+def test_masking():
+    pc = NestedSamples(root="./tests/example_data/pc")
+    mask = pc['x0'] > 0
+
+    plot_types = ['kde', 'hist']
+    if 'fastkde' in sys.modules:
+        plot_types += ['fastkde']
+
+    for ptype in plot_types:
+        fig, axes = make_1d_axes(['x0', 'x1', 'x2'])
+        pc[mask].plot_1d(axes=axes, plot_type=ptype)
+
+    for ptype in plot_types + ['scatter']:
+        fig, axes = make_2d_axes(['x0', 'x1', 'x2'], upper=False)
+        pc[mask].plot_2d(axes=axes, types=dict(lower=ptype, diagonal='hist'))

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -40,12 +40,12 @@ def test_build_mcmc():
 
     mcmc = MCMCSamples(data=samples, w=w)
     assert(len(mcmc) == nsamps)
-    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2],
+    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2, 'weight'],
                                                  dtype=object))
 
     mcmc = MCMCSamples(data=samples, w=w, logL=logL)
     assert(len(mcmc) == nsamps)
-    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2, 'logL'],
+    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2, 'weight', 'logL'],
                                                  dtype=object))
 
     mcmc = MCMCSamples(data=samples, columns=params)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -40,12 +40,12 @@ def test_build_mcmc():
 
     mcmc = MCMCSamples(data=samples, w=w)
     assert(len(mcmc) == nsamps)
-    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2, 'weight'],
+    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2],
                                                  dtype=object))
 
     mcmc = MCMCSamples(data=samples, w=w, logL=logL)
     assert(len(mcmc) == nsamps)
-    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2, 'weight', 'logL'],
+    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2, 'logL'],
                                                  dtype=object))
 
     mcmc = MCMCSamples(data=samples, columns=params)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -1,21 +1,19 @@
-%load_ext autoreload
-%autoreload 2
-
 from anesthetic.weighted_pandas import WeightedDataFrame, WeightedSeries
 from pandas import Series
 import numpy
 from numpy.testing import assert_array_equal
 
+
 def test_WeightedDataFrame_constructor():
     numpy.random.seed(0)
     N = 1000
     m = 3
-    data = numpy.random.rand(N,m)
+    data = numpy.random.rand(N, m)
     weights = numpy.random.rand(N)
     cols = ['A', 'B', 'C']
     df = WeightedDataFrame(data, w=weights, columns=cols)
     assert df.w.shape == (N,)
-    assert df.shape == (N,m)
+    assert df.shape == (N, m)
     assert isinstance(df.w, Series)
     assert_array_equal(df, data)
     assert_array_equal(df.w, weights)
@@ -28,10 +26,4 @@ def test_WeightedDataFrame_slice():
     assert isinstance(df['A'],  WeightedSeries)
     assert df[:10].shape == (10, 3)
     assert df[:10].w.shape == (10,)
-
-
-def test_WeightedDataFrame_mean():
-    df = test_WeightedDataFrame_constructor()
-    assert isinstance(df['A'],  WeightedSeries)
-    assert df[:10].shape == (10, 3)
-    assert df[:10].w.shape == (10,)
+    assert df[:10].u.shape == (10,)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -12,11 +12,11 @@ def test_WeightedDataFrame_constructor():
     weights = numpy.random.rand(N)
     cols = ['A', 'B', 'C']
     df = WeightedDataFrame(data, w=weights, columns=cols)
-    assert df.w.shape == (N,)
+    assert df.weight.shape == (N,)
     assert df.shape == (N, m)
-    assert isinstance(df.w, Series)
+    assert isinstance(df.weight, Series)
     assert_array_equal(df, data)
-    assert_array_equal(df.w, weights)
+    assert_array_equal(df.weight, weights)
     assert_array_equal(df.columns, cols)
     return df
 
@@ -25,5 +25,5 @@ def test_WeightedDataFrame_slice():
     df = test_WeightedDataFrame_constructor()
     assert isinstance(df['A'],  WeightedSeries)
     assert df[:10].shape == (10, 3)
-    assert df[:10].w.shape == (10,)
+    assert df[:10].weight.shape == (10,)
     assert df[:10]._u.shape == (10,)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -26,4 +26,4 @@ def test_WeightedDataFrame_slice():
     assert isinstance(df['A'],  WeightedSeries)
     assert df[:10].shape == (10, 3)
     assert df[:10].w.shape == (10,)
-    assert df[:10].u.shape == (10,)
+    assert df[:10]._u.shape == (10,)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -1,0 +1,37 @@
+%load_ext autoreload
+%autoreload 2
+
+from anesthetic.weighted_pandas import WeightedDataFrame, WeightedSeries
+from pandas import Series
+import numpy
+from numpy.testing import assert_array_equal
+
+def test_WeightedDataFrame_constructor():
+    numpy.random.seed(0)
+    N = 1000
+    m = 3
+    data = numpy.random.rand(N,m)
+    weights = numpy.random.rand(N)
+    cols = ['A', 'B', 'C']
+    df = WeightedDataFrame(data, w=weights, columns=cols)
+    assert df.w.shape == (N,)
+    assert df.shape == (N,m)
+    assert isinstance(df.w, Series)
+    assert_array_equal(df, data)
+    assert_array_equal(df.w, weights)
+    assert_array_equal(df.columns, cols)
+    return df
+
+
+def test_WeightedDataFrame_slice():
+    df = test_WeightedDataFrame_constructor()
+    assert isinstance(df['A'],  WeightedSeries)
+    assert df[:10].shape == (10, 3)
+    assert df[:10].w.shape == (10,)
+
+
+def test_WeightedDataFrame_mean():
+    df = test_WeightedDataFrame_constructor()
+    assert isinstance(df['A'],  WeightedSeries)
+    assert df[:10].shape == (10, 3)
+    assert df[:10].w.shape == (10,)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -26,4 +26,4 @@ def test_WeightedDataFrame_slice():
     assert isinstance(df['A'],  WeightedSeries)
     assert df[:10].shape == (10, 3)
     assert df[:10].weight.shape == (10,)
-    assert df[:10]._u.shape == (10,)
+    assert df[:10]._rand.shape == (10,)


### PR DESCRIPTION
# Description

This fixes #53 by ensuring that the invisible weights array is sliced whenever the array is.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
