### PR TITLE
Nan - zero weight bug fix for contour plot covariance computation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley
-:Version: 1.3.1
+:Version: 1.3.2
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -529,6 +529,11 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     if len(data_x) == 0 or len(data_y) == 0:
         return np.zeros(0), np.zeros(0), np.zeros((0, 0))
 
+    if weights is not None:
+        data_x = data_x[weights != 0]
+        data_y = data_y[weights != 0]
+        weights = weights[weights != 0]
+
     cov = np.cov(data_x, data_y, aweights=weights)
     tri, w = triangular_sample_compression_2d(data_x, data_y, cov,
                                               weights, ncompress)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -571,3 +571,17 @@ def test_limit_assignment():
     assert ns.limits['weight'][1] == 1
     assert ns.limits['nlive'][0] == 0
     assert ns.limits['nlive'][1] == 125
+
+
+def test_contour_plot_2d_nan():
+    """Contour plots with nans arising from issue #96"""
+    np.random.seed(3)
+    ns = NestedSamples(root='./tests/example_data/pc')
+
+    ns.loc[:10, 'x0'] = np.nan
+    with pytest.raises(np.linalg.LinAlgError):
+        ns.plot_2d(['x0', 'x1'])
+
+    # Check this error is removed in the case of zero weights
+    ns._weight[:10] = 0
+    ns.plot_2d(['x0', 'x1'])

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -578,7 +578,7 @@ def test_contour_plot_2d_nan():
     np.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
 
-    ns.loc[:10, 'x0'] = np.nan
+    ns.loc[:9, 'x0'] = np.nan
     with pytest.raises(np.linalg.LinAlgError):
         ns.plot_2d(['x0', 'x1'])
 

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -579,7 +579,7 @@ def test_contour_plot_2d_nan():
     ns = NestedSamples(root='./tests/example_data/pc')
 
     ns.loc[:9, 'x0'] = np.nan
-    with pytest.raises(np.linalg.LinAlgError):
+    with pytest.raises((np.linalg.LinAlgError, RuntimeError)):
         ns.plot_2d(['x0', 'x1'])
 
     # Check this error is removed in the case of zero weights


### PR DESCRIPTION
# Description

This PR starts a fix for #96, by pushing a failing test, which will be fixed by masking out zero weights in the covariance matrix calculation.

Fixes #96

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works