### PR TITLE
Add columns kwarg

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -60,11 +60,18 @@ class MCMCSamples(WeightedDataFrame):
         root = kwargs.pop('root', None)
         if root is not None:
             reader = SampleReader(root)
+            if os.path.isfile(reader.birth_file) or os.path.isfile(reader.ev_file):
+                raise ValueError("The file root %s seems to point to a Nested "
+                              "Sampling chain. Please use NestedSamples "
+                              "instead which has the same features as "
+                              "MCMCSamples and more. MCMCSamples should be "
+                              "used for MCMC chains only." % root)
             w, logL, samples = reader.samples()
             params, tex = reader.paramnames()
+            columns = kwargs.pop('columns', params)
             limits = reader.limits()
             kwargs['label'] = kwargs.get('label', os.path.basename(root))
-            self.__init__(data=samples, columns=params, w=w, logL=logL,
+            self.__init__(data=samples, columns=columns, w=w, logL=logL,
                           tex=tex, limits=limits, *args, **kwargs)
             self.root = root
         else:
@@ -390,9 +397,10 @@ class NestedSamples(MCMCSamples):
             reader = SampleReader(root)
             samples, logL, logL_birth = reader.samples()
             params, tex = reader.paramnames()
+            columns = kwargs.pop('columns', params)
             limits = reader.limits()
             kwargs['label'] = kwargs.get('label', os.path.basename(root))
-            self.__init__(data=samples, columns=params,
+            self.__init__(data=samples, columns=columns,
                           logL=logL, logL_birth=logL_birth,
                           tex=tex, limits=limits, *args, **kwargs)
             self.root = root

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -62,10 +62,10 @@ class MCMCSamples(WeightedDataFrame):
             reader = SampleReader(root)
             if hasattr(reader, 'birth_file') or hasattr(reader, 'ev_file'):
                 raise ValueError("The file root %s seems to point to a Nested "
-                              "Sampling chain. Please use NestedSamples "
-                              "instead which has the same features as "
-                              "MCMCSamples and more. MCMCSamples should be "
-                              "used for MCMC chains only." % root)
+                                 "Sampling chain. Please use NestedSamples "
+                                 "instead which has the same features as "
+                                 "MCMCSamples and more. MCMCSamples should be "
+                                 "used for MCMC chains only." % root)
             w, logL, samples = reader.samples()
             params, tex = reader.paramnames()
             columns = kwargs.pop('columns', params)

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -60,7 +60,7 @@ class MCMCSamples(WeightedDataFrame):
         root = kwargs.pop('root', None)
         if root is not None:
             reader = SampleReader(root)
-            if os.path.isfile(reader.birth_file) or os.path.isfile(reader.ev_file):
+            if hasattr(reader, 'birth_file') or hasattr(reader, 'ev_file'):
                 raise ValueError("The file root %s seems to point to a Nested "
                               "Sampling chain. Please use NestedSamples "
                               "instead which has the same features as "

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -139,8 +139,8 @@ def test_different_parameters():
 
 def test_manual_columns():
     old_params = ['x0', 'x1', 'x2', 'x3', 'x4']
-    mcmc_params = ['weight', 'logL']
-    ns_params = ['logL', 'logL_birth', 'nlive', 'weight']
+    mcmc_params = ['logL', 'weight']
+    ns_params = ['logL', 'weight', 'logL_birth', 'nlive']
     mcmc = MCMCSamples(root='./tests/example_data/gd')
     ns = NestedSamples(root='./tests/example_data/pc')
     assert_array_equal(mcmc.columns, old_params + mcmc_params)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -117,7 +117,6 @@ def test_read_polychord():
 
 
 def test_NS_input_fails_in_MCMCSamples():
-    numpy.random.seed(3)
     with pytest.raises(ValueError) as excinfo:
         MCMCSamples(root='./tests/example_data/pc')
     assert "Please use NestedSamples instead which has the same features as " \
@@ -139,6 +138,17 @@ def test_different_parameters():
     fig, axes = make_2d_axes([params_x, params_y])
     ns.plot_2d(axes)
     plt.close('all')
+
+
+def test_manual_columns():
+    old_params = ['x0', 'x1', 'x2', 'x3', 'x4', 'logL', 'logL_birth', 'nlive', 'weight']
+    ns = NestedSamples(root='./tests/example_data/pc')
+    assert_array_equal(ns.columns, old_params)
+
+    new_params = ['y0', 'y1', 'y2', 'y3', 'y4']
+    ns = NestedSamples(root='./tests/example_data/pc', columns=new_params)
+    new_params += ['logL', 'logL_birth', 'nlive', 'weight']
+    assert_array_equal(ns.columns, new_params)
 
 
 def test_plot_2d_types():

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -116,6 +116,15 @@ def test_read_polychord():
     assert_array_equal(ns_nolive[cols], ns[cols][:ns_nolive.shape[0]])
 
 
+def test_NS_input_fails_in_MCMCSamples():
+    numpy.random.seed(3)
+    with pytest.raises(ValueError) as excinfo:
+        MCMCSamples(root='./tests/example_data/pc')
+    assert "Please use NestedSamples instead which has the same features as " \
+           "MCMCSamples and more. MCMCSamples should be used for MCMC " \
+           "chains only." in str(excinfo.value)
+
+
 def test_different_parameters():
     numpy.random.seed(3)
     params_x = ['x0', 'x1', 'x2', 'x3', 'x4']

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -141,14 +141,19 @@ def test_different_parameters():
 
 
 def test_manual_columns():
-    old_params = ['x0', 'x1', 'x2', 'x3', 'x4', 'logL', 'logL_birth', 'nlive', 'weight']
+    old_params = ['x0', 'x1', 'x2', 'x3', 'x4']
+    mcmc_params = ['weight', 'logL']
+    ns_params = ['logL', 'logL_birth', 'nlive', 'weight']
+    mcmc = MCMCSamples(root='./tests/example_data/gd')
     ns = NestedSamples(root='./tests/example_data/pc')
-    assert_array_equal(ns.columns, old_params)
+    assert_array_equal(mcmc.columns, old_params + mcmc_params)
+    assert_array_equal(ns.columns, old_params + ns_params)
 
     new_params = ['y0', 'y1', 'y2', 'y3', 'y4']
+    mcmc = MCMCSamples(root='./tests/example_data/gd', columns=new_params)
     ns = NestedSamples(root='./tests/example_data/pc', columns=new_params)
-    new_params += ['logL', 'logL_birth', 'nlive', 'weight']
-    assert_array_equal(ns.columns, new_params)
+    assert_array_equal(mcmc.columns, new_params + mcmc_params)
+    assert_array_equal(ns.columns, new_params + ns_params)
 
 
 def test_plot_2d_types():


### PR DESCRIPTION
# Description

This allows column names to be passed manually to both `MCMCSamples` and `NestedSamples` but behaves as usual if only the root is passed.

Addresses #37 and #38.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
