### PR TITLE
Bug fix for contour plots

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley
-:Version: 1.3.3
+:Version: 1.3.4
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -483,7 +483,7 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ax.contour(x[i], y[j], pdf[np.ix_(j, i)], levels, zorder=zorder,
                vmin=0, vmax=pdf.max(), linewidths=linewidths, colors='k',
                *args, **kwargs)
-    ax.patches += [plt.Rectangle((0, 0), 1, 1, fc=cmap(0.999), ec=cmap(0.32),
+    ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999), ec=cmap(0.32),
                                  lw=2, label=label)]
 
     ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
@@ -575,7 +575,7 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ax.tricontour(tri, p, contours, zorder=zorder,
                   vmin=0, vmax=p.max(), linewidths=linewidths, colors='k',
                   *args, **kwargs)
-    ax.patches += [plt.Rectangle((0, 0), 1, 1, fc=cmap(0.999), ec=cmap(0.32),
+    ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999), ec=cmap(0.32),
                                  lw=2, label=label)]
 
     ax.set_xlim(*check_bounds(tri.x, xmin, xmax), auto=True)
@@ -659,7 +659,7 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
         image = ax.pcolormesh(x, y, pdf.T, cmap=cmap, vmin=0, vmax=pdf.max(),
                               *args, **kwargs)
 
-    ax.patches += [plt.Rectangle((0, 0), 1, 1, fc=cmap(0.999), ec=cmap(0.32),
+    ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999), ec=cmap(0.32),
                                  lw=2, label=label)]
 
     ax.set_xlim(*check_bounds(x, xmin, xmax), auto=True)

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -168,11 +168,12 @@ def make_2d_axes(params, **kwargs):
     tex = kwargs.pop('tex', {})
     tex = {p: tex[p] if p in tex else p for p in all_params}
     fig = kwargs.pop('fig') if 'fig' in kwargs else plt.figure()
-    if 'subplot_spec' in kwargs:
-        grid = SGS(*axes.shape, hspace=0, wspace=0,
-                   subplot_spec=kwargs.pop('subplot_spec'))
-    else:
-        grid = GS(*axes.shape, hspace=0, wspace=0)
+    spec = kwargs.pop('subplot_spec', None)
+    if axes.shape[0] != 0 and axes.shape[1] != 0:
+        if spec is not None:
+            grid = SGS(*axes.shape, hspace=0, wspace=0, subplot_spec=spec)
+        else:
+            grid = GS(*axes.shape, hspace=0, wspace=0)
 
     if kwargs:
         raise TypeError('Unexpected **kwargs: %r' % kwargs)


### PR DESCRIPTION
# Description

Eagle-eyed anesthetic users will have noted that sometimes there is a small shaded rectangle in the lower left corner of a contour plot canvas. This is caused by the patches that are appended to contour plots in order to generate a pleasing legend icon. The small rectangle can be removed by adjusting the patch to be zero size. This is a very minor bug fix, so should not require any additional tests.

Note that since the recent release of matplotlib 3.3, a couple of the tests now fail due to a change in the behaviour of gridspec. This PR also addresses this by checking before attempting to construct a zero sized grid of plots.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works