### PR TITLE
add tests for nan in data with zero weights causing issues in mean, var, std, cov

### DIFF
--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -57,14 +57,14 @@ class WeightedSeries(_WeightedObject, pandas.Series):
         """Weighted mean of the sampled distribution."""
         if self.weight is None:
             return np.average(self)
-        nonzero = self.weight > 0
+        nonzero = self.weight != 0
         return np.average(self[nonzero], weights=self.weight[nonzero])
 
     def var(self):
         """Weighted variance of the sampled distribution."""
         if self.weight is None:
             return np.average((self-self.mean())**2)
-        nonzero = self.weight > 0
+        nonzero = self.weight != 0
         return np.average((self[nonzero]-self.mean())**2,
                           weights=self.weight[nonzero])
 
@@ -122,7 +122,7 @@ class WeightedDataFrame(_WeightedObject, pandas.DataFrame):
         """Weighted mean of the sampled distribution."""
         if self.weight is None:
             return pandas.Series(np.average(self, axis=0), index=self.columns)
-        nonzero = self.weight > 0
+        nonzero = self.weight != 0
         mean = np.average(self[nonzero], weights=self.weight[nonzero], axis=0)
         return pandas.Series(mean, index=self.columns)
 
@@ -131,7 +131,7 @@ class WeightedDataFrame(_WeightedObject, pandas.DataFrame):
         if self.weight is None:
             return pandas.Series(np.average((self-self.mean())**2, axis=0),
                                  index=self.columns)
-        nonzero = self.weight > 0
+        nonzero = self.weight != 0
         var = np.average((self[nonzero]-self.mean())**2,
                          weights=self.weight[nonzero], axis=0)
         return pandas.Series(var, index=self.columns)
@@ -141,7 +141,7 @@ class WeightedDataFrame(_WeightedObject, pandas.DataFrame):
         if self.weight is None:
             return pandas.DataFrame(np.cov(self.T), index=self.columns,
                                     columns=self.columns)
-        nonzero = self.weight > 0
+        nonzero = self.weight != 0
         cov = np.cov(self[nonzero].T, aweights=self.weight[nonzero])
         return pandas.DataFrame(cov, index=self.columns, columns=self.columns)
 

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -55,15 +55,11 @@ class WeightedSeries(_WeightedObject, pandas.Series):
 
     def mean(self):
         """Weighted mean of the sampled distribution."""
-        if self.weight is None:
-            return np.average(self)
         nonzero = self.weight != 0
         return np.average(self[nonzero], weights=self.weight[nonzero])
 
     def var(self):
         """Weighted variance of the sampled distribution."""
-        if self.weight is None:
-            return np.average((self-self.mean())**2)
         nonzero = self.weight != 0
         return np.average((self[nonzero]-self.mean())**2,
                           weights=self.weight[nonzero])
@@ -120,17 +116,12 @@ class WeightedDataFrame(_WeightedObject, pandas.DataFrame):
 
     def mean(self):
         """Weighted mean of the sampled distribution."""
-        if self.weight is None:
-            return pandas.Series(np.average(self, axis=0), index=self.columns)
         nonzero = self.weight != 0
         mean = np.average(self[nonzero], weights=self.weight[nonzero], axis=0)
         return pandas.Series(mean, index=self.columns)
 
     def var(self):
         """Weighted variance of the sampled distribution."""
-        if self.weight is None:
-            return pandas.Series(np.average((self-self.mean())**2, axis=0),
-                                 index=self.columns)
         nonzero = self.weight != 0
         var = np.average((self[nonzero]-self.mean())**2,
                          weights=self.weight[nonzero], axis=0)
@@ -138,9 +129,6 @@ class WeightedDataFrame(_WeightedObject, pandas.DataFrame):
 
     def cov(self):
         """Weighted covariance of the sampled distribution."""
-        if self.weight is None:
-            return pandas.DataFrame(np.cov(self.T), index=self.columns,
-                                    columns=self.columns)
         nonzero = self.weight != 0
         cov = np.cov(self[nonzero].T, aweights=self.weight[nonzero])
         return pandas.DataFrame(cov, index=self.columns, columns=self.columns)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -81,8 +81,6 @@ def test_WeightedDataFrame_constructor():
     assert_array_equal(df.columns, cols)
     return df
 
-    return df
-
 
 def test_WeightedDataFrame_slice():
     df = test_WeightedDataFrame_constructor()
@@ -145,6 +143,22 @@ def test_WeightedDataFrame_compress():
     assert(len(np.unique(unit_weights.index)) == len(unit_weights))
 
 
+def test_WeightedDataFrame_nan():
+    df = test_WeightedDataFrame_constructor()
+
+    df['A'][0] = np.nan
+    df['B'][0] = np.nan
+    df['C'][0] = np.nan
+    assert (np.all(np.isnan(df.mean())))
+    assert (np.all(np.isnan(df.std())))
+    assert (np.all(np.isnan(df.cov())))
+
+    df._weight[0] = 0
+    assert_allclose(df.mean(), 0.5, atol=1e-2)
+    assert_allclose(df.std(), (1./12)**0.5, atol=1e-2)
+    assert_allclose(df.cov(), (1./12)*np.identity(3), atol=1e-2)
+
+
 def test_WeightedSeries_mean():
     series = test_WeightedSeries_constructor()
     mean = series.mean()
@@ -189,3 +203,17 @@ def test_WeightedSeries_compress():
         assert_allclose(i, len(series.compress(i)), rtol=1e-1)
     unit_weights = series.compress(0)
     assert(len(np.unique(unit_weights.index)) == len(unit_weights))
+
+
+def test_WeightedSeries_nan():
+    series = test_WeightedSeries_constructor()
+
+    series[0] = np.nan
+    assert np.isnan(series.mean())
+    assert np.isnan(series.std())
+    assert np.isnan(series.var())
+
+    series._weight[0] = 0
+    assert_allclose(series.mean(), 0.5, atol=1e-2)
+    assert_allclose(series.var(), 1./12, atol=1e-2)
+    assert_allclose(series.std(), (1./12)**0.5, atol=1e-2)


### PR DESCRIPTION
Make a change similar to #102 for statistical functions (mean, var, etc.) in `WeightedSeries` and `WeightedDataFrame` to better handle `nan` in the data.

Fixes #111 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
