### PR TITLE
Added code for a getdist converter

### DIFF
--- a/anesthetic/convert.py
+++ b/anesthetic/convert.py
@@ -1,0 +1,27 @@
+"""Tools for converting to other outputs."""
+
+
+def to_getdist(nested_samples):
+    """Convert from anesthetic to getdist samples.
+
+    Parameters
+    ----------
+    nested_samples: MCMCSamples or NestedSamples
+        anesthetic samples to be converted
+
+    Returns
+    -------
+    getdist_samples: getdist.mcsamples.MCSamples
+        getdist equivalent samples
+    """
+    import getdist
+    samples = nested_samples.values
+    weights = nested_samples.weight.values
+    loglikes = -2*nested_samples.logL.values
+    names = nested_samples.columns
+    ranges = {name: nested_samples._limits(name) for name in names}
+    return getdist.mcsamples.MCSamples(samples=samples,
+                                       weights=weights,
+                                       loglikes=loglikes,
+                                       ranges=ranges,
+                                       names=names)

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib inline\n",
     "from anesthetic import MCMCSamples\n",
     "mcmc_root = 'plikHM_TTTEEE_lowl_lowE_lensing/base_plikHM_TTTEEE_lowl_lowE_lensing'\n",
     "mcmc = MCMCSamples(root=mcmc_root)"
@@ -390,9 +390,27 @@
    "source": [
     "nested.gui()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are also tools for converting to alternative formats, in case you have\n",
+    " pipelines in other plotters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from anesthetic.convert import to_getdist\n",
+    "getdist_samples = to_getdist(nested)"
+   ]
   }
  ],
  "metadata": {},
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/demo.py
+++ b/demo.py
@@ -23,7 +23,7 @@ for filename in ["plikHM_TTTEEE_lowl_lowE_lensing.tar.gz","plikHM_TTTEEE_lowl_lo
 #| ## Marginalised posterior plotting
 #| Import anesthetic and load the MCMC samples:
 
-%matplotlib notebook
+%matplotlib inline
 from anesthetic import MCMCSamples
 mcmc_root = 'plikHM_TTTEEE_lowl_lowE_lensing/base_plikHM_TTTEEE_lowl_lowE_lensing'
 mcmc = MCMCSamples(root=mcmc_root)
@@ -134,3 +134,9 @@ fig.tight_layout()
 #| sampling run after the fact.
 
 nested.gui()
+
+#| There are also tools for converting to alternative formats, in case you have
+#| pipelines in other plotters:
+
+from anesthetic.convert import to_getdist
+getdist_samples = to_getdist(nested)

--- a/requirements_extras.txt
+++ b/requirements_extras.txt
@@ -4,3 +4,4 @@ pandas
 matplotlib>=3.1.2
 fastkde
 astropy
+getdist

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,15 @@
+from anesthetic import MCMCSamples
+from anesthetic.convert import to_getdist
+from numpy.testing import assert_array_equal
+
+
+def test_to_getdist():
+    anesthetic_samples = MCMCSamples(root='./tests/example_data/gd')
+    getdist_samples = to_getdist(anesthetic_samples)
+
+    assert_array_equal(getdist_samples.samples, anesthetic_samples)
+    assert_array_equal(getdist_samples.weights, anesthetic_samples.weight)
+
+    for param, p in zip(getdist_samples.getParamNames().names,
+                        anesthetic_samples.columns):
+        assert param.name == p

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -4,12 +4,15 @@ from numpy.testing import assert_array_equal
 
 
 def test_to_getdist():
-    anesthetic_samples = MCMCSamples(root='./tests/example_data/gd')
-    getdist_samples = to_getdist(anesthetic_samples)
+    try:
+        anesthetic_samples = MCMCSamples(root='./tests/example_data/gd')
+        getdist_samples = to_getdist(anesthetic_samples)
 
-    assert_array_equal(getdist_samples.samples, anesthetic_samples)
-    assert_array_equal(getdist_samples.weights, anesthetic_samples.weight)
+        assert_array_equal(getdist_samples.samples, anesthetic_samples)
+        assert_array_equal(getdist_samples.weights, anesthetic_samples.weight)
 
-    for param, p in zip(getdist_samples.getParamNames().names,
-                        anesthetic_samples.columns):
-        assert param.name == p
+        for param, p in zip(getdist_samples.getParamNames().names,
+                            anesthetic_samples.columns):
+            assert param.name == p
+    except ModuleNotFoundError:
+        pass


### PR DESCRIPTION
# Description

This is code which anecdotally I know would be useful to other users who have large plotting pipelines in getdist, but would like to be able to make use of anesthetics nested sampling post-processing tools.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works