### PR TITLE
Bug fix for histogram plotting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley
-:Version: 1.2.4
+:Version: 1.2.5
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ anesthetic: nested sampling visualisation
 
 
 
+
 ``anesthetic`` brings together tools for processing nested sampling chains, leveraging standard scientific python libraries.
 
 You can see example usage and plots in the `plot gallery <http://htmlpreview.github.io/?https://github.com/williamjameshandley/cosmo_example/blob/master/demos/demo.html>`_, or in the corresponding `Jupyter notebook <https://mybinder.org/v2/gh/williamjameshandley/anesthetic/master?filepath=demo.ipynb>`_.

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,6 @@ anesthetic: nested sampling visualisation
 
 
 
-
 ``anesthetic`` brings together tools for processing nested sampling chains, leveraging standard scientific python libraries.
 
 You can see example usage and plots in the `plot gallery <http://htmlpreview.github.io/?https://github.com/williamjameshandley/cosmo_example/blob/master/demos/demo.html>`_, or in the corresponding `Jupyter notebook <https://mybinder.org/v2/gh/williamjameshandley/anesthetic/master?filepath=demo.ipynb>`_.

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -600,6 +600,18 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
     label = kwargs.pop('label', None)
     levels = kwargs.pop('levels', None)
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
+    weights = kwargs.pop('weights', None)
+
+    if xmin is None:
+        xmin = quantile(data_x, 0.01, weights)
+    if xmax is None:
+        xmax = quantile(data_x, 0.99, weights)
+    if ymin is None:
+        ymin = quantile(data_y, 0.01, weights)
+    if ymax is None:
+        ymax = quantile(data_y, 0.99, weights)
+
+    range = kwargs.pop('range', ((xmin, xmax), (ymin, ymax)))
 
     if len(data_x) == 0 or len(data_y) == 0:
         return numpy.zeros(0), numpy.zeros(0), numpy.zeros((0, 0))
@@ -607,13 +619,12 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
     cmap = basic_cmap(color)
 
     if levels is None:
-        pdf, x, y, image = ax.hist2d(data_x, data_y, cmap=cmap,
+        pdf, x, y, image = ax.hist2d(data_x, data_y, weights=weights,
+                                     cmap=cmap, range=range,
                                      *args, **kwargs)
     else:
         bins = kwargs.pop('bins', 10)
-        range = kwargs.pop('range', None)
         density = kwargs.pop('density', False)
-        weights = kwargs.pop('weights', None)
         cmin = kwargs.pop('cmin', None)
         cmax = kwargs.pop('cmax', None)
         pdf, x, y = numpy.histogram2d(data_x, data_y, bins, range,

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -602,13 +602,13 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
     weights = kwargs.pop('weights', None)
 
-    if xmin is None or ~numpy.isfinite(xmin):
+    if xmin is None or not numpy.isfinite(xmin):
         xmin = quantile(data_x, 0.01, weights)
-    if xmax is None or ~numpy.isfinite(xmax):
+    if xmax is None or not numpy.isfinite(xmax):
         xmax = quantile(data_x, 0.99, weights)
-    if ymin is None or ~numpy.isfinite(ymin):
+    if ymin is None or not numpy.isfinite(ymin):
         ymin = quantile(data_y, 0.01, weights)
-    if ymax is None or ~numpy.isfinite(ymax):
+    if ymax is None or not numpy.isfinite(ymax):
         ymax = quantile(data_y, 0.99, weights)
 
     range = kwargs.pop('range', ((xmin, xmax), (ymin, ymax)))

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -378,9 +378,9 @@ def hist_plot_1d(ax, data, *args, **kwargs):
     xmax = kwargs.pop('xmax', None)
     plotter = kwargs.pop('plotter', '')
     weights = kwargs.pop('weights', None)
-    if xmin is None:
+    if xmin is None or not numpy.isfinite(xmin):
         xmin = quantile(data, 0.01, weights)
-    if xmax is None:
+    if xmax is None or not numpy.isfinite(xmax):
         xmax = quantile(data, 0.99, weights)
     histtype = kwargs.pop('histtype', 'bar')
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -602,13 +602,13 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
     weights = kwargs.pop('weights', None)
 
-    if xmin is None:
+    if xmin is None or ~numpy.isfinite(xmin):
         xmin = quantile(data_x, 0.01, weights)
-    if xmax is None:
+    if xmax is None or ~numpy.isfinite(xmax):
         xmax = quantile(data_x, 0.99, weights)
-    if ymin is None:
+    if ymin is None or ~numpy.isfinite(ymin):
         ymin = quantile(data_y, 0.01, weights)
-    if ymax is None:
+    if ymax is None or ~numpy.isfinite(ymax):
         ymax = quantile(data_y, 0.99, weights)
 
     range = kwargs.pop('range', ((xmin, xmax), (ymin, ymax)))

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -185,10 +185,6 @@ def iso_probability_contours(pdf, contours=[0.68, 0.95]):
     interp = interp1d([0]+list(m), [0]+list(p))
     c = list(interp(contours))+[max(p)]
 
-    # Correct non-zero edges
-    if p.min() != 0:
-        c = [p.max()] + c
-
     # Correct level sets
     for i in range(1, len(c)):
         if c[i-1] == c[i]:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -300,6 +300,9 @@ def test_hist_plot_2d():
     ymin, ymax = ax.get_ylim()
     assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
 
+    hist_plot_2d(ax, data_x, data_y, xmin=-numpy.inf)
+    assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
+
     data_x, data_y = numpy.random.uniform(-10, 10, (2, 1000000))
     weights = numpy.exp(-(data_x**2 + data_y**2)/2)
     hist_plot_2d(ax, data_x, data_y, weights=weights, bins=30)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -262,19 +262,21 @@ def test_hist_plot_1d():
             assert(polygon.get_ec() == ColorConverter.to_rgba('r', alpha=0.5))
 
             # Check xmin
-            xmin = -0.5
-            bars = hist_plot_1d(ax, data, histtype='bar', xmin=xmin, plotter=p)
-            assert((numpy.array([b.xy[0] for b in bars]) >= -0.5).all())
-            polygon, = hist_plot_1d(ax, data, histtype='step', xmin=xmin)
-            assert((polygon.xy[:, 0] >= -0.5).all())
+            for xmin in [-numpy.inf, -0.5]:
+                bars = hist_plot_1d(ax, data, histtype='bar',
+                                    xmin=xmin, plotter=p)
+                assert((numpy.array([b.xy[0] for b in bars]) >= xmin).all())
+                polygon, = hist_plot_1d(ax, data, histtype='step', xmin=xmin)
+                assert((polygon.xy[:, 0] >= xmin).all())
 
             # Check xmax
-            xmax = 0.5
-            bars = hist_plot_1d(ax, data, histtype='bar', xmax=xmax, plotter=p)
-            assert((numpy.array([b.xy[-1] for b in bars]) <= 0.5).all())
-            polygon, = hist_plot_1d(ax, data, histtype='step',
+            for xmax in [numpy.inf, 0.5]:
+                bars = hist_plot_1d(ax, data, histtype='bar',
                                     xmax=xmax, plotter=p)
-            assert((polygon.xy[:, 0] <= 0.5).all())
+                assert((numpy.array([b.xy[-1] for b in bars]) <= xmax).all())
+                polygon, = hist_plot_1d(ax, data, histtype='step',
+                                        xmax=xmax, plotter=p)
+                assert((polygon.xy[:, 0] <= xmax).all())
 
             # Check xmin and xmax
             bars = hist_plot_1d(ax, data, histtype='bar',

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -5,7 +5,7 @@ import sys
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gs
 from anesthetic.plot import (make_1d_axes, make_2d_axes, kde_plot_1d,
-                             fastkde_plot_1d, hist_plot_1d,
+                             fastkde_plot_1d, hist_plot_1d, hist_plot_2d,
                              fastkde_contour_plot_2d, kde_contour_plot_2d,
                              scatter_plot_2d)
 from numpy.testing import assert_array_equal
@@ -289,6 +289,23 @@ def test_hist_plot_1d():
         except ImportError:
             if p == 'astropyhist' and 'astropy' not in sys.modules:
                 pass
+
+
+def test_hist_plot_2d():
+    fig, ax = plt.subplots()
+    numpy.random.seed(0)
+    data_x, data_y = numpy.random.randn(2, 10000)
+    hist_plot_2d(ax, data_x, data_y)
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
+
+    data_x, data_y = numpy.random.uniform(-10, 10, (2, 1000000))
+    weights = numpy.exp(-(data_x**2 + data_y**2)/2)
+    hist_plot_2d(ax, data_x, data_y, weights=weights, bins=30)
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
 
 
 def test_contour_plot_2d():

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -301,6 +301,9 @@ def test_hist_plot_2d():
     assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
 
     hist_plot_2d(ax, data_x, data_y, xmin=-numpy.inf)
+    hist_plot_2d(ax, data_x, data_y, xmax=numpy.inf)
+    hist_plot_2d(ax, data_x, data_y, ymin=-numpy.inf)
+    hist_plot_2d(ax, data_x, data_y, ymax=numpy.inf)
     assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
 
     data_x, data_y = numpy.random.uniform(-10, 10, (2, 1000000))


### PR DESCRIPTION
# Description

Recently I've been using the 2d-histogram plotting, and found a couple of bugs:

- When plotting with samples drawn from a wide range but with low weight (i.e. a typical nested sampling run), the axes resized in a way that was annoying, and iconsistent with the way that ``plot_hist_1d works``. This PR fixes this, and supplies a test that fails with the old code, but passes with the update
- There is a 'non-zero edge' correction in `iso_probability_contours` that apparently doesn't do anything except break in certain difficult to define cases. Removing it makes it more consistent with the behaviour of `iso_probability_contours_from_samples` and does not break. Will reinstate this code if it does become clear that it was serving a specific purpose.

Fixes # (issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works