### PR TITLE
-infinity handling in set_beta

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -447,7 +447,8 @@ class NestedSamples(MCMCSamples):
     @beta.setter
     def beta(self, beta):
         self._beta = beta
-        logw = self.dlogX() + self.beta*self.logL
+        logw = self.dlogX() + numpy.where(self.logL == -numpy.inf,
+                                          -numpy.inf, self.beta * self.logL)
         self._weight = numpy.exp(logw - logw.max())
 
         if self._weight is not None:

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -508,6 +508,16 @@ def test_beta():
         assert not numpy.array_equal(pc['weight'], weight)
 
 
+def test_beta_with_logL_infinities():
+    ns = NestedSamples(root="./tests/example_data/pc")
+    for i in range(10):
+        ns['logL'][i] = -numpy.inf
+    prior = ns.set_beta(0)
+    assert numpy.all(prior.logL[:10] == -numpy.inf)
+    assert numpy.all(prior.weight[:10] == 0)
+    ns.plot_1d(['x0', 'x1'])
+
+
 def test_live_points():
     numpy.random.seed(4)
     pc = NestedSamples(root="./tests/example_data/pc")


### PR DESCRIPTION
Implements minimal change suggested in #84 .

Fixes #84 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
