### PR TITLE
automatic minmax limits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley
-:Version: 1.2.5
+:Version: 1.2.6
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -97,9 +97,9 @@ class MCMCSamples(WeightedDataFrame):
                 self['weight'] = self.weight
                 self.tex['weight'] = r'MCMC weight'
 
-            self.set_automatic_limits()
+            self._set_automatic_limits()
 
-    def set_automatic_limits(self):
+    def _set_automatic_limits(self):
         """Set all unassigned limits to min and max of sample."""
         for param in self.columns:
             if param not in self.limits:
@@ -437,7 +437,7 @@ class NestedSamples(MCMCSamples):
             if logL_birth is not None:
                 self._compute_nlive(logL_birth)
 
-            self.set_automatic_limits()
+            self._set_automatic_limits()
 
     @property
     def beta(self):

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -89,10 +89,6 @@ class MCMCSamples(WeightedDataFrame):
             self.root = None
             super(MCMCSamples, self).__init__(*args, **kwargs)
 
-            for param in self.columns:
-                if param not in self.limits:
-                    self.limits[param] = (self[param].min(), self[param].max())
-
             if logL is not None:
                 self['logL'] = logL
                 self.tex['logL'] = r'$\log\mathcal{L}$'
@@ -100,6 +96,10 @@ class MCMCSamples(WeightedDataFrame):
             if self._weight is not None:
                 self['weight'] = self.weight
                 self.tex['weight'] = r'MCMC weight'
+
+            for param in self.columns:
+                if param not in self.limits:
+                    self.limits[param] = (self[param].min(), self[param].max())
 
     def plot(self, ax, paramname_x, paramname_y=None, *args, **kwargs):
         """Interface for 2D and 1D plotting routines.
@@ -432,6 +432,10 @@ class NestedSamples(MCMCSamples):
                                                 *args, **kwargs)
             if logL_birth is not None:
                 self._compute_nlive(logL_birth)
+
+            for param in self.columns:
+                if param not in self.limits:
+                    self.limits[param] = (self[param].min(), self[param].max())
 
     @property
     def beta(self):

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -89,6 +89,12 @@ class MCMCSamples(WeightedDataFrame):
             self.root = None
             super(MCMCSamples, self).__init__(*args, **kwargs)
 
+            for param in self.columns:
+                if param not in self.limits:
+                    print(param)
+                    print(self[param])
+                    self.limits[param] = (self[param].min(), self[param].max())
+
             if logL is not None:
                 self['logL'] = logL
                 self.tex['logL'] = r'$\log\mathcal{L}$'

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -91,8 +91,6 @@ class MCMCSamples(WeightedDataFrame):
 
             for param in self.columns:
                 if param not in self.limits:
-                    print(param)
-                    print(self[param])
                     self.limits[param] = (self[param].min(), self[param].max())
 
             if logL is not None:

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -97,9 +97,13 @@ class MCMCSamples(WeightedDataFrame):
                 self['weight'] = self.weight
                 self.tex['weight'] = r'MCMC weight'
 
-            for param in self.columns:
-                if param not in self.limits:
-                    self.limits[param] = (self[param].min(), self[param].max())
+            self.set_automatic_limits()
+
+    def set_automatic_limits(self):
+        """Set all unassigned limits to min and max of sample."""
+        for param in self.columns:
+            if param not in self.limits:
+                self.limits[param] = (self[param].min(), self[param].max())
 
     def plot(self, ax, paramname_x, paramname_y=None, *args, **kwargs):
         """Interface for 2D and 1D plotting routines.
@@ -433,9 +437,7 @@ class NestedSamples(MCMCSamples):
             if logL_birth is not None:
                 self._compute_nlive(logL_birth)
 
-            for param in self.columns:
-                if param not in self.limits:
-                    self.limits[param] = (self[param].min(), self[param].max())
+            self.set_automatic_limits()
 
     @property
     def beta(self):

--- a/tests/example_data/pc.ranges
+++ b/tests/example_data/pc.ranges
@@ -1,4 +1,3 @@
 x0	None	None
-x1	None	None
 x2	0	None
 x3	0	1

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -523,3 +523,20 @@ def test_live_points():
     logL = pc.logL_birth.max()
     assert (last_live_points.logL > logL).all()
     assert len(last_live_points) == pc.nlive.mode()[0]
+
+
+def test_limit_assignment():
+    numpy.random.seed(3)
+    ns = NestedSamples(root='./tests/example_data/pc')
+    # `None` in .ranges file:
+    assert ns.limits['x0'][0] is None
+    assert ns.limits['x0'][1] is None
+    # parameter not listed in .ranges file:
+    assert ns.limits['x1'][0] == ns.x1.min()
+    assert ns.limits['x1'][1] == ns.x1.max()
+    # `None` for only one limit in .ranges file:
+    assert ns.limits['x2'][0] == 0
+    assert ns.limits['x2'][1] is None
+    # both limits specified in .ranges file:
+    assert ns.limits['x3'][0] == 0
+    assert ns.limits['x3'][1] == 1

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -540,3 +540,10 @@ def test_limit_assignment():
     # both limits specified in .ranges file:
     assert ns.limits['x3'][0] == 0
     assert ns.limits['x3'][1] == 1
+    # limits for logL, weight, nlive
+    assert ns.limits['logL'][0] == -777.0115456428716
+    assert ns.limits['logL'][1] == 5.748335384373301
+    assert ns.limits['weight'][0] == 0
+    assert ns.limits['weight'][1] == 1
+    assert ns.limits['nlive'][0] == 0
+    assert ns.limits['nlive'][1] == 125


### PR DESCRIPTION
Automatically set all limits not specified by a `.ranges` file to their respective minimum and maximum values in the sample.

Fixes #36 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
