### PR TITLE
Equal min and max limits fix

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -355,7 +355,10 @@ class MCMCSamples(WeightedDataFrame):
         return fig, axes
 
     def _limits(self, paramname):
-        return self.limits.get(paramname, (None, None))
+        limits = self.limits.get(paramname, (None, None))
+        if limits[0] == limits[1]:
+            limits = (None, None)
+        return limits
 
     def _reload_data(self):
         self.__init__(root=self.root)

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -156,26 +156,26 @@ class MCMCSamples(WeightedDataFrame):
         if do_1d_plot:
             if paramname_x in self and plot_type is not None:
                 xmin, xmax = self._limits(paramname_x)
+                kwargs['xmin'] = kwargs.get('xmin', xmin)
+                kwargs['xmax'] = kwargs.get('xmax', xmax)
                 if plot_type == 'kde':
                     if ncompress is None:
                         ncompress = 1000
                     return kde_plot_1d(ax, self[paramname_x],
                                        weights=self.weight,
                                        ncompress=ncompress,
-                                       xmin=xmin, xmax=xmax,
                                        *args, **kwargs)
                 elif plot_type == 'fastkde':
                     x = self[paramname_x].compress(ncompress)
-                    return fastkde_plot_1d(ax, x, xmin=xmin, xmax=xmax,
-                                           *args, **kwargs)
+                    return fastkde_plot_1d(ax, x, *args, **kwargs)
                 elif plot_type == 'hist':
                     return hist_plot_1d(ax, self[paramname_x],
                                         weights=self.weight,
-                                        xmin=xmin, xmax=xmax, *args, **kwargs)
+                                        *args, **kwargs)
                 elif plot_type == 'astropyhist':
                     x = self[paramname_x].compress(ncompress)
                     return hist_plot_1d(ax, x, plotter='astropyhist',
-                                        xmin=xmin, xmax=xmax, *args, **kwargs)
+                                        *args, **kwargs)
                 else:
                     raise NotImplementedError("plot_type is '%s', but must be"
                                               " one of {'kde', 'fastkde', "
@@ -188,38 +188,34 @@ class MCMCSamples(WeightedDataFrame):
             if (paramname_x in self and paramname_y in self
                     and plot_type is not None):
                 xmin, xmax = self._limits(paramname_x)
+                kwargs['xmin'] = kwargs.get('xmin', xmin)
+                kwargs['xmax'] = kwargs.get('xmax', xmax)
                 ymin, ymax = self._limits(paramname_y)
+                kwargs['ymin'] = kwargs.get('ymin', ymin)
+                kwargs['ymax'] = kwargs.get('ymax', ymax)
                 if plot_type == 'kde':
                     if ncompress is None:
                         ncompress = 1000
                     x = self[paramname_x]
                     y = self[paramname_y]
                     return kde_contour_plot_2d(ax, x, y, weights=self.weight,
-                                               xmin=xmin, xmax=xmax,
-                                               ymin=ymin, ymax=ymax,
                                                ncompress=ncompress,
                                                *args, **kwargs)
                 elif plot_type == 'fastkde':
                     x = self[paramname_x].compress(ncompress)
                     y = self[paramname_y].compress(ncompress)
                     return fastkde_contour_plot_2d(ax, x, y,
-                                                   xmin=xmin, xmax=xmax,
-                                                   ymin=ymin, ymax=ymax,
                                                    *args, **kwargs)
                 elif plot_type == 'scatter':
                     if ncompress is None:
                         ncompress = 500
                     x = self[paramname_x].compress(ncompress)
                     y = self[paramname_y].compress(ncompress)
-                    return scatter_plot_2d(ax, x, y, xmin=xmin, xmax=xmax,
-                                           ymin=ymin, ymax=ymax,
-                                           *args, **kwargs)
+                    return scatter_plot_2d(ax, x, y, *args, **kwargs)
                 elif plot_type == 'hist':
                     x = self[paramname_x]
                     y = self[paramname_y]
                     return hist_plot_2d(ax, x, y, weights=self.weight,
-                                        xmin=xmin, xmax=xmax,
-                                        ymin=ymin, ymax=ymax,
                                         *args, **kwargs)
                 else:
                     raise NotImplementedError("plot_type is '%s', but must be"

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -571,3 +571,24 @@ def test_limit_assignment():
     assert ns.limits['weight'][1] == 1
     assert ns.limits['nlive'][0] == 0
     assert ns.limits['nlive'][1] == 125
+
+
+def test_xmin_xmax_1d():
+    """Test to provide a solution to #89"""
+    np.random.seed(3)
+    ns = NestedSamples(root='./tests/example_data/pc')
+    fig, ax = ns.plot_1d('x0', plot_type='hist')
+    assert ax['x0'].get_xlim() != (-1, 1)
+    fig, ax = ns.plot_1d('x0', plot_type='hist', xmin=-1, xmax=1)
+    assert ax['x0'].get_xlim() == (-1, 1)
+
+
+def test_equal_min_max():
+    """Test to provide a solution to #89"""
+    np.random.seed(3)
+    ns = NestedSamples(root='./tests/example_data/pc')
+    with pytest.raises(ValueError):
+        ns.plot_2d(['x0', 'x1', 'x2'], xmin=3, xmax=3)
+
+    ns.limits['x0'] = (3, 3)
+    ns.plot_2d(['x0', 'x1', 'x2'])

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -593,7 +593,7 @@ def test_equal_min_max():
     ns.limits['x0'] = (3, 3)
     ns.plot_2d(['x0', 'x1', 'x2'])
 
-    
+
 def test_contour_plot_2d_nan():
     """Contour plots with nans arising from issue #96"""
     np.random.seed(3)


### PR DESCRIPTION
# Description

This PR cleans up the xmin and xmax interface by allowing users to override xmin and xmax as user-provided kwargs (which also reduces the length of the code).

Fixes #89 by returning no limits `(None, None)` if equal limits are specified for any reason.

Initial test fails for first commit, which is fixed by the second.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works