### PR TITLE
Added missing default values to NestedSamples

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -77,13 +77,13 @@ class MCMCSamples(WeightedDataFrame):
                                  "MCMCSamples and more. MCMCSamples should be "
                                  "used for MCMC chains only." % root)
             burn_in = kwargs.pop('burn_in', False)
-            w, logL, samples = reader.samples(burn_in=burn_in)
+            weight, logL, samples = reader.samples(burn_in=burn_in)
             params, tex = reader.paramnames()
             columns = kwargs.pop('columns', params)
             limits = reader.limits()
             kwargs['label'] = kwargs.get('label', os.path.basename(root))
-            self.__init__(data=samples, columns=columns, w=w, logL=logL,
-                          tex=tex, limits=limits, *args, **kwargs)
+            self.__init__(data=samples, columns=columns, weight=weight,
+                          logL=logL, tex=tex, limits=limits, *args, **kwargs)
             self.root = root
         else:
             logzero = kwargs.pop('logzero', -1e30)
@@ -624,9 +624,9 @@ class NestedSamples(MCMCSamples):
 
         if nsamples is None:
             dlogX = np.squeeze(dlogX)
-            return WeightedSeries(dlogX, self.index, w=self.weight)
+            return WeightedSeries(dlogX, self.index, weight=self.weight)
         else:
-            return WeightedDataFrame(dlogX, self.index, w=self.weight)
+            return WeightedDataFrame(dlogX, self.index, weight=self.weight)
 
     def _compute_nlive(self, logL_birth):
         if is_int(logL_birth):

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -38,7 +38,7 @@ class MCMCSamples(WeightedDataFrame):
     columns: list(str)
         reference names of parameters
 
-    w: np.array
+    weight: np.array
         weights of samples.
 
     logL: np.array

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -400,16 +400,20 @@ class NestedSamples(MCMCSamples):
         birth loglikelihoods, or number of live points.
 
     tex: dict
-        mapping from columns to tex labels for plotting
+        optional mapping from column names to tex labels for plotting
 
     limits: dict
-        mapping from columns to prior limits
+        mapping from columns to prior limits.
+        Defaults defined by .ranges file (if it exists)
+        otherwise defined by minimum and maximum of the nested sampling data
 
     label: str
         Legend label
+        default: basename of root
 
     beta: float
         thermodynamic temperature
+        default: 1.
 
     logzero: float
         The threshold for `log(0)` values assigned to rejected sample points.

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -45,6 +45,7 @@ class WeightedSeries(_WeightedObject, pandas.Series):
 
     def __init__(self, *args, **kwargs):
         w = kwargs.pop('w', None)
+        w = kwargs.pop('weight', w)
         super(WeightedSeries, self).__init__(*args, **kwargs)
         self._construct_weights(w)
 
@@ -99,6 +100,7 @@ class WeightedDataFrame(_WeightedObject, pandas.DataFrame):
 
     def __init__(self, *args, **kwargs):
         w = kwargs.pop('w', None)
+        w = kwargs.pop('weight', w)
         super(WeightedDataFrame, self).__init__(*args, **kwargs)
         self._construct_weights(w)
 

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pandas
+from warnings import warn
 from anesthetic.utils import compress_weights, channel_capacity, quantile
 
 
@@ -19,9 +20,9 @@ class _WeightedObject(object):
         """Random number for consistent compression."""
         return self._rand_[self.index]
 
-    def _construct_weights(self, w):
-        if w is not None:
-            self._weight = pandas.Series(index=self.index, data=w)
+    def _construct_weights(self, weight):
+        if weight is not None:
+            self._weight = pandas.Series(index=self.index, data=weight)
         else:
             self._weight = None
         rand = np.random.rand(len(self))
@@ -44,10 +45,13 @@ class WeightedSeries(_WeightedObject, pandas.Series):
     """Weighted version of pandas.Series."""
 
     def __init__(self, *args, **kwargs):
-        w = kwargs.pop('w', None)
-        w = kwargs.pop('weight', w)
+        if 'w' in kwargs:
+            warn("'w' as a kwarg will be deprecated in the future. "
+                 "Please use 'weight'", FutureWarning)
+        weight = kwargs.pop('w', None)
+        weight = kwargs.pop('weight', weight)
         super(WeightedSeries, self).__init__(*args, **kwargs)
-        self._construct_weights(w)
+        self._construct_weights(weight)
 
     def mean(self):
         """Weighted mean of the sampled distribution."""
@@ -89,7 +93,7 @@ class WeightedSeries(_WeightedObject, pandas.Series):
     @property
     def _constructor_expanddim(self):
         def __constructor_expanddim(*args, **kwargs):
-            frame = WeightedDataFrame(*args, w=self._weight, **kwargs)
+            frame = WeightedDataFrame(*args, weight=self._weight, **kwargs)
             frame._rand_ = self._rand_
             return frame
         return __constructor_expanddim
@@ -99,10 +103,13 @@ class WeightedDataFrame(_WeightedObject, pandas.DataFrame):
     """Weighted version of pandas.DataFrame."""
 
     def __init__(self, *args, **kwargs):
-        w = kwargs.pop('w', None)
-        w = kwargs.pop('weight', w)
+        if 'w' in kwargs:
+            warn("'w' as a kwarg will be deprecated in the future. "
+                 "Please use 'weight'", FutureWarning)
+        weight = kwargs.pop('w', None)
+        weight = kwargs.pop('weight', weight)
         super(WeightedDataFrame, self).__init__(*args, **kwargs)
-        self._construct_weights(w)
+        self._construct_weights(weight)
 
     def mean(self):
         """Weighted mean of the sampled distribution."""
@@ -158,7 +165,7 @@ class WeightedDataFrame(_WeightedObject, pandas.DataFrame):
     @property
     def _constructor_sliced(self):
         def __constructor_sliced(*args, **kwargs):
-            series = WeightedSeries(*args, w=self._weight, **kwargs)
+            series = WeightedSeries(*args, weight=self._weight, **kwargs)
             series._rand_ = self._rand_
             return series
         return __constructor_sliced

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -23,7 +23,7 @@ def test_build_mcmc():
     ndims = 3
     samples = np.random.randn(nsamps, ndims)
     logL = np.random.rand(nsamps)
-    w = np.random.randint(1, 20, size=nsamps)
+    weight = np.random.randint(1, 20, size=nsamps)
     params = ['A', 'B', 'C']
     tex = {'A': '$A$', 'B': '$B$', 'C': '$C$'}
     limits = {'A': (-1, 1), 'B': (-2, 2), 'C': (-3, 3)}
@@ -36,12 +36,12 @@ def test_build_mcmc():
     assert(len(mcmc) == nsamps)
     assert_array_equal(mcmc.columns, np.array([0, 1, 2, 'logL'], dtype=object))
 
-    mcmc = MCMCSamples(data=samples, w=w)
+    mcmc = MCMCSamples(data=samples, weight=weight)
     assert(len(mcmc) == nsamps)
     assert_array_equal(mcmc.columns, np.array([0, 1, 2, 'weight'],
                                               dtype=object))
 
-    mcmc = MCMCSamples(data=samples, w=w, logL=logL)
+    mcmc = MCMCSamples(data=samples, weight=weight, logL=logL)
     assert(len(mcmc) == nsamps)
     assert_array_equal(mcmc.columns, np.array([0, 1, 2, 'logL', 'weight'],
                                               dtype=object))
@@ -58,13 +58,13 @@ def test_build_mcmc():
     for p in params:
         assert(mcmc.limits[p] == limits[p])
 
-    ns = NestedSamples(data=samples, logL=logL, w=w)
+    ns = NestedSamples(data=samples, logL=logL, weight=weight)
     assert(len(ns) == nsamps)
     assert(np.all(np.isfinite(ns.logL)))
     logL[:10] = -1e300
-    w[:10] = 0.
-    mcmc = MCMCSamples(data=samples, logL=logL, w=w, logzero=-1e29)
-    ns = NestedSamples(data=samples, logL=logL, w=w, logzero=-1e29)
+    weight[:10] = 0.
+    mcmc = MCMCSamples(data=samples, logL=logL, weight=weight, logzero=-1e29)
+    ns = NestedSamples(data=samples, logL=logL, weight=weight, logzero=-1e29)
     assert_array_equal(mcmc.columns, np.array([0, 1, 2, 'logL', 'weight'],
                                               dtype=object))
     assert_array_equal(ns.columns, np.array([0, 1, 2, 'logL', 'weight'],
@@ -74,8 +74,8 @@ def test_build_mcmc():
     assert(np.all(mcmc.logL[10:] == logL[10:]))
     assert(np.all(ns.logL[10:] == logL[10:]))
 
-    mcmc = MCMCSamples(data=samples, logL=logL, w=w, logzero=-1e301)
-    ns = NestedSamples(data=samples, logL=logL, w=w, logzero=-1e301)
+    mcmc = MCMCSamples(data=samples, logL=logL, weight=weight, logzero=-1e301)
+    ns = NestedSamples(data=samples, logL=logL, weight=weight, logzero=-1e301)
     assert(np.all(np.isfinite(mcmc.logL)))
     assert(np.all(np.isfinite(ns.logL)))
     assert(np.all(mcmc.logL == logL))

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -1,3 +1,4 @@
+import pytest
 from anesthetic.weighted_pandas import WeightedDataFrame, WeightedSeries
 from pandas import Series, DataFrame
 import numpy as np
@@ -13,17 +14,19 @@ def test_WeightedSeries_constructor():
     assert_array_equal(series.weight, 1)
     assert_array_equal(series, data)
 
-    series = WeightedSeries(data, w=None)
-    assert_array_equal(series.weight, 1)
-    assert_array_equal(series, data)
+    with pytest.warns(FutureWarning):
+        series = WeightedSeries(data, w=None)
+        assert_array_equal(series.weight, 1)
+        assert_array_equal(series, data)
 
     series = WeightedSeries(data, weight=None)
     assert_array_equal(series.weight, 1)
     assert_array_equal(series, data)
 
     weight = np.random.rand(N)
-    series = WeightedSeries(data, w=weight)
-    assert_array_equal(series, data)
+    with pytest.warns(FutureWarning):
+        series = WeightedSeries(data, w=weight)
+        assert_array_equal(series, data)
 
     series = WeightedSeries(data, weight=weight)
     assert_array_equal(series, data)
@@ -50,24 +53,25 @@ def test_WeightedDataFrame_constructor():
     assert_array_equal(df.weight, 1)
     assert_array_equal(df, data)
 
-    df = WeightedDataFrame(data, w=None, columns=cols)
-    assert_array_equal(df.weight, 1)
-    assert_array_equal(df, data)
+    with pytest.warns(FutureWarning):
+        df = WeightedDataFrame(data, w=None, columns=cols)
+        assert_array_equal(df.weight, 1)
+        assert_array_equal(df, data)
 
     df = WeightedDataFrame(data, weight=None, columns=cols)
     assert_array_equal(df.weight, 1)
     assert_array_equal(df, data)
 
     weight = np.random.rand(N)
-    df = WeightedDataFrame(data, w=weight, columns=cols)
-    assert df.weight.shape == (N,)
-    assert df.shape == (N, m)
-    assert isinstance(df.weight, Series)
-    assert_array_equal(df, data)
-    assert_array_equal(df.weight, weight)
-    assert_array_equal(df.columns, cols)
+    with pytest.warns(FutureWarning):
+        df = WeightedDataFrame(data, w=weight, columns=cols)
+        assert df.weight.shape == (N,)
+        assert df.shape == (N, m)
+        assert isinstance(df.weight, Series)
+        assert_array_equal(df, data)
+        assert_array_equal(df.weight, weight)
+        assert_array_equal(df.columns, cols)
 
-    weight = np.random.rand(N)
     df = WeightedDataFrame(data, weight=weight, columns=cols)
     assert df.weight.shape == (N,)
     assert df.shape == (N, m)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -17,17 +17,24 @@ def test_WeightedSeries_constructor():
     assert_array_equal(series.weight, 1)
     assert_array_equal(series, data)
 
-    weights = np.random.rand(N)
-    series = WeightedSeries(data, w=weights)
+    series = WeightedSeries(data, weight=None)
+    assert_array_equal(series.weight, 1)
+    assert_array_equal(series, data)
+
+    weight = np.random.rand(N)
+    series = WeightedSeries(data, w=weight)
+    assert_array_equal(series, data)
+
+    series = WeightedSeries(data, weight=weight)
     assert_array_equal(series, data)
 
     assert series.weight.shape == (N,)
     assert series.shape == (N,)
     assert isinstance(series.weight, Series)
     assert_array_equal(series, data)
-    assert_array_equal(series.weight, weights)
+    assert_array_equal(series.weight, weight)
     assert isinstance(series.to_frame(), WeightedDataFrame)
-    assert_array_equal(series.to_frame().weight, weights)
+    assert_array_equal(series.to_frame().weight, weight)
 
     return series
 
@@ -47,15 +54,29 @@ def test_WeightedDataFrame_constructor():
     assert_array_equal(df.weight, 1)
     assert_array_equal(df, data)
 
-    weights = np.random.rand(N)
-    df = WeightedDataFrame(data, w=weights, columns=cols)
+    df = WeightedDataFrame(data, weight=None, columns=cols)
+    assert_array_equal(df.weight, 1)
+    assert_array_equal(df, data)
 
+    weight = np.random.rand(N)
+    df = WeightedDataFrame(data, w=weight, columns=cols)
     assert df.weight.shape == (N,)
     assert df.shape == (N, m)
     assert isinstance(df.weight, Series)
     assert_array_equal(df, data)
-    assert_array_equal(df.weight, weights)
+    assert_array_equal(df.weight, weight)
     assert_array_equal(df.columns, cols)
+
+    weight = np.random.rand(N)
+    df = WeightedDataFrame(data, weight=weight, columns=cols)
+    assert df.weight.shape == (N,)
+    assert df.shape == (N, m)
+    assert isinstance(df.weight, Series)
+    assert_array_equal(df, data)
+    assert_array_equal(df.weight, weight)
+    assert_array_equal(df.columns, cols)
+    return df
+
     return df
 
 


### PR DESCRIPTION
# Description

This addresses all the points in #91, aside from `logL_birth`, which like `logL` is overriden by `root`, so there is no 'default' per-se. If root is not supplied, then you should supply a `logL_birth` of some form, although this cannot be an error if not on account of how it extends the underlying `pd.DataFrame` class.

Fixes #91

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works