### PR TITLE
add minimum scipy version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley
-:Version: 1.3.2
+:Version: 1.3.3
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scipy
+scipy>=1.2.0
 numpy
 pandas
 matplotlib>=3.1.2


### PR DESCRIPTION
scipy's `gaussian_kde` only accepts the kwarg `weights` from version `1.2.0` onwards. Update anesthetic requirements accordingly.

Fixes #106 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
