### PR TITLE
Convert numpy to np

### DIFF
--- a/anesthetic/boundary.py
+++ b/anesthetic/boundary.py
@@ -1,6 +1,6 @@
 """Boundary correction utilities."""
 
-import numpy
+import numpy as np
 from scipy.special import erf
 
 
@@ -9,10 +9,10 @@ def cut_and_normalise_gaussian(x, p, sigma, xmin=None, xmax=None):
 
     Parameters
     ----------
-    x: numpy.array
+    x: np.array
         locations for normalisation correction
 
-    p: numpy.array
+    p: np.array
         probability densities for normalisation correction
 
     sigma: float
@@ -24,16 +24,16 @@ def cut_and_normalise_gaussian(x, p, sigma, xmin=None, xmax=None):
 
     Returns
     -------
-    p: numpy.array
+    p: np.array
         corrected probabilities
 
     """
-    correction = numpy.ones_like(x)
+    correction = np.ones_like(x)
 
     if xmin is not None:
-        correction *= 0.5*(1 + erf((x - xmin)/sigma/numpy.sqrt(2)))
-        correction[x < xmin] = numpy.inf
+        correction *= 0.5*(1 + erf((x - xmin)/sigma/np.sqrt(2)))
+        correction[x < xmin] = np.inf
     if xmax is not None:
-        correction *= 0.5*(1 + erf((xmax - x)/sigma/numpy.sqrt(2)))
-        correction[x > xmax] = numpy.inf
+        correction *= 0.5*(1 + erf((xmax - x)/sigma/np.sqrt(2)))
+        correction[x > xmax] = np.inf
     return p/correction

--- a/anesthetic/gui/plot.py
+++ b/anesthetic/gui/plot.py
@@ -1,5 +1,5 @@
 """Main plotting tools."""
-import numpy
+import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import (GridSpec as GS,
                                  GridSpecFromSubplotSpec as sGS)
@@ -53,7 +53,7 @@ class Higson(Widget):
     def reset_range(self):
         """Reset the ranges of the higson plot."""
         xdata = self.curve.get_xdata()
-        xdata = xdata[numpy.isfinite(xdata)]
+        xdata = xdata[np.isfinite(xdata)]
         self.ax.set_xlim(xdata.max(), xdata.min())
 
 
@@ -159,9 +159,9 @@ class RunPlotter(object):
         self.samples = samples
 
         if params:
-            self.params = numpy.array(params)
+            self.params = np.array(params)
         else:
-            self.params = numpy.array(self.samples.columns[:10])
+            self.params = np.array(self.samples.columns[:10])
 
         self.fig = plt.figure()
         self._set_up()
@@ -245,12 +245,11 @@ class RunPlotter(object):
 
     def update(self, _):
         """Update all the plots upon slider changes."""
-        with numpy.errstate(divide='ignore'):
-            logX = numpy.log(self.samples.nlive /
-                             (self.samples.nlive+1)).cumsum()
+        with np.errstate(divide='ignore'):
+            logX = np.log(self.samples.nlive / (self.samples.nlive+1)).cumsum()
         kT = self.temperature()
         LX = self.samples.logL/kT + logX
-        LX = numpy.exp(LX-LX.max())
+        LX = np.exp(LX-LX.max())
         i = self.evolution()
         logL = self.samples.logL.iloc[i]
         try:

--- a/anesthetic/kde.py
+++ b/anesthetic/kde.py
@@ -16,7 +16,7 @@ def fastkde_1d(d, xmin=None, xmax=None):
 
     Parameters
     ----------
-    d: numpy.array
+    d: np.array
         Data to perform kde on
 
     xmin, xmax: float
@@ -25,9 +25,9 @@ def fastkde_1d(d, xmin=None, xmax=None):
 
     Returns
     -------
-    x: numpy.array
+    x: np.array
         x-coordinates of kernel density estimates
-    p: numpy.array
+    p: np.array
         kernel density estimates
 
     """
@@ -59,7 +59,7 @@ def fastkde_2d(d_x, d_y, xmin=None, xmax=None, ymin=None, ymax=None):
 
     Parameters
     ----------
-    d_x, d_y: numpy.array
+    d_x, d_y: np.array
         x/y coordinates of data to perform kde on
 
     xmin, xmax, ymin, ymax: float
@@ -68,9 +68,9 @@ def fastkde_2d(d_x, d_y, xmin=None, xmax=None, ymin=None, ymax=None):
 
     Returns
     -------
-    x,y: numpy.array
+    x,y: np.array
         x/y-coordinates of kernel density estimates. One-dimensional array
-    p: numpy.array
+    p: np.array
         kernel density estimates. Two-dimensional array
 
     """

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -11,7 +11,7 @@ to create a set of axes and legend proxies.
 
 """
 import sys
-import numpy
+import numpy as np
 import pandas
 import matplotlib.pyplot as plt
 from scipy.stats import gaussian_kde
@@ -69,12 +69,12 @@ def make_1d_axes(params, **kwargs):
         Pandas array of axes objects
 
     """
-    axes = pandas.Series(index=numpy.atleast_1d(params), dtype=object)
+    axes = pandas.Series(index=np.atleast_1d(params), dtype=object)
     axes[:] = None
     tex = kwargs.pop('tex', {})
     fig = kwargs.pop('fig') if 'fig' in kwargs else plt.figure()
-    ncols = kwargs.pop('ncols', int(numpy.ceil(numpy.sqrt(len(axes)))))
-    nrows = int(numpy.ceil(len(axes)/float(ncols)))
+    ncols = kwargs.pop('ncols', int(np.ceil(np.sqrt(len(axes)))))
+    nrows = int(np.ceil(len(axes)/float(ncols)))
     if 'subplot_spec' in kwargs:
         grid = SGS(nrows, ncols, wspace=0,
                    subplot_spec=kwargs.pop('subplot_spec'))
@@ -143,8 +143,8 @@ def make_2d_axes(params, **kwargs):
     lower = kwargs.pop('lower', True)
     diagonal = kwargs.pop('diagonal', True)
 
-    axes = pandas.DataFrame(index=numpy.atleast_1d(yparams),
-                            columns=numpy.atleast_1d(xparams),
+    axes = pandas.DataFrame(index=np.atleast_1d(yparams),
+                            columns=np.atleast_1d(xparams),
                             dtype=object)
     axes[:][:] = None
     all_params = list(axes.columns) + list(axes.index)
@@ -244,7 +244,7 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
     ax: matplotlib.axes.Axes
         axis object to plot on
 
-    data: numpy.array
+    data: np.array
         Uniformly weighted samples to generate kernel density estimator.
 
     xmin, xmax: float
@@ -259,7 +259,7 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
 
     """
     if len(data) == 0:
-        return numpy.zeros(0), numpy.zeros(0)
+        return np.zeros(0), np.zeros(0)
 
     if data.max()-data.min() <= 0:
         return
@@ -291,10 +291,10 @@ def kde_plot_1d(ax, data, *args, **kwargs):
     ax: matplotlib.axes.Axes
         axis object to plot on.
 
-    data: numpy.array
+    data: np.array
         Samples to generate kernel density estimator.
 
-    weights: numpy.array, optional
+    weights: np.array, optional
         Sample weights.
 
     ncompress: int, optional
@@ -312,7 +312,7 @@ def kde_plot_1d(ax, data, *args, **kwargs):
 
     """
     if len(data) == 0:
-        return numpy.zeros(0), numpy.zeros(0)
+        return np.zeros(0), np.zeros(0)
 
     if data.max()-data.min() <= 0:
         return
@@ -330,7 +330,7 @@ def kde_plot_1d(ax, data, *args, **kwargs):
         i = i & (x > xmin)
     if xmax is not None:
         i = i & (x < xmax)
-    sigma = numpy.sqrt(kde.covariance[0, 0])
+    sigma = np.sqrt(kde.covariance[0, 0])
     pp = cut_and_normalise_gaussian(x[i], p[i], sigma, xmin, xmax)
     pp /= pp.max()
     ans = ax.plot(x[i], pp, *args, **kwargs)
@@ -349,10 +349,10 @@ def hist_plot_1d(ax, data, *args, **kwargs):
     ax: matplotlib.axes.Axes
         axis object to plot on
 
-    data: numpy.array
+    data: np.array
         Samples to generate histogram from
 
-    weights: numpy.array, optional
+    weights: np.array, optional
         Sample weights.
 
     xmin, xmax: float
@@ -378,9 +378,9 @@ def hist_plot_1d(ax, data, *args, **kwargs):
     xmax = kwargs.pop('xmax', None)
     plotter = kwargs.pop('plotter', '')
     weights = kwargs.pop('weights', None)
-    if xmin is None or not numpy.isfinite(xmin):
+    if xmin is None or not np.isfinite(xmin):
         xmin = quantile(data, 0.01, weights)
-    if xmax is None or not numpy.isfinite(xmax):
+    if xmax is None or not np.isfinite(xmax):
         xmax = quantile(data, 0.99, weights)
     histtype = kwargs.pop('histtype', 'bar')
 
@@ -419,7 +419,7 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ax: matplotlib.axes.Axes
         axis object to plot on
 
-    data_x, data_y: numpy.array
+    data_x, data_y: np.array
         x and y coordinates of uniformly weighted samples to generate kernel
         density estimator.
 
@@ -448,7 +448,7 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
 
     if len(data_x) == 0 or len(data_y) == 0:
-        return numpy.zeros(0), numpy.zeros(0), numpy.zeros((0, 0))
+        return np.zeros(0), np.zeros(0), np.zeros((0, 0))
 
     try:
         x, y, pdf = fastkde_2d(data_x, data_y,
@@ -462,12 +462,12 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     i = (pdf >= levels[0]*0.5).any(axis=0)
     j = (pdf >= levels[0]*0.5).any(axis=1)
 
-    cbar = ax.contourf(x[i], y[j], pdf[numpy.ix_(j, i)], levels, cmap=cmap,
+    cbar = ax.contourf(x[i], y[j], pdf[np.ix_(j, i)], levels, cmap=cmap,
                        zorder=zorder, vmin=0, vmax=pdf.max(), *args, **kwargs)
     for c in cbar.collections:
         c.set_cmap(cmap)
 
-    ax.contour(x[i], y[j], pdf[numpy.ix_(j, i)], levels, zorder=zorder,
+    ax.contour(x[i], y[j], pdf[np.ix_(j, i)], levels, zorder=zorder,
                vmin=0, vmax=pdf.max(), linewidths=linewidths, colors='k',
                *args, **kwargs)
     ax.patches += [plt.Rectangle((0, 0), 1, 1, fc=cmap(0.999), ec=cmap(0.32),
@@ -491,11 +491,11 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ax: matplotlib.axes.Axes
         axis object to plot on.
 
-    data_x, data_y: numpy.array
+    data_x, data_y: np.array
         x and y coordinates of uniformly weighted samples to generate kernel
         density estimator.
 
-    weights: numpy.array, optional
+    weights: np.array, optional
         Sample weights.
 
     ncompress: int, optional
@@ -524,24 +524,24 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
 
     if len(data_x) == 0 or len(data_y) == 0:
-        return numpy.zeros(0), numpy.zeros(0), numpy.zeros((0, 0))
+        return np.zeros(0), np.zeros(0), np.zeros((0, 0))
 
-    cov = numpy.cov(data_x, data_y, aweights=weights)
+    cov = np.cov(data_x, data_y, aweights=weights)
     tri, w = triangular_sample_compression_2d(data_x, data_y, cov,
                                               weights, ncompress)
     kde = gaussian_kde([tri.x, tri.y], weights=w)
 
     x, y = kde.resample(ncompress)
-    x = numpy.concatenate([tri.x, x])
-    y = numpy.concatenate([tri.y, y])
-    w = numpy.concatenate([w, numpy.zeros(ncompress)])
+    x = np.concatenate([tri.x, x])
+    y = np.concatenate([tri.y, y])
+    w = np.concatenate([w, np.zeros(ncompress)])
     tri = scaled_triangulation(x, y, cov)
 
     p = kde([tri.x, tri.y])
 
-    sigmax = numpy.sqrt(kde.covariance[0, 0])
+    sigmax = np.sqrt(kde.covariance[0, 0])
     p = cut_and_normalise_gaussian(tri.x, p, sigmax, xmin, xmax)
-    sigmay = numpy.sqrt(kde.covariance[1, 1])
+    sigmay = np.sqrt(kde.covariance[1, 1])
     p = cut_and_normalise_gaussian(tri.y, p, sigmay, ymin, ymax)
 
     contours = iso_probability_contours_from_samples(p, weights=w)
@@ -574,7 +574,7 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ax: matplotlib.axes.Axes
         axis object to plot on
 
-    data_x, data_y: numpy.array
+    data_x, data_y: np.array
         x and y coordinates of uniformly weighted samples to generate kernel
         density estimator.
 
@@ -602,19 +602,19 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
     weights = kwargs.pop('weights', None)
 
-    if xmin is None or not numpy.isfinite(xmin):
+    if xmin is None or not np.isfinite(xmin):
         xmin = quantile(data_x, 0.01, weights)
-    if xmax is None or not numpy.isfinite(xmax):
+    if xmax is None or not np.isfinite(xmax):
         xmax = quantile(data_x, 0.99, weights)
-    if ymin is None or not numpy.isfinite(ymin):
+    if ymin is None or not np.isfinite(ymin):
         ymin = quantile(data_y, 0.01, weights)
-    if ymax is None or not numpy.isfinite(ymax):
+    if ymax is None or not np.isfinite(ymax):
         ymax = quantile(data_y, 0.99, weights)
 
     range = kwargs.pop('range', ((xmin, xmax), (ymin, ymax)))
 
     if len(data_x) == 0 or len(data_y) == 0:
-        return numpy.zeros(0), numpy.zeros(0), numpy.zeros((0, 0))
+        return np.zeros(0), np.zeros(0), np.zeros((0, 0))
 
     cmap = basic_cmap(color)
 
@@ -627,16 +627,16 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
         density = kwargs.pop('density', False)
         cmin = kwargs.pop('cmin', None)
         cmax = kwargs.pop('cmax', None)
-        pdf, x, y = numpy.histogram2d(data_x, data_y, bins, range,
-                                      density, weights)
+        pdf, x, y = np.histogram2d(data_x, data_y, bins, range,
+                                   density, weights)
         levels = iso_probability_contours(pdf, levels)
-        pdf = numpy.digitize(pdf, levels, right=True)
-        pdf = numpy.array(levels)[pdf]
-        pdf = numpy.ma.masked_array(pdf, pdf < levels[1])
+        pdf = np.digitize(pdf, levels, right=True)
+        pdf = np.array(levels)[pdf]
+        pdf = np.ma.masked_array(pdf, pdf < levels[1])
         if cmin is not None:
-            pdf[pdf < cmin] = numpy.ma.masked
+            pdf[pdf < cmin] = np.ma.masked
         if cmax is not None:
-            pdf[pdf > cmax] = numpy.ma.masked
+            pdf[pdf > cmax] = np.ma.masked
         image = ax.pcolormesh(x, y, pdf.T, cmap=cmap, vmin=0, vmax=pdf.max(),
                               *args, **kwargs)
 
@@ -659,7 +659,7 @@ def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ax: matplotlib.axes.Axes
         axis object to plot on
 
-    data_x, data_y: numpy.array
+    data_x, data_y: np.array
         x and y coordinates of uniformly weighted samples to plot.
 
     xmin, xmax, ymin, ymax: float
@@ -725,7 +725,7 @@ def get_legend_proxy(fig):
                   for ax in fig.axes
                   for coll in ax.collections
                   if isinstance(coll, LineCollection)]
-        colors = numpy.unique(colors, axis=0)
+        colors = np.unique(colors, axis=0)
         cmaps = [basic_cmap(color) for color in colors]
         proxy = [plt.Rectangle((0, 0), 1, 1, facecolor=cmap(0.0),
                                edgecolor=cmap(0.999), linewidth=1)

--- a/anesthetic/read/getdistreader.py
+++ b/anesthetic/read/getdistreader.py
@@ -1,5 +1,5 @@
 """Tools for reading from getdist chains files."""
-import numpy
+import numpy as np
 import glob
 from anesthetic.read.chainreader import ChainReader
 
@@ -59,9 +59,9 @@ class GetDistReader(ChainReader):
 
     def samples(self):
         """Read <root>_1.txt in getdist format."""
-        data = numpy.concatenate([numpy.loadtxt(chains_file)
-                                  for chains_file in self.chains_files])
-        weights, chi2, samples = numpy.split(data, [1, 2], axis=1)
+        data = np.concatenate([np.loadtxt(chains_file)
+                               for chains_file in self.chains_files])
+        weights, chi2, samples = np.split(data, [1, 2], axis=1)
         logL = chi2/-2.
         return weights.flatten(), logL.flatten(), samples
 

--- a/anesthetic/read/montepythonreader.py
+++ b/anesthetic/read/montepythonreader.py
@@ -3,7 +3,7 @@ import sys
 import os
 import glob
 import warnings
-import numpy
+import numpy as np
 from anesthetic.read.chainreader import ChainReader
 try:
     with warnings.catch_warnings():
@@ -77,17 +77,17 @@ class MontePythonReader(ChainReader):
         analyze.extract_parameter_names(info=self.info)
         analyze.find_maximum_of_likelihood(info=self.info)
         data_per_chain = analyze.remove_bad_points(info=self.info)
-        self.data = numpy.concatenate(data_per_chain, axis=0)
+        self.data = np.concatenate(data_per_chain, axis=0)
 
     def paramnames(self):
         """Return parameter labels and corresponding tex signs.
 
         Returns
         -------
-        params: numpy.ndarray
+        params: np.ndarray
             reference name for the sample, used as labels in the pandas array
 
-        tex: numpy.ndarray
+        tex: np.ndarray
             axis labels, possibly in tex, with the understanding that it will
             be surrounded by dollar signs
 
@@ -105,13 +105,13 @@ class MontePythonReader(ChainReader):
 
         Returns
         -------
-        weights: numpy.ndarray
+        weights: np.ndarray
             weights of each step in the sample
 
-        logL: numpy.ndarray
+        logL: np.ndarray
             loglikelihood of each step in the sample
 
-        samples: numpy.ndarray
+        samples: np.ndarray
             MontePython MCMC samples
 
         """

--- a/anesthetic/read/multinestreader.py
+++ b/anesthetic/read/multinestreader.py
@@ -1,5 +1,5 @@
 """Tools for reading from multinest chains files."""
-import numpy
+import numpy as np
 from anesthetic.read.getdistreader import GetDistReader
 
 
@@ -9,35 +9,34 @@ class MultiNestReader(GetDistReader):
     def samples(self):
         """Read <root>ev.dat and <root>phys_live.points in multinest format."""
         try:
-            data = numpy.loadtxt(self.birth_file)
-            samples, logL, logL_birth, _ = numpy.split(data, [-4, -3, -2],
-                                                       axis=1)
-            logL = numpy.squeeze(logL)
-            logL_birth = numpy.squeeze(logL_birth)
+            data = np.loadtxt(self.birth_file)
+            samples, logL, logL_birth, _ = np.split(data, [-4, -3, -2], axis=1)
+            logL = np.squeeze(logL)
+            logL_birth = np.squeeze(logL_birth)
 
-            data = numpy.loadtxt(self.phys_live_birth_file)
+            data = np.loadtxt(self.phys_live_birth_file)
             (live_samples, live_logL,
-             live_logL_birth, _) = numpy.split(data, [-3, -2, -1], axis=1)
-            live_logL = numpy.squeeze(live_logL)
-            live_logL_birth = numpy.squeeze(live_logL_birth)
-            i = numpy.argsort(live_logL)
-            samples = numpy.concatenate((samples, live_samples[i]), axis=0)
-            logL = numpy.concatenate((logL, live_logL[i]))
-            logL_birth = numpy.concatenate((logL_birth, live_logL_birth[i]))
+             live_logL_birth, _) = np.split(data, [-3, -2, -1], axis=1)
+            live_logL = np.squeeze(live_logL)
+            live_logL_birth = np.squeeze(live_logL_birth)
+            i = np.argsort(live_logL)
+            samples = np.concatenate((samples, live_samples[i]), axis=0)
+            logL = np.concatenate((logL, live_logL[i]))
+            logL_birth = np.concatenate((logL_birth, live_logL_birth[i]))
             return samples, logL, logL_birth
 
         except IOError:
-            data = numpy.loadtxt(self.ev_file)
-            samples, logL, _ = numpy.split(data, [-3, -2], axis=1)
-            logL = numpy.squeeze(logL)
+            data = np.loadtxt(self.ev_file)
+            samples, logL, _ = np.split(data, [-3, -2], axis=1)
+            logL = np.squeeze(logL)
 
-            data = numpy.loadtxt(self.phys_live_file)
-            live_samples, live_logL, _ = numpy.split(data, [-2, -1], axis=1)
-            live_logL = numpy.squeeze(live_logL)
-            i = numpy.argsort(live_logL)
+            data = np.loadtxt(self.phys_live_file)
+            live_samples, live_logL, _ = np.split(data, [-2, -1], axis=1)
+            live_logL = np.squeeze(live_logL)
+            i = np.argsort(live_logL)
             nlive = len(live_logL)
-            samples = numpy.concatenate((samples, live_samples[i]), axis=0)
-            logL = numpy.concatenate((logL, live_logL[i]))
+            samples = np.concatenate((samples, live_samples[i]), axis=0)
+            logL = np.concatenate((logL, live_logL[i]))
             return samples, logL, nlive
 
     @property

--- a/anesthetic/read/polychordreader.py
+++ b/anesthetic/read/polychordreader.py
@@ -1,5 +1,5 @@
 """Tools for reading from polychord chains files."""
-import numpy
+import numpy as np
 from anesthetic.read.getdistreader import GetDistReader
 
 
@@ -8,16 +8,16 @@ class PolyChordReader(GetDistReader):
 
     def samples(self):
         """Read ``<root>_dead-birth.txt`` in polychord format."""
-        data = numpy.loadtxt(self.birth_file)
+        data = np.loadtxt(self.birth_file)
         try:
-            _data = numpy.loadtxt(self.phys_live_birth_file)
-            data = numpy.concatenate([data, _data])
-            data = numpy.unique(data, axis=0)
-            i = numpy.argsort(data[:, -2])
+            _data = np.loadtxt(self.phys_live_birth_file)
+            data = np.concatenate([data, _data])
+            data = np.unique(data, axis=0)
+            i = np.argsort(data[:, -2])
             data = data[i, :]
         except (OSError, IOError):
             pass
-        samples, logL, logL_birth = numpy.split(data, [-2, -1], axis=1)
+        samples, logL, logL_birth = np.split(data, [-2, -1], axis=1)
         return samples, logL.flatten(), logL_birth.flatten()
 
     @property

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -1,6 +1,6 @@
 """Pandas DataFrame and Series with weighted samples."""
 
-import numpy
+import numpy as np
 import pandas
 from anesthetic.utils import compress_weights, channel_capacity, quantile
 
@@ -24,12 +24,12 @@ class _WeightedObject(object):
             self._weight = pandas.Series(index=self.index, data=w)
         else:
             self._weight = None
-        rand = numpy.random.rand(len(self))
+        rand = np.random.rand(len(self))
         self._rand_ = pandas.Series(index=self.index, data=rand)
 
     def std(self):
         """Weighted standard deviation of the sampled distribution."""
-        return numpy.sqrt(self.var())
+        return np.sqrt(self.var())
 
     def median(self):
         """Weighted median of the sampled distribution."""
@@ -50,11 +50,11 @@ class WeightedSeries(_WeightedObject, pandas.Series):
 
     def mean(self):
         """Weighted mean of the sampled distribution."""
-        return numpy.average(self, weights=self.weight)
+        return np.average(self, weights=self.weight)
 
     def var(self):
         """Weighted variance of the sampled distribution."""
-        return numpy.average((self-self.mean())**2, weights=self.weight)
+        return np.average((self-self.mean())**2, weights=self.weight)
 
     def quantile(self, q=0.5):
         """Weighted quantile of the sampled distribution."""
@@ -104,24 +104,24 @@ class WeightedDataFrame(_WeightedObject, pandas.DataFrame):
 
     def mean(self):
         """Weighted mean of the sampled distribution."""
-        return pandas.Series(numpy.average(self, weights=self.weight, axis=0),
+        return pandas.Series(np.average(self, weights=self.weight, axis=0),
                              index=self.columns)
 
     def var(self):
         """Weighted variance of the sampled distribution."""
-        return pandas.Series(numpy.average((self-self.mean())**2,
-                                           weights=self.weight, axis=0),
+        return pandas.Series(np.average((self-self.mean())**2,
+                                        weights=self.weight, axis=0),
                              index=self.columns)
 
     def cov(self):
         """Weighted covariance of the sampled distribution."""
-        return pandas.DataFrame(numpy.cov(self.T, aweights=self.weight),
+        return pandas.DataFrame(np.cov(self.T, aweights=self.weight),
                                 index=self.columns, columns=self.columns)
 
     def quantile(self, q=0.5):
         """Weighted quantile of the sampled distribution."""
-        data = numpy.array([c.quantile(q) for _, c in self.iteritems()])
-        if numpy.isscalar(q):
+        data = np.array([c.quantile(q) for _, c in self.iteritems()])
+        if np.isscalar(q):
             return pandas.Series(data, index=self.columns)
         else:
             return pandas.DataFrame(data.T, columns=self.columns, index=q)
@@ -143,8 +143,8 @@ class WeightedDataFrame(_WeightedObject, pandas.DataFrame):
 
         """
         i = compress_weights(self.weight, self._rand, nsamples)
-        data = numpy.repeat(self.values, i, axis=0)
-        index = numpy.repeat(self.index.values, i)
+        data = np.repeat(self.values, i, axis=0)
+        index = np.repeat(self.index.values, i)
         df = pandas.DataFrame(data=data, index=index, columns=self.columns)
         if 'weight' in self:
             return df.drop(columns='weight')

--- a/bin/plot.py
+++ b/bin/plot.py
@@ -1,5 +1,5 @@
 from anesthetic import NestedSamples
-import numpy
+import numpy as np
 ns = NestedSamples(root='./tests/example_data/pc')
 fig, axes = ns.plot_2d(['x0', 'x1', 'x2', 'x3', 'x4'])
 
@@ -11,30 +11,30 @@ a, b, m = 2., 4., 0.5         # x4 parameters
 n = 1000
 ls = 'k--'
 
-x = numpy.linspace(-0.4,0.4,n)
-p = numpy.exp(-x**2/sigma0**2/2)/numpy.sqrt(2*numpy.pi)/sigma0
+x = np.linspace(-0.4,0.4,n)
+p = np.exp(-x**2/sigma0**2/2)/np.sqrt(2*np.pi)/sigma0
 axes['x0']['x0'].twin.plot(x, p/p.max(), ls)
 
-x = numpy.linspace(-0.4,0.4,n)
-p = numpy.exp(-x**2/sigma1**2/2)/numpy.sqrt(2*numpy.pi)/sigma1
+x = np.linspace(-0.4,0.4,n)
+p = np.exp(-x**2/sigma1**2/2)/np.sqrt(2*np.pi)/sigma1
 axes['x1']['x1'].twin.plot(x, p/p.max(), ls)
 
-x = numpy.linspace(-0.1,0.6,n)
-p = numpy.exp(-x/sigma2)/sigma2 * (x>0)
+x = np.linspace(-0.1,0.6,n)
+p = np.exp(-x/sigma2)/sigma2 * (x>0)
 axes['x2']['x2'].twin.plot(x, p/p.max(), ls)
 
-x = numpy.linspace(-0.1,1.1,n)
+x = np.linspace(-0.1,1.1,n)
 p = (x<1) & (x>0)
 axes['x3']['x3'].twin.plot(x, p/p.max(), ls)
 
-x = numpy.linspace(a-0.1,b+0.1,n)
+x = np.linspace(a-0.1,b+0.1,n)
 p = ((x<b) & (x>a)) * (1/(b-a) + m * (x-(b+a)/2.))
 axes['x4']['x4'].twin.plot(x, p/p.max(), ls)
 
 
 
-x3 = numpy.linspace(0,1,n)
-x0 = numpy.ones_like(x3) * sigma0
+x3 = np.linspace(0,1,n)
+x0 = np.ones_like(x3) * sigma0
 axes['x0']['x3'].plot(2*x0, x3, ls)
 axes['x0']['x3'].plot(x0, x3, ls)
 axes['x0']['x3'].plot(-x0, x3, ls)
@@ -46,62 +46,62 @@ axes['x1']['x3'].plot(-x0, x3, ls)
 axes['x1']['x3'].plot(-2*x0, x3, ls)
 
 for p in [0.66, 0.95]:
-    axes['x2']['x3'].plot(-numpy.log(1-p)*x0, x3, ls)
+    axes['x2']['x3'].plot(-np.log(1-p)*x0, x3, ls)
 
 from scipy.optimize import root
 from scipy.special import erf
 
 for p in [0.66, 0.95]:
-    k = root(lambda k: -2*numpy.exp(-k)*numpy.sqrt(k/numpy.pi) + erf(numpy.sqrt(k)) - p, 1).x[0]
-    x = numpy.linspace(-numpy.sqrt(2*k), numpy.sqrt(2*k), n)
+    k = root(lambda k: -2*np.exp(-k)*np.sqrt(k/np.pi) + erf(np.sqrt(k)) - p, 1).x[0]
+    x = np.linspace(-np.sqrt(2*k), np.sqrt(2*k), n)
     y = k - x**2/2
     axes['x0']['x2'].plot(x*sigma0, y*sigma2, ls)
     axes['x1']['x2'].plot(x*sigma1, y*sigma2, ls)
 
-t = numpy.linspace(0, 2*numpy.pi, n)
-x0 = sigma1*eps*numpy.cos(t) + sigma0 * numpy.sin(t)
-x1 = numpy.sqrt(1-eps**2) * sigma1 * numpy.cos(t)
+t = np.linspace(0, 2*np.pi, n)
+x0 = sigma1*eps*np.cos(t) + sigma0 * np.sin(t)
+x1 = np.sqrt(1-eps**2) * sigma1 * np.cos(t)
 
 
-x0 = sigma0 * numpy.sin(t)
-x1 = sigma1 * (numpy.sqrt(1-eps**2) * numpy.cos(t)  + eps*numpy.sin(t))
+x0 = sigma0 * np.sin(t)
+x1 = sigma1 * (np.sqrt(1-eps**2) * np.cos(t)  + eps*np.sin(t))
 for p in [0.66, 0.95]:
-    r = numpy.sqrt(-2*numpy.log(1-p))
+    r = np.sqrt(-2*np.log(1-p))
     axes['x0']['x1'].plot(r*x1, r*x0, ls)
 
-x3 = numpy.linspace(0,1,n)
+x3 = np.linspace(0,1,n)
 for p in [0.66, 0.95]:
     x4 = 1/(a-b)/m + (a+b)/2 + (((m*(a-b)**2+2)/(a-b))**2 - 8*m*p)**0.5/2/m
-    x4 = x4 * numpy.ones_like(x3)
+    x4 = x4 * np.ones_like(x3)
     axes['x3']['x4'].plot(x3, x4, ls)
 
-axes['x3']['x4'].plot(x3, numpy.ones_like(x3)*b, ls)
+axes['x3']['x4'].plot(x3, np.ones_like(x3)*b, ls)
 
-axes['x3']['x4'].plot(x3[0] * numpy.ones(n), numpy.linspace(x4[0],b,n), ls)
-axes['x3']['x4'].plot(x3[-1] * numpy.ones(n), numpy.linspace(x4[0],b,n), ls)
+axes['x3']['x4'].plot(x3[0] * np.ones(n), np.linspace(x4[0],b,n), ls)
+axes['x3']['x4'].plot(x3[-1] * np.ones(n), np.linspace(x4[0],b,n), ls)
 
-x4 = numpy.linspace(a,b,n)
+x4 = np.linspace(a,b,n)
 for p in [0.66, 0.95]:
-    k = 1/(b-a) + m/2 * (b-a - numpy.sqrt(8*p/m))
-    x4 = numpy.linspace((a+b)/2+(k/m + 1/(a-b)/m), b,n)
-    x2 = sigma2*(-numpy.log(k) + numpy.log(1/(b-a) + m * (x4-(b+a)/2)))
+    k = 1/(b-a) + m/2 * (b-a - np.sqrt(8*p/m))
+    x4 = np.linspace((a+b)/2+(k/m + 1/(a-b)/m), b,n)
+    x2 = sigma2*(-np.log(k) + np.log(1/(b-a) + m * (x4-(b+a)/2)))
     axes['x2']['x4'].plot(x2, x4, ls)
 
-axes['x2']['x4'].plot(numpy.zeros_like(x4), x4, ls)
-axes['x2']['x4'].plot(x2, b*numpy.ones_like(x2), ls)
+axes['x2']['x4'].plot(np.zeros_like(x4), x4, ls)
+axes['x2']['x4'].plot(x2, b*np.ones_like(x2), ls)
 
 from scipy.special import erf, erfi
 from scipy.optimize import root
 
 for p in [0.66, 0.95]:
-    k = root(lambda k: (1/(b-a)**2*(2+(b-a)**2*m)**2*erf(numpy.sqrt(numpy.log((2+(b-a)**2*m)/2/(b-a)/k))) - 4*k**2*erfi(numpy.sqrt(numpy.log((2+(b-a)**2*m)/2/(b-a)/k))))/8/m-p, 0.5).x[0]
-    x1 = numpy.sqrt(2*numpy.log((2+(a-b)**2*m)/2/(b-a)/k))
-    x1 = numpy.linspace(-x1,x1,n)
-    x4 = (a+b)/2 + numpy.exp(x1**2/2)*k/m - 1/(b-a)/m
+    k = root(lambda k: (1/(b-a)**2*(2+(b-a)**2*m)**2*erf(np.sqrt(np.log((2+(b-a)**2*m)/2/(b-a)/k))) - 4*k**2*erfi(np.sqrt(np.log((2+(b-a)**2*m)/2/(b-a)/k))))/8/m-p, 0.5).x[0]
+    x1 = np.sqrt(2*np.log((2+(a-b)**2*m)/2/(b-a)/k))
+    x1 = np.linspace(-x1,x1,n)
+    x4 = (a+b)/2 + np.exp(x1**2/2)*k/m - 1/(b-a)/m
     x1 *= sigma1
     axes['x1']['x4'].plot(x1, x4, ls)
 
     axes['x0']['x4'].plot(x1, x4, ls)
 
-axes['x1']['x4'].plot(x1, b*numpy.ones_like(x1), ls)
-axes['x0']['x4'].plot(x1, b*numpy.ones_like(x1), ls)
+axes['x1']['x4'].plot(x1, b*np.ones_like(x1), ls)
+axes['x0']['x4'].plot(x1, b*np.ones_like(x1), ls)

--- a/images/animate.py
+++ b/images/animate.py
@@ -1,20 +1,21 @@
 from matplotlib.animation import FuncAnimation
-import numpy
 from anesthetic import NestedSamples
-nested = NestedSamples.read('plikHM_TTTEEE_lowl_lowE_lensing_NS/NS_plikHM_TTTEEE_lowl_lowE_lensing')
-#nested = NestedSamples.read('./tests/example_data/ns/ns')
+root = 'plikHM_TTTEEE_lowl_lowE_lensing_NS/NS_plikHM_TTTEEE_lowl_lowE_lensing'
+nested = NestedSamples.read(root=root)
 
-plotter = nested.gui(['omegam','H0','sigma8'])
+plotter = nested.gui(['omegam', 'H0', 'sigma8'])
 plotter.param_choice.buttons.set_active(1)
 plotter.param_choice.buttons.set_active(2)
-plotter.fig.set_size_inches(5,6)
+plotter.fig.set_size_inches(5, 6)
 plotter.fig.tight_layout()
+
 
 def update(i):
     print(i)
     plotter.evolution.slider.set_val(i)
     plotter.update(None)
 
-frames = numpy.arange(plotter.evolution.slider.valmin, 50000, 2000)
+
+frames = np.arange(plotter.evolution.slider.valmin, 50000, 2000)
 anim = FuncAnimation(plotter.fig, update, frames=frames)
 anim.save('images/anim.gif', writer='imagemagick')

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,6 +1,6 @@
 import matplotlib_agg  # noqa: F401
 import pytest
-import numpy
+import numpy as np
 import sys
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gs
@@ -105,7 +105,7 @@ def test_make_2d_axes_inputs_outputs():
 
 
 def test_make_2d_axes_behaviour():
-    numpy.random.seed(0)
+    np.random.seed(0)
 
     def calc_n(axes):
         """Compute the number of upper, lower and diagonal plots."""
@@ -170,12 +170,12 @@ def test_make_2d_axes_behaviour():
 
 
 def test_2d_axes_limits():
-    numpy.random.seed(0)
+    np.random.seed(0)
     paramnames = ['A', 'B', 'C', 'D']
     fig, axes = make_2d_axes(paramnames)
     for x in paramnames:
         for y in paramnames:
-            a, b, c, d = numpy.random.rand(4)
+            a, b, c, d = np.random.rand(4)
             axes[x][y].set_xlim(a, b)
             for z in paramnames:
                 assert(axes[x][z].get_xlim() == (a, b))
@@ -189,8 +189,8 @@ def test_2d_axes_limits():
 
 def test_kde_plot_1d():
     fig, ax = plt.subplots()
-    numpy.random.seed(0)
-    data = numpy.random.randn(1000)
+    np.random.seed(0)
+    data = np.random.randn(1000)
 
     for plot_1d in [kde_plot_1d, fastkde_plot_1d]:
         try:
@@ -225,55 +225,54 @@ def test_kde_plot_1d():
 
 def test_hist_plot_1d():
     fig, ax = plt.subplots()
-    numpy.random.seed(0)
-    data = numpy.random.randn(1000)
+    np.random.seed(0)
+    data = np.random.randn(1000)
     for p in ['', 'astropyhist']:
         try:
             # Check heights for histtype 'bar'
             bars = hist_plot_1d(ax, data, histtype='bar', plotter=p)
-            assert(numpy.all([isinstance(b, Patch) for b in bars]))
+            assert(np.all([isinstance(b, Patch) for b in bars]))
             assert(max([b.get_height() for b in bars]) == 1.)
-            assert(numpy.all(numpy.array([b.get_height() for b in bars])
-                             <= 1.))
+            assert(np.all(np.array([b.get_height() for b in bars]) <= 1.))
 
             # Check heights for histtype 'step'
             polygon, = hist_plot_1d(ax, data, histtype='step', plotter=p)
             assert(isinstance(polygon, Polygon))
             trans = polygon.get_transform() - ax.transData
-            assert(numpy.isclose(trans.transform(polygon.xy)[:, -1].max(), 1.,
-                                 rtol=1e-10, atol=1e-10))
-            assert(numpy.all(trans.transform(polygon.xy)[:, -1] <= 1.))
+            assert(np.isclose(trans.transform(polygon.xy)[:, -1].max(), 1.,
+                              rtol=1e-10, atol=1e-10))
+            assert(np.all(trans.transform(polygon.xy)[:, -1] <= 1.))
 
             # Check heights for histtype 'stepfilled'
             polygon, = hist_plot_1d(ax, data, histtype='stepfilled', plotter=p)
             assert(isinstance(polygon, Polygon))
             trans = polygon.get_transform() - ax.transData
-            assert(numpy.isclose(trans.transform(polygon.xy)[:, -1].max(), 1.,
-                                 rtol=1e-10, atol=1e-10))
-            assert(numpy.all(trans.transform(polygon.xy)[:, -1] <= 1.))
+            assert(np.isclose(trans.transform(polygon.xy)[:, -1].max(), 1.,
+                              rtol=1e-10, atol=1e-10))
+            assert(np.all(trans.transform(polygon.xy)[:, -1] <= 1.))
 
             # Check arguments are passed onward to underlying function
             bars = hist_plot_1d(ax, data, histtype='bar',
                                 color='r', alpha=0.5, plotter=p)
             cc = ColorConverter.to_rgba('r', alpha=0.5)
-            assert(numpy.all([b.get_fc() == cc for b in bars]))
+            assert(np.all([b.get_fc() == cc for b in bars]))
             polygon, = hist_plot_1d(ax, data, histtype='step',
                                     color='r', alpha=0.5, plotter=p)
             assert(polygon.get_ec() == ColorConverter.to_rgba('r', alpha=0.5))
 
             # Check xmin
-            for xmin in [-numpy.inf, -0.5]:
+            for xmin in [-np.inf, -0.5]:
                 bars = hist_plot_1d(ax, data, histtype='bar',
                                     xmin=xmin, plotter=p)
-                assert((numpy.array([b.xy[0] for b in bars]) >= xmin).all())
+                assert((np.array([b.xy[0] for b in bars]) >= xmin).all())
                 polygon, = hist_plot_1d(ax, data, histtype='step', xmin=xmin)
                 assert((polygon.xy[:, 0] >= xmin).all())
 
             # Check xmax
-            for xmax in [numpy.inf, 0.5]:
+            for xmax in [np.inf, 0.5]:
                 bars = hist_plot_1d(ax, data, histtype='bar',
                                     xmax=xmax, plotter=p)
-                assert((numpy.array([b.xy[-1] for b in bars]) <= xmax).all())
+                assert((np.array([b.xy[-1] for b in bars]) <= xmax).all())
                 polygon, = hist_plot_1d(ax, data, histtype='step',
                                         xmax=xmax, plotter=p)
                 assert((polygon.xy[:, 0] <= xmax).all())
@@ -281,8 +280,8 @@ def test_hist_plot_1d():
             # Check xmin and xmax
             bars = hist_plot_1d(ax, data, histtype='bar',
                                 xmin=xmin, xmax=xmax, plotter=p)
-            assert((numpy.array([b.xy[0] for b in bars]) >= -0.5).all())
-            assert((numpy.array([b.xy[-1] for b in bars]) <= 0.5).all())
+            assert((np.array([b.xy[0] for b in bars]) >= -0.5).all())
+            assert((np.array([b.xy[-1] for b in bars]) <= 0.5).all())
             polygon, = hist_plot_1d(ax, data, histtype='step',
                                     xmin=xmin, xmax=xmax, plotter=p)
             assert((polygon.xy[:, 0] >= -0.5).all())
@@ -295,21 +294,21 @@ def test_hist_plot_1d():
 
 def test_hist_plot_2d():
     fig, ax = plt.subplots()
-    numpy.random.seed(0)
-    data_x, data_y = numpy.random.randn(2, 10000)
+    np.random.seed(0)
+    data_x, data_y = np.random.randn(2, 10000)
     hist_plot_2d(ax, data_x, data_y)
     xmin, xmax = ax.get_xlim()
     ymin, ymax = ax.get_ylim()
     assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
 
-    hist_plot_2d(ax, data_x, data_y, xmin=-numpy.inf)
-    hist_plot_2d(ax, data_x, data_y, xmax=numpy.inf)
-    hist_plot_2d(ax, data_x, data_y, ymin=-numpy.inf)
-    hist_plot_2d(ax, data_x, data_y, ymax=numpy.inf)
+    hist_plot_2d(ax, data_x, data_y, xmin=-np.inf)
+    hist_plot_2d(ax, data_x, data_y, xmax=np.inf)
+    hist_plot_2d(ax, data_x, data_y, ymin=-np.inf)
+    hist_plot_2d(ax, data_x, data_y, ymax=np.inf)
     assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
 
-    data_x, data_y = numpy.random.uniform(-10, 10, (2, 1000000))
-    weights = numpy.exp(-(data_x**2 + data_y**2)/2)
+    data_x, data_y = np.random.uniform(-10, 10, (2, 1000000))
+    weights = np.exp(-(data_x**2 + data_y**2)/2)
     hist_plot_2d(ax, data_x, data_y, weights=weights, bins=30)
     xmin, xmax = ax.get_xlim()
     ymin, ymax = ax.get_ylim()
@@ -320,9 +319,9 @@ def test_contour_plot_2d():
     for contour_plot_2d in [kde_contour_plot_2d, fastkde_contour_plot_2d]:
         try:
             ax = plt.gca()
-            numpy.random.seed(1)
-            data_x = numpy.random.randn(1000)
-            data_y = numpy.random.randn(1000)
+            np.random.seed(1)
+            data_x = np.random.randn(1000)
+            data_y = np.random.randn(1000)
             c = contour_plot_2d(ax, data_x, data_y)
             if contour_plot_2d is fastkde_contour_plot_2d:
                 assert(isinstance(c, QuadContourSet))
@@ -375,9 +374,9 @@ def test_contour_plot_2d():
 
 def test_scatter_plot_2d():
     fig, ax = plt.subplots()
-    numpy.random.seed(2)
-    data_x = numpy.random.randn(1000)
-    data_y = numpy.random.randn(1000)
+    np.random.seed(2)
+    data_x = np.random.randn(1000)
+    data_y = np.random.randn(1000)
     lines, = scatter_plot_2d(ax, data_x, data_y)
     assert(isinstance(lines, Line2D))
 

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -510,7 +510,7 @@ def test_beta():
 def test_beta_with_logL_infinities():
     ns = NestedSamples(root="./tests/example_data/pc")
     for i in range(10):
-        ns['logL'][i] = -np.inf
+        ns.loc[i, 'logL'] = -np.inf
     prior = ns.set_beta(0)
     assert np.all(prior.logL[:10] == -np.inf)
     assert np.all(prior.weight[:10] == 0)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -2,7 +2,7 @@ import matplotlib_agg  # noqa: F401
 import os
 import sys
 import pytest
-import numpy
+import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 from matplotlib.patches import Rectangle
@@ -18,34 +18,33 @@ except ImportError:
 
 
 def test_build_mcmc():
-    numpy.random.seed(3)
+    np.random.seed(3)
     nsamps = 1000
     ndims = 3
-    samples = numpy.random.randn(nsamps, ndims)
-    logL = numpy.random.rand(nsamps)
-    w = numpy.random.randint(1, 20, size=nsamps)
+    samples = np.random.randn(nsamps, ndims)
+    logL = np.random.rand(nsamps)
+    w = np.random.randint(1, 20, size=nsamps)
     params = ['A', 'B', 'C']
     tex = {'A': '$A$', 'B': '$B$', 'C': '$C$'}
     limits = {'A': (-1, 1), 'B': (-2, 2), 'C': (-3, 3)}
 
     mcmc = MCMCSamples(data=samples)
     assert(len(mcmc) == nsamps)
-    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2], dtype=object))
+    assert_array_equal(mcmc.columns, np.array([0, 1, 2], dtype=object))
 
     mcmc = MCMCSamples(data=samples, logL=logL)
     assert(len(mcmc) == nsamps)
-    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2, 'logL'],
-                                                 dtype=object))
+    assert_array_equal(mcmc.columns, np.array([0, 1, 2, 'logL'], dtype=object))
 
     mcmc = MCMCSamples(data=samples, w=w)
     assert(len(mcmc) == nsamps)
-    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2, 'weight'],
-                                                 dtype=object))
+    assert_array_equal(mcmc.columns, np.array([0, 1, 2, 'weight'],
+                                              dtype=object))
 
     mcmc = MCMCSamples(data=samples, w=w, logL=logL)
     assert(len(mcmc) == nsamps)
-    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2, 'logL', 'weight'],
-                                                 dtype=object))
+    assert_array_equal(mcmc.columns, np.array([0, 1, 2, 'logL', 'weight'],
+                                              dtype=object))
 
     mcmc = MCMCSamples(data=samples, columns=params)
     assert(len(mcmc) == nsamps)
@@ -61,32 +60,32 @@ def test_build_mcmc():
 
     ns = NestedSamples(data=samples, logL=logL, w=w)
     assert(len(ns) == nsamps)
-    assert(numpy.all(numpy.isfinite(ns.logL)))
+    assert(np.all(np.isfinite(ns.logL)))
     logL[:10] = -1e300
     w[:10] = 0.
     mcmc = MCMCSamples(data=samples, logL=logL, w=w, logzero=-1e29)
     ns = NestedSamples(data=samples, logL=logL, w=w, logzero=-1e29)
-    assert_array_equal(mcmc.columns, numpy.array([0, 1, 2, 'logL', 'weight'],
-                                                 dtype=object))
-    assert_array_equal(ns.columns, numpy.array([0, 1, 2, 'logL', 'weight'],
-                                               dtype=object))
-    assert(numpy.all(mcmc.logL[:10] == -numpy.inf))
-    assert(numpy.all(ns.logL[:10] == -numpy.inf))
-    assert(numpy.all(mcmc.logL[10:] == logL[10:]))
-    assert(numpy.all(ns.logL[10:] == logL[10:]))
+    assert_array_equal(mcmc.columns, np.array([0, 1, 2, 'logL', 'weight'],
+                                              dtype=object))
+    assert_array_equal(ns.columns, np.array([0, 1, 2, 'logL', 'weight'],
+                                            dtype=object))
+    assert(np.all(mcmc.logL[:10] == -np.inf))
+    assert(np.all(ns.logL[:10] == -np.inf))
+    assert(np.all(mcmc.logL[10:] == logL[10:]))
+    assert(np.all(ns.logL[10:] == logL[10:]))
 
     mcmc = MCMCSamples(data=samples, logL=logL, w=w, logzero=-1e301)
     ns = NestedSamples(data=samples, logL=logL, w=w, logzero=-1e301)
-    assert(numpy.all(numpy.isfinite(mcmc.logL)))
-    assert(numpy.all(numpy.isfinite(ns.logL)))
-    assert(numpy.all(mcmc.logL == logL))
-    assert(numpy.all(ns.logL == logL))
+    assert(np.all(np.isfinite(mcmc.logL)))
+    assert(np.all(np.isfinite(ns.logL)))
+    assert(np.all(mcmc.logL == logL))
+    assert(np.all(ns.logL == logL))
 
     assert(mcmc.root is None)
 
 
 def test_read_getdist():
-    numpy.random.seed(3)
+    np.random.seed(3)
     mcmc = MCMCSamples(root='./tests/example_data/gd')
     mcmc.plot_2d(['x0', 'x1', 'x2', 'x3'])
     mcmc.plot_1d(['x0', 'x1', 'x2', 'x3'])
@@ -101,7 +100,7 @@ def test_read_getdist():
                    raises=ImportError,
                    reason="requires montepython package")
 def test_read_montepython():
-    numpy.random.seed(3)
+    np.random.seed(3)
     mcmc = MCMCSamples(root='./tests/example_data/mp')
     mcmc.plot_2d(['x0', 'x1', 'x2', 'x3'])
     mcmc.plot_1d(['x0', 'x1', 'x2', 'x3'])
@@ -109,7 +108,7 @@ def test_read_montepython():
 
 
 def test_read_multinest():
-    numpy.random.seed(3)
+    np.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/mn')
     ns.plot_2d(['x0', 'x1', 'x2', 'x3'])
     ns.plot_1d(['x0', 'x1', 'x2', 'x3'])
@@ -121,7 +120,7 @@ def test_read_multinest():
 
 
 def test_read_polychord():
-    numpy.random.seed(3)
+    np.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     ns.plot_2d(['x0', 'x1', 'x2', 'x3'])
     ns.plot_1d(['x0', 'x1', 'x2', 'x3'])
@@ -146,7 +145,7 @@ def test_NS_input_fails_in_MCMCSamples():
 
 
 def test_different_parameters():
-    numpy.random.seed(3)
+    np.random.seed(3)
     params_x = ['x0', 'x1', 'x2', 'x3', 'x4']
     params_y = ['x0', 'x1', 'x2']
     fig, axes = make_1d_axes(params_x)
@@ -178,7 +177,7 @@ def test_manual_columns():
 
 
 def test_plot_2d_types():
-    numpy.random.seed(3)
+    np.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     params_x = ['x0', 'x1', 'x2', 'x3']
     params_y = ['x0', 'x1', 'x2']
@@ -213,7 +212,7 @@ def test_plot_2d_types():
 
 
 def test_plot_2d_types_multiple_calls():
-    numpy.random.seed(3)
+    np.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     params = ['x0', 'x1', 'x2', 'x3']
 
@@ -230,7 +229,7 @@ def test_plot_2d_types_multiple_calls():
 
 
 def test_root_and_label():
-    numpy.random.seed(3)
+    np.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     assert(ns.root == './tests/example_data/pc')
     assert(ns.label == 'pc')
@@ -249,7 +248,7 @@ def test_root_and_label():
 
 
 def test_plot_2d_legend():
-    numpy.random.seed(3)
+    np.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     mc = MCMCSamples(root='./tests/example_data/gd')
     params = ['x0', 'x1', 'x2', 'x3']
@@ -317,7 +316,7 @@ def test_plot_2d_legend():
 
 
 def test_plot_2d_colours():
-    numpy.random.seed(3)
+    np.random.seed(3)
     gd = MCMCSamples(root="./tests/example_data/gd")
     gd.drop(columns='x3', inplace=True)
     pc = NestedSamples(root="./tests/example_data/pc")
@@ -362,7 +361,7 @@ def test_plot_2d_colours():
 
 
 def test_plot_1d_colours():
-    numpy.random.seed(3)
+    np.random.seed(3)
     gd = MCMCSamples(root="./tests/example_data/gd")
     gd.drop(columns='x3', inplace=True)
     pc = NestedSamples(root="./tests/example_data/pc")
@@ -410,7 +409,7 @@ def test_plot_1d_colours():
                    raises=ImportError,
                    reason="requires astropy package")
 def test_astropyhist():
-    numpy.random.seed(3)
+    np.random.seed(3)
     mcmc = NestedSamples(root='./tests/example_data/pc')
     mcmc.plot_2d(['x0', 'x1', 'x2', 'x3'], types={'diagonal': 'astropyhist'})
     mcmc.plot_1d(['x0', 'x1', 'x2', 'x3'], plot_type='astropyhist')
@@ -418,7 +417,7 @@ def test_astropyhist():
 
 
 def test_hist_levels():
-    numpy.random.seed(3)
+    np.random.seed(3)
     mcmc = NestedSamples(root='./tests/example_data/pc')
     mcmc.plot_2d(['x0', 'x1', 'x2', 'x3'], types={'lower': 'hist'},
                  levels=[0.68, 0.95], bins=20)
@@ -426,7 +425,7 @@ def test_hist_levels():
 
 
 def test_ns_output():
-    numpy.random.seed(3)
+    np.random.seed(3)
     pc = NestedSamples(root='./tests/example_data/pc')
     for beta in [1., 0., 0.5]:
         pc.beta = beta
@@ -466,7 +465,7 @@ def test_masking():
 
 
 def test_merging():
-    numpy.random.seed(3)
+    np.random.seed(3)
     samples_1 = NestedSamples(root='./tests/example_data/pc')
     samples_2 = NestedSamples(root='./tests/example_data/pc_250')
     samples = merge_nested_samples([samples_1, samples_2])
@@ -495,31 +494,31 @@ def test_beta():
     assert_array_equal(pc['weight'], pc.weight)
     assert_array_almost_equal(sorted(prior.weight, reverse=True), prior.weight)
 
-    for beta in numpy.linspace(0, 2, 10):
+    for beta in np.linspace(0, 2, 10):
         pc.set_beta(beta, inplace=True)
         assert pc.beta == beta
         assert_array_equal(pc['weight'], pc.weight)
-        assert not numpy.array_equal(pc['weight'], weight)
+        assert not np.array_equal(pc['weight'], weight)
 
-    for beta in numpy.linspace(0, 2, 10):
+    for beta in np.linspace(0, 2, 10):
         pc.beta = beta
         assert pc.beta == beta
         assert_array_equal(pc['weight'], pc.weight)
-        assert not numpy.array_equal(pc['weight'], weight)
+        assert not np.array_equal(pc['weight'], weight)
 
 
 def test_beta_with_logL_infinities():
     ns = NestedSamples(root="./tests/example_data/pc")
     for i in range(10):
-        ns['logL'][i] = -numpy.inf
+        ns['logL'][i] = -np.inf
     prior = ns.set_beta(0)
-    assert numpy.all(prior.logL[:10] == -numpy.inf)
-    assert numpy.all(prior.weight[:10] == 0)
+    assert np.all(prior.logL[:10] == -np.inf)
+    assert np.all(prior.weight[:10] == 0)
     ns.plot_1d(['x0', 'x1'])
 
 
 def test_live_points():
-    numpy.random.seed(4)
+    np.random.seed(4)
     pc = NestedSamples(root="./tests/example_data/pc")
 
     for i, logL in pc.logL.iteritems():
@@ -536,7 +535,7 @@ def test_live_points():
 
 
 def test_limit_assignment():
-    numpy.random.seed(3)
+    np.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     # `None` in .ranges file:
     assert ns.limits['x0'][0] is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import warnings
-import numpy
+import numpy as np
 from scipy import special as sp
 from numpy.testing import assert_array_equal
 from anesthetic.utils import (nest_level, compute_nlive, unique, is_int,
@@ -19,13 +19,13 @@ def test_nest_level():
 
 def test_compute_nlive():
     # Generate a 'pure' nested sampling run
-    numpy.random.seed(0)
+    np.random.seed(0)
     nlive = 500
     ncompress = 100
-    logL = numpy.cumsum(numpy.random.rand(nlive, ncompress), axis=1)
-    logL_birth = numpy.concatenate((numpy.ones((nlive, 1))*-1e30,
-                                    logL[:, :-1]), axis=1)
-    i = numpy.argsort(logL.flatten())
+    logL = np.cumsum(np.random.rand(nlive, ncompress), axis=1)
+    logL_birth = np.concatenate((np.ones((nlive, 1))*-1e30, logL[:, :-1]),
+                                axis=1)
+    i = np.argsort(logL.flatten())
     logL = logL.flatten()[i]
     logL_birth = logL_birth.flatten()[i]
 
@@ -47,35 +47,35 @@ def test_unique():
 
 
 def test_triangular_sample_compression_2d():
-    numpy.random.seed(0)
+    np.random.seed(0)
     n = 5000
-    x = numpy.random.rand(n)
-    y = numpy.random.rand(n)
-    w = numpy.random.rand(n)
-    cov = numpy.identity(2)
+    x = np.random.rand(n)
+    y = np.random.rand(n)
+    w = np.random.rand(n)
+    cov = np.identity(2)
     tri, W = triangular_sample_compression_2d(x, y, cov, w)
     assert len(W) == 1000
-    assert numpy.isclose(sum(W), sum(w), rtol=1e-1)
+    assert np.isclose(sum(W), sum(w), rtol=1e-1)
 
 
 def test_is_int():
     assert is_int(1)
-    assert is_int(numpy.int64(1))
+    assert is_int(np.int64(1))
     assert not is_int(1.)
-    assert not is_int(numpy.float64(1.))
+    assert not is_int(np.float64(1.))
 
 
 def test_logsumexpinf():
-    a = numpy.random.rand(10)
-    b = numpy.random.rand(10)
-    assert logsumexp(-numpy.inf, b=[-numpy.inf]) == -numpy.inf
+    a = np.random.rand(10)
+    b = np.random.rand(10)
+    assert logsumexp(-np.inf, b=[-np.inf]) == -np.inf
     assert logsumexp(a, b=b) == sp.logsumexp(a, b=b)
-    a[0] = -numpy.inf
+    a[0] = -np.inf
     assert logsumexp(a, b=b) == sp.logsumexp(a, b=b)
-    b[0] = -numpy.inf
+    b[0] = -np.inf
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore',
                                 'invalid value encountered in multiply',
                                 RuntimeWarning)
-        assert numpy.isnan(sp.logsumexp(a, b=b))
-    assert numpy.isfinite(logsumexp(a, b=b))
+        assert np.isnan(sp.logsumexp(a, b=b))
+    assert np.isfinite(logsumexp(a, b=b))

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -1,13 +1,13 @@
 from anesthetic.weighted_pandas import WeightedDataFrame, WeightedSeries
 from pandas import Series, DataFrame
-import numpy
+import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 
 
 def test_WeightedSeries_constructor():
-    numpy.random.seed(0)
+    np.random.seed(0)
     N = 100000
-    data = numpy.random.rand(N)
+    data = np.random.rand(N)
 
     series = WeightedSeries(data)
     assert_array_equal(series.weight, 1)
@@ -17,7 +17,7 @@ def test_WeightedSeries_constructor():
     assert_array_equal(series.weight, 1)
     assert_array_equal(series, data)
 
-    weights = numpy.random.rand(N)
+    weights = np.random.rand(N)
     series = WeightedSeries(data, w=weights)
     assert_array_equal(series, data)
 
@@ -33,10 +33,10 @@ def test_WeightedSeries_constructor():
 
 
 def test_WeightedDataFrame_constructor():
-    numpy.random.seed(0)
+    np.random.seed(0)
     N = 100000
     m = 3
-    data = numpy.random.rand(N, m)
+    data = np.random.rand(N, m)
     cols = ['A', 'B', 'C']
 
     df = WeightedDataFrame(data, columns=cols)
@@ -47,7 +47,7 @@ def test_WeightedDataFrame_constructor():
     assert_array_equal(df.weight, 1)
     assert_array_equal(df, data)
 
-    weights = numpy.random.rand(N)
+    weights = np.random.rand(N)
     df = WeightedDataFrame(data, w=weights, columns=cols)
 
     assert df.weight.shape == (N,)
@@ -85,7 +85,7 @@ def test_WeightedDataFrame_cov():
     df = test_WeightedDataFrame_constructor()
     cov = df.cov()
     assert isinstance(cov, DataFrame)
-    assert_allclose(cov, (1./12)*numpy.identity(3), atol=1e-2)
+    assert_allclose(cov, (1./12)*np.identity(3), atol=1e-2)
 
 
 def test_WeightedDataFrame_median():
@@ -97,7 +97,7 @@ def test_WeightedDataFrame_median():
 
 def test_WeightedDataFrame_quantile():
     df = test_WeightedDataFrame_constructor()
-    for q in numpy.linspace(0, 1, 10):
+    for q in np.linspace(0, 1, 10):
         quantile = df.quantile(q)
         assert isinstance(quantile, Series)
         assert_allclose(quantile, q, atol=1e-2)
@@ -108,16 +108,16 @@ def test_WeightedDataFrame_neff():
     neff = df.neff()
     assert isinstance(neff, float)
     assert neff < len(df)
-    assert neff > len(df) * numpy.exp(-0.25)
+    assert neff > len(df) * np.exp(-0.25)
 
 
 def test_WeightedDataFrame_compress():
     df = test_WeightedDataFrame_constructor()
     assert_allclose(df.neff(), len(df.compress()), rtol=1e-2)
-    for i in numpy.logspace(3, 5, 10):
+    for i in np.logspace(3, 5, 10):
         assert_allclose(i, len(df.compress(i)), rtol=1e-1)
     unit_weights = df.compress(0)
-    assert(len(numpy.unique(unit_weights.index)) == len(unit_weights))
+    assert(len(np.unique(unit_weights.index)) == len(unit_weights))
 
 
 def test_WeightedSeries_mean():
@@ -143,7 +143,7 @@ def test_WeightedSeries_median():
 
 def test_WeightedSeries_quantile():
     series = test_WeightedSeries_constructor()
-    for q in numpy.linspace(0, 1, 10):
+    for q in np.linspace(0, 1, 10):
         quantile = series.quantile(q)
         assert isinstance(quantile, float)
         assert_allclose(quantile, q, atol=1e-2)
@@ -154,13 +154,13 @@ def test_WeightedSeries_neff():
     neff = series.neff()
     assert isinstance(neff, float)
     assert neff < len(series)
-    assert neff > len(series) * numpy.exp(-0.25)
+    assert neff > len(series) * np.exp(-0.25)
 
 
 def test_WeightedSeries_compress():
     series = test_WeightedSeries_constructor()
     assert_allclose(series.neff(), len(series.compress()), rtol=1e-2)
-    for i in numpy.logspace(3, 5, 10):
+    for i in np.logspace(3, 5, 10):
         assert_allclose(i, len(series.compress(i)), rtol=1e-1)
     unit_weights = series.compress(0)
-    assert(len(numpy.unique(unit_weights.index)) == len(unit_weights))
+    assert(len(np.unique(unit_weights.index)) == len(unit_weights))


### PR DESCRIPTION
# Description

Following #76, this replaces all instances of `numpy` with `np`.

This obviously shortens some lines of code, meaning that they no longer needed to be broken over lines. I took this opportunity to do so where possible whilst remaining PEP8 compliant.

I made one minor change to a test which previously used `pdarray[column][index]`. It is more future-proof to use `pdarray.loc[index, column]`, since this will give a modifiable view onto an array in future versions of pandas, whilst the other will not (and was currently raising a warning)

Fixes #76

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works