### PR TITLE
Pop quantile kwarg q in 2d

### DIFF
--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -458,6 +458,7 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     linewidths = kwargs.pop('linewidths', 0.5)
     levels = kwargs.pop('levels', [0.68, 0.95])
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
+    _ = kwargs.pop('q', None)
 
     if len(data_x) == 0 or len(data_y) == 0:
         return np.zeros(0), np.zeros(0), np.zeros((0, 0))

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -458,7 +458,7 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     linewidths = kwargs.pop('linewidths', 0.5)
     levels = kwargs.pop('levels', [0.68, 0.95])
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
-    _ = kwargs.pop('q', None)
+    kwargs.pop('q', None)
 
     if len(data_x) == 0 or len(data_y) == 0:
         return np.zeros(0), np.zeros(0), np.zeros((0, 0))
@@ -531,11 +531,11 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ymax = kwargs.pop('ymax', None)
     weights = kwargs.pop('weights', None)
     ncompress = kwargs.pop('ncompress', 1000)
-    _ = kwargs.pop('q', None)
     label = kwargs.pop('label', None)
     zorder = kwargs.pop('zorder', 1)
     linewidths = kwargs.pop('linewidths', 0.5)
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
+    kwargs.pop('q', None)
 
     if len(data_x) == 0 or len(data_y) == 0:
         return np.zeros(0), np.zeros(0), np.zeros((0, 0))
@@ -696,7 +696,7 @@ def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
     xmax = kwargs.pop('xmax', None)
     ymin = kwargs.pop('ymin', None)
     ymax = kwargs.pop('ymax', None)
-    _ = kwargs.pop('q', None)
+    kwargs.pop('q', None)
     kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
     markersize = kwargs.pop('markersize', 1)
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -530,6 +530,7 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ymax = kwargs.pop('ymax', None)
     weights = kwargs.pop('weights', None)
     ncompress = kwargs.pop('ncompress', 1000)
+    _ = kwargs.pop('q', None)
     label = kwargs.pop('label', None)
     zorder = kwargs.pop('zorder', 1)
     linewidths = kwargs.pop('linewidths', 0.5)
@@ -694,6 +695,7 @@ def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
     xmax = kwargs.pop('xmax', None)
     ymin = kwargs.pop('ymin', None)
     ymax = kwargs.pop('ymax', None)
+    _ = kwargs.pop('q', None)
     kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
     markersize = kwargs.pop('markersize', 1)
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -324,61 +324,66 @@ def test_hist_plot_2d():
     assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
 
 
-def test_contour_plot_2d():
-    for contour_plot_2d in [kde_contour_plot_2d, fastkde_contour_plot_2d]:
-        try:
-            ax = plt.gca()
-            np.random.seed(1)
-            data_x = np.random.randn(1000)
-            data_y = np.random.randn(1000)
-            c = contour_plot_2d(ax, data_x, data_y)
-            if contour_plot_2d is fastkde_contour_plot_2d:
-                assert(isinstance(c, QuadContourSet))
-            elif contour_plot_2d is kde_contour_plot_2d:
-                assert(isinstance(c, TriContourSet))
+@pytest.mark.parametrize('contour_plot_2d', [kde_contour_plot_2d, fastkde_contour_plot_2d])
+def test_contour_plot_2d(contour_plot_2d):
+    try:
+        ax = plt.gca()
+        np.random.seed(1)
+        data_x = np.random.randn(1000)
+        data_y = np.random.randn(1000)
+        c = contour_plot_2d(ax, data_x, data_y)
+        if contour_plot_2d is fastkde_contour_plot_2d:
+            assert(isinstance(c, QuadContourSet))
+        elif contour_plot_2d is kde_contour_plot_2d:
+            assert(isinstance(c, TriContourSet))
 
-            xmin, xmax, ymin, ymax = -0.5, 0.5, -0.5, 0.5
+        xmin, xmax, ymin, ymax = -0.5, 0.5, -0.5, 0.5
 
-            # Check xmin
-            ax = plt.gca()
-            contour_plot_2d(ax, data_x, data_y, xmin=xmin)
-            assert(ax.get_xlim()[0] >= xmin)
-            plt.close()
+        # Check xmin
+        ax = plt.gca()
+        contour_plot_2d(ax, data_x, data_y, xmin=xmin)
+        assert(ax.get_xlim()[0] >= xmin)
+        plt.close()
 
-            # Check xmax
-            ax = plt.gca()
-            contour_plot_2d(ax, data_x, data_y, xmax=xmax)
-            assert(ax.get_xlim()[1] <= xmax)
-            plt.close()
+        # Check xmax
+        ax = plt.gca()
+        contour_plot_2d(ax, data_x, data_y, xmax=xmax)
+        assert(ax.get_xlim()[1] <= xmax)
+        plt.close()
 
-            # Check xmin and xmax
-            ax = plt.gca()
-            contour_plot_2d(ax, data_x, data_y, xmin=xmin, xmax=xmax)
-            assert(ax.get_xlim()[1] <= xmax)
-            assert(ax.get_xlim()[0] >= xmin)
-            plt.close()
+        # Check xmin and xmax
+        ax = plt.gca()
+        contour_plot_2d(ax, data_x, data_y, xmin=xmin, xmax=xmax)
+        assert(ax.get_xlim()[1] <= xmax)
+        assert(ax.get_xlim()[0] >= xmin)
+        plt.close()
 
-            # Check ymin
-            ax = plt.gca()
-            contour_plot_2d(ax, data_x, data_y, ymin=ymin)
-            assert(ax.get_ylim()[0] >= ymin)
-            plt.close()
+        # Check ymin
+        ax = plt.gca()
+        contour_plot_2d(ax, data_x, data_y, ymin=ymin)
+        assert(ax.get_ylim()[0] >= ymin)
+        plt.close()
 
-            # Check ymax
-            ax = plt.gca()
-            contour_plot_2d(ax, data_x, data_y, ymax=ymax)
-            assert(ax.get_ylim()[1] <= ymax)
-            plt.close()
+        # Check ymax
+        ax = plt.gca()
+        contour_plot_2d(ax, data_x, data_y, ymax=ymax)
+        assert(ax.get_ylim()[1] <= ymax)
+        plt.close()
 
-            # Check ymin and ymax
-            ax = plt.gca()
-            contour_plot_2d(ax, data_x, data_y, ymin=ymin, ymax=ymax)
-            assert(ax.get_ylim()[1] <= ymax)
-            assert(ax.get_ylim()[0] >= ymin)
-            plt.close()
-        except ImportError:
-            if 'fastkde' not in sys.modules:
-                pass
+        # Check ymin and ymax
+        ax = plt.gca()
+        contour_plot_2d(ax, data_x, data_y, ymin=ymin, ymax=ymax)
+        assert(ax.get_ylim()[1] <= ymax)
+        assert(ax.get_ylim()[0] >= ymin)
+        plt.close()
+
+        # Check q
+        ax = plt.gca()
+        contour_plot_2d(ax, data_x, data_y, q=0)
+        plt.close()
+    except ImportError:
+        if 'fastkde' not in sys.modules:
+            pass
 
 
 def test_scatter_plot_2d():
@@ -408,6 +413,11 @@ def test_scatter_plot_2d():
     ax = plt.gca()
     scatter_plot_2d(ax, data_x, data_y, ymax=ymax)
     assert(ax.get_ylim()[1] <= ymax)
+    plt.close()
+
+    # Check q
+    ax = plt.gca()
+    scatter_plot_2d(ax, data_x, data_y, q=0)
     plt.close()
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -324,7 +324,8 @@ def test_hist_plot_2d():
     assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
 
 
-@pytest.mark.parametrize('contour_plot_2d', [kde_contour_plot_2d, fastkde_contour_plot_2d])
+@pytest.mark.parametrize('contour_plot_2d', [kde_contour_plot_2d,
+                                             fastkde_contour_plot_2d])
 def test_contour_plot_2d(contour_plot_2d):
     try:
         ax = plt.gca()


### PR DESCRIPTION
The quantile kwarg `q` introduced in #99 causes warnings and errors in the 2d plots for fastkde, kde, and scatter.
This PR removes it (`kwargs.pop('q', None)`) before calling the plotting functions.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
