### PR TITLE
Read cobaya mcmc

### DIFF
--- a/anesthetic/read/getdistreader.py
+++ b/anesthetic/read/getdistreader.py
@@ -71,6 +71,11 @@ class GetDistReader(ChainReader):
         return self.root + '.paramnames'
 
     @property
+    def yaml_file(self):
+        """Cobaya parameter file."""
+        return self.root + '.updated.yaml'
+
+    @property
     def ranges_file(self):
         """File containing parameter names."""
         return self.root + '.ranges'
@@ -79,6 +84,8 @@ class GetDistReader(ChainReader):
     def chains_files(self):
         """File containing parameter names."""
         files = glob.glob(self.root + '_[0-9].txt')
+        if not files:
+            files = glob.glob(self.root + '.[0-9].txt')
         if not files:
             files = [self.root + '.txt']
 

--- a/anesthetic/read/getdistreader.py
+++ b/anesthetic/read/getdistreader.py
@@ -57,22 +57,20 @@ class GetDistReader(ChainReader):
         except IOError:
             return super(GetDistReader, self).limits()
 
-    def samples(self, discard_burnin=False):
+    def samples(self, burn_in=False):
         """Read <root>_1.txt in getdist format."""
         data = np.array([])
         for chains_file in self.chains_files:
             data_i = np.loadtxt(chains_file)
-            if discard_burnin:
-                if 0 < discard_burnin < 1:
-                    index = int(len(data_i) * discard_burnin)
-                elif (type(discard_burnin) is int
-                      and 1 < discard_burnin < len(data_i)):
-                    index = discard_burnin
+            if burn_in:
+                if 0 < burn_in < 1:
+                    index = int(len(data_i) * burn_in)
+                elif type(burn_in) is int and 1 < burn_in < len(data_i):
+                    index = burn_in
                 else:
-                    raise ValueError(
-                        "`discard_burnin` is %s, but should be an integer "
-                        "greater 1 and smaller len(data) or a float between "
-                        "0 and 1." % discard_burnin)
+                    raise ValueError("`burn_in` is %s, but should be an "
+                                     "integer greater 1 and smaller len(data) "
+                                     "or a float between 0 and 1." % burn_in)
                 data_i = data_i[index:]
             data = np.concatenate((data, data_i)) if data.size else data_i
         weights, chi2, samples = np.split(data, [1, 2], axis=1)

--- a/anesthetic/read/samplereader.py
+++ b/anesthetic/read/samplereader.py
@@ -17,7 +17,7 @@ def SampleReader(root):
         return pc
 
     gd = GetDistReader(root)
-    if (os.path.isfile(gd.paramnames_file)
+    if ((os.path.isfile(gd.paramnames_file) or os.path.isfile(gd.yaml_file))
             and os.path.isfile(gd.chains_files[0])
             and os.path.isfile(gd.chains_files[-1])):
         return gd

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -59,8 +59,9 @@ class MCMCSamples(WeightedDataFrame):
         default: -1e30
 
     discard_burnin: int or float
-        discard the first integer number of nsamples (int)
+        Discard the first integer number of nsamples (int)
         or the first fraction of nsamples (float).
+        Only works if `root` provided and if chains are GetDist compatible.
         default: False
 
     """
@@ -75,7 +76,8 @@ class MCMCSamples(WeightedDataFrame):
                                  "instead which has the same features as "
                                  "MCMCSamples and more. MCMCSamples should be "
                                  "used for MCMC chains only." % root)
-            w, logL, samples = reader.samples()
+            discard_burnin = kwargs.pop('discard_burnin', False)
+            w, logL, samples = reader.samples(discard_burnin=discard_burnin)
             params, tex = reader.paramnames()
             columns = kwargs.pop('columns', params)
             limits = reader.limits()
@@ -92,28 +94,6 @@ class MCMCSamples(WeightedDataFrame):
             self.limits = kwargs.pop('limits', {})
             self.label = kwargs.pop('label', None)
             self.root = None
-
-            discard_burnin = kwargs.pop('discard_burnin', False)
-            if discard_burnin:
-                if discard_burnin > len(kwargs['data']):
-                    raise IOError(
-                        "`discard_burnin` = %g > %g = len(data), but needs to "
-                        "be smaller than the number of samples."
-                        % (discard_burnin, len(kwargs['data']))
-                        )
-                if 0 < discard_burnin < 1:
-                    index = int(len(logL) * discard_burnin)
-                elif discard_burnin > 1 and type(discard_burnin) is int:
-                    index = discard_burnin
-                else:
-                    raise IOError("`discard_burnin` is %s, but should be an "
-                                  "integer greater 1 or a float between zero "
-                                  "and 1." % discard_burnin)
-                if logL is not None:
-                    logL = logL[index:]
-                kwargs['data'] = kwargs['data'][index:]
-                if 'w' in kwargs and kwargs['w'] is not None:
-                    kwargs['w'] = kwargs['w'][index:]
 
             super(MCMCSamples, self).__init__(*args, **kwargs)
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -58,9 +58,9 @@ class MCMCSamples(WeightedDataFrame):
         Anything equal or below this value is set to `-np.inf`.
         default: -1e30
 
-    discard_burnin: int or float
-        Discard the first integer number of nsamples (int)
-        or the first fraction of nsamples (float).
+    burn_in: int or float
+        Discards the first integer number of nsamples if int
+        or the first fraction of nsamples if float.
         Only works if `root` provided and if chains are GetDist compatible.
         default: False
 
@@ -76,8 +76,8 @@ class MCMCSamples(WeightedDataFrame):
                                  "instead which has the same features as "
                                  "MCMCSamples and more. MCMCSamples should be "
                                  "used for MCMC chains only." % root)
-            discard_burnin = kwargs.pop('discard_burnin', False)
-            w, logL, samples = reader.samples(discard_burnin=discard_burnin)
+            burn_in = kwargs.pop('burn_in', False)
+            w, logL, samples = reader.samples(burn_in=burn_in)
             params, tex = reader.paramnames()
             columns = kwargs.pop('columns', params)
             limits = reader.limits()

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -93,14 +93,14 @@ class MCMCSamples(WeightedDataFrame):
             self.label = kwargs.pop('label', None)
             self.root = None
 
-            data = kwargs.pop('data')
-            w = kwargs.pop('w', None)
             discard_burnin = kwargs.pop('discard_burnin', False)
             if discard_burnin:
-                if discard_burnin > len(data):
-                    raise IOError("`discard_burnin` = %g > %g = len(data), "
-                                  "but needs to be smaller than the number of "
-                                  "samples." % (discard_burnin, len(data)))
+                if discard_burnin > len(kwargs['data']):
+                    raise IOError(
+                        "`discard_burnin` = %g > %g = len(data), but needs to "
+                        "be smaller than the number of samples."
+                        % (discard_burnin, len(kwargs['data']))
+                        )
                 if 0 < discard_burnin < 1:
                     index = int(len(logL) * discard_burnin)
                 elif discard_burnin > 1 and type(discard_burnin) is int:
@@ -111,11 +111,11 @@ class MCMCSamples(WeightedDataFrame):
                                   "and 1." % discard_burnin)
                 if logL is not None:
                     logL = logL[index:]
-                data = data[index:]
-                if w is not None:
-                    w = w[index:]
+                kwargs['data'] = kwargs['data'][index:]
+                if 'w' in kwargs and kwargs['w'] is not None:
+                    kwargs['w'] = kwargs['w'][index:]
 
-            super(MCMCSamples, self).__init__(data=data, w=w, *args, **kwargs)
+            super(MCMCSamples, self).__init__(*args, **kwargs)
 
             if logL is not None:
                 self['logL'] = logL

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -58,6 +58,11 @@ class MCMCSamples(WeightedDataFrame):
         Anything equal or below this value is set to `-np.inf`.
         default: -1e30
 
+    discard_burnin: int or float
+        discard the first integer number of nsamples (int)
+        or the first fraction of nsamples (float).
+        default: False
+
     """
 
     def __init__(self, *args, **kwargs):
@@ -87,7 +92,30 @@ class MCMCSamples(WeightedDataFrame):
             self.limits = kwargs.pop('limits', {})
             self.label = kwargs.pop('label', None)
             self.root = None
-            super(MCMCSamples, self).__init__(*args, **kwargs)
+
+            data = kwargs.pop('data')
+            w = kwargs.pop('w', None)
+            discard_burnin = kwargs.pop('discard_burnin', False)
+            if discard_burnin:
+                if discard_burnin > len(data):
+                    raise IOError("`discard_burnin` = %g > %g = len(data), "
+                                  "but needs to be smaller than the number of "
+                                  "samples." % (discard_burnin, len(data)))
+                if 0 < discard_burnin < 1:
+                    index = int(len(logL) * discard_burnin)
+                elif discard_burnin > 1 and type(discard_burnin) is int:
+                    index = discard_burnin
+                else:
+                    raise IOError("`discard_burnin` is %s, but should be an "
+                                  "integer greater 1 or a float between zero "
+                                  "and 1." % discard_burnin)
+                if logL is not None:
+                    logL = logL[index:]
+                data = data[index:]
+                if w is not None:
+                    w = w[index:]
+
+            super(MCMCSamples, self).__init__(data=data, w=w, *args, **kwargs)
 
             if logL is not None:
                 self['logL'] = logL

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -94,7 +94,6 @@ class MCMCSamples(WeightedDataFrame):
             self.limits = kwargs.pop('limits', {})
             self.label = kwargs.pop('label', None)
             self.root = None
-
             super(MCMCSamples, self).__init__(*args, **kwargs)
 
             if logL is not None:

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -96,15 +96,15 @@ def test_read_getdist():
     plt.close("all")
 
 
-def test_read_getdist_discard_burnin():
+def test_read_getdist_discard_burn_in():
     np.random.seed(3)
-    mcmc = MCMCSamples(discard_burnin=0.3, root='./tests/example_data/gd')
+    mcmc = MCMCSamples(burn_in=0.3, root='./tests/example_data/gd')
     mcmc.plot_2d(['x0', 'x1', 'x2', 'x3'])
     mcmc.plot_1d(['x0', 'x1', 'x2', 'x3'])
 
     # for 2 getdist chains of length 5000
     mcmc0 = MCMCSamples(root='./tests/example_data/gd')
-    mcmc1 = MCMCSamples(discard_burnin=1000, root='./tests/example_data/gd')
+    mcmc1 = MCMCSamples(burn_in=1000, root='./tests/example_data/gd')
     for key in ['x0', 'x1', 'x2', 'x3', 'x4']:
         assert_array_equal(mcmc0[key][1000:5000], mcmc1[key][:4000])
     mcmc1.plot_2d(['x0', 'x1', 'x2', 'x3', 'x4'])

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -96,6 +96,21 @@ def test_read_getdist():
     plt.close("all")
 
 
+def test_read_getdist_discard_burnin():
+    np.random.seed(3)
+    mcmc = MCMCSamples(discard_burnin=0.3, root='./tests/example_data/gd')
+    mcmc.plot_2d(['x0', 'x1', 'x2', 'x3'])
+    mcmc.plot_1d(['x0', 'x1', 'x2', 'x3'])
+
+    # for 2 getdist chains of length 5000
+    mcmc0 = MCMCSamples(root='./tests/example_data/gd')
+    mcmc1 = MCMCSamples(discard_burnin=1000, root='./tests/example_data/gd')
+    for key in ['x0', 'x1', 'x2', 'x3', 'x4']:
+        assert_array_equal(mcmc0[key][1000:5000], mcmc1[key][:4000])
+    mcmc1.plot_2d(['x0', 'x1', 'x2', 'x3', 'x4'])
+    mcmc1.plot_1d(['x0', 'x1', 'x2', 'x3', 'x4'])
+
+
 @pytest.mark.xfail('montepython' not in sys.modules,
                    raises=ImportError,
                    reason="requires montepython package")


### PR DESCRIPTION
* Provides functionality to read MCMC chains from Cobaya which use `.` instead of `_` for their chains and which have a `.yaml` file instead of a `.paramnames` file.
* Provides functionality to discard burn-in samples, which is useful e.g. when comparing PolyChord results to Planck MCMC chains.

Fixes #18 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
