### PR TITLE
Unfilled contours and inherit color from cmap

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley
-:Version: 1.3.5
+:Version: 1.3.6
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley
-:Version: 1.3.4
+:Version: 1.3.5
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -269,6 +269,9 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
 
     xmin = kwargs.pop('xmin', None)
     xmax = kwargs.pop('xmax', None)
+    cmap = kwargs.pop('cmap', None)
+    color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
+                                 if cmap is None else cmap(2/3)))
     q = kwargs.pop('q', '5sigma')
     q = quantile_plot_interval(q=q)
 
@@ -279,7 +282,7 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
     p /= p.max()
     i = ((x > quantile(x, q[0], p)) & (x < quantile(x, q[1], p)))
 
-    ans = ax.plot(x[i], p[i], *args, **kwargs)
+    ans = ax.plot(x[i], p[i], color=color, *args, **kwargs)
     ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
     return ans
 
@@ -399,16 +402,20 @@ def hist_plot_1d(ax, data, *args, **kwargs):
         xmax = quantile(data, 0.99, weights)
     range = kwargs.pop('range', (xmin, xmax))
     histtype = kwargs.pop('histtype', 'bar')
+    cmap = kwargs.pop('cmap', None)
+    color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
+                                 if cmap is None else cmap(2/3)))
 
     if plotter == 'astropyhist':
         try:
-            h, edges, bars = hist(data, ax=ax, range=range,
+            h, edges, bars = hist(data, ax=ax, color=color, range=range,
                                   histtype=histtype, *args, **kwargs)
         except NameError:
             raise ImportError("You need to install astropy to use astropyhist")
     else:
-        h, edges, bars = ax.hist(data, range=range, histtype=histtype,
-                                 weights=weights, *args, **kwargs)
+        h, edges, bars = ax.hist(data, color=color, range=range,
+                                 histtype=histtype, weights=weights,
+                                 *args, **kwargs)
 
     if histtype == 'bar':
         for b in bars:

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -35,7 +35,7 @@ from anesthetic.utils import (sample_compression_1d, quantile,
                               triangular_sample_compression_2d,
                               iso_probability_contours,
                               iso_probability_contours_from_samples,
-                              scaled_triangulation)
+                              scaled_triangulation, match_contour_to_contourf)
 from anesthetic.boundary import cut_and_normalise_gaussian
 
 
@@ -504,20 +504,24 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
                             *args, **kwargs)
         for c in contf.collections:
             c.set_cmap(cmap)
-        ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999),
-                                     ec=cmap(0.32), lw=2, label=label)]
+        ax.patches += [plt.Rectangle((0, 0), 0, 0, lw=2, label=label,
+                                     fc=cmap(0.999), ec=cmap(0.32))]
         cmap = None
     else:
-        contf = None
-        cmap = kwargs.pop('cmap', None)
-        edgecolor = edgecolor if cmap is None else None
         linewidths = kwargs.pop('linewidths',
                                 plt.rcParams.get('lines.linewidth'))
-        ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=None, ec=edgecolor,
-                                     lw=2, label=label)]
+        cmap = kwargs.pop('cmap', None)
+        contf = None
+        ax.patches += [
+            plt.Rectangle((0, 0), 0, 0, lw=2, label=label,
+                          fc='None' if cmap is None else cmap(0.999),
+                          ec=edgecolor if cmap is None else cmap(0.32))
+        ]
+        edgecolor = edgecolor if cmap is None else None
 
+    vmin, vmax = match_contour_to_contourf(levels, vmin=0, vmax=pdf.max())
     cont = ax.contour(x[i], y[j], pdf[np.ix_(j, i)], levels, zorder=zorder,
-                      vmin=0, vmax=0.32 * pdf.max(), linewidths=linewidths,
+                      vmin=vmin, vmax=vmax, linewidths=linewidths,
                       colors=edgecolor, cmap=cmap, *args, **kwargs)
 
     ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
@@ -613,19 +617,24 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
                                vmin=0, vmax=p.max(), *args, **kwargs)
         for c in contf.collections:
             c.set_cmap(cmap)
-        ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999),
-                                     ec=cmap(0.32), lw=2, label=label)]
+        ax.patches += [plt.Rectangle((0, 0), 0, 0, lw=2, label=label,
+                                     fc=cmap(0.999), ec=cmap(0.32))]
         cmap = None
     else:
-        contf = None
+        linewidths = kwargs.pop('linewidths',
+                                plt.rcParams.get('lines.linewidth'))
         cmap = kwargs.pop('cmap', None)
+        contf = None
+        ax.patches += [
+            plt.Rectangle((0, 0), 0, 0, lw=2, label=label,
+                          fc='None' if cmap is None else cmap(0.999),
+                          ec=edgecolor if cmap is None else cmap(0.32))
+        ]
         edgecolor = edgecolor if cmap is None else None
-        linewidths = kwargs.pop('linewidths', 1.5)
-        ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=None, ec=edgecolor,
-                                     lw=2, label=label)]
 
+    vmin, vmax = match_contour_to_contourf(contours, vmin=0, vmax=p.max())
     cont = ax.tricontour(tri, p, contours, zorder=zorder,
-                         vmin=0, vmax=0.32 * p.max(), linewidths=linewidths,
+                         vmin=vmin, vmax=vmax, linewidths=linewidths,
                          colors=edgecolor, cmap=cmap, *args, **kwargs)
 
     ax.set_xlim(*check_bounds(tri.x, xmin, xmax), auto=True)

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -623,7 +623,7 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
         ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=None, ec=edgecolor,
                                      lw=2, label=label)]
 
-    cont = ax.tricontour(tri, p, contours, zorder=zorder, vmin=0, vmax=p.max(),
+    cont = ax.tricontour(tri, p, contours, zorder=zorder, vmin=0, vmax=0.32 * p.max(),
                          linewidths=linewidths, colors=edgecolor, cmap=cmap,
                          *args, **kwargs)
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -271,7 +271,7 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
     xmax = kwargs.pop('xmax', None)
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
-                                 if cmap is None else cmap(2/3)))
+                                 if cmap is None else cmap(2. / 3.)))
     q = kwargs.pop('q', '5sigma')
     q = quantile_plot_interval(q=q)
 
@@ -331,7 +331,7 @@ def kde_plot_1d(ax, data, *args, **kwargs):
     ncompress = kwargs.pop('ncompress', 1000)
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
-                                 if cmap is None else cmap(2/3)))
+                                 if cmap is None else cmap(2. / 3.)))
     q = kwargs.pop('q', '5sigma')
     q = quantile_plot_interval(q=q)
 
@@ -404,7 +404,7 @@ def hist_plot_1d(ax, data, *args, **kwargs):
     histtype = kwargs.pop('histtype', 'bar')
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
-                                 if cmap is None else cmap(2/3)))
+                                 if cmap is None else cmap(2. / 3.)))
 
     if plotter == 'astropyhist':
         try:
@@ -730,7 +730,7 @@ def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
     markersize = kwargs.pop('markersize', 1)
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
-                                 if cmap is None else cmap(2/3)))
+                                 if cmap is None else cmap(2. / 3.)))
 
     points = ax.plot(data_x, data_y, 'o', color=color, markersize=markersize,
                      *args, **kwargs)

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -516,7 +516,7 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
                                      lw=2, label=label)]
 
     cont = ax.contour(x[i], y[j], pdf[np.ix_(j, i)], levels, zorder=zorder,
-                      vmin=0, vmax=pdf.max(), linewidths=linewidths,
+                      vmin=0, vmax=0.32 * pdf.max(), linewidths=linewidths,
                       colors=edgecolor, cmap=cmap, *args, **kwargs)
 
     ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
@@ -623,9 +623,9 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
         ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=None, ec=edgecolor,
                                      lw=2, label=label)]
 
-    cont = ax.tricontour(tri, p, contours, zorder=zorder, vmin=0, vmax=0.32 * p.max(),
-                         linewidths=linewidths, colors=edgecolor, cmap=cmap,
-                         *args, **kwargs)
+    cont = ax.tricontour(tri, p, contours, zorder=zorder,
+                         vmin=0, vmax=0.32 * p.max(), linewidths=linewidths,
+                         colors=edgecolor, cmap=cmap, *args, **kwargs)
 
     ax.set_xlim(*check_bounds(tri.x, xmin, xmax), auto=True)
     ax.set_ylim(*check_bounds(tri.y, ymin, ymax), auto=True)

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -609,7 +609,7 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
         linewidths = kwargs.pop('linewidths', 0.5)
         cmap = kwargs.pop('cmap', basic_cmap(facecolor))
         contf = ax.tricontourf(tri, p, contours, cmap=cmap, zorder=zorder,
-                              vmin=0, vmax=p.max(), *args, **kwargs)
+                               vmin=0, vmax=p.max(), *args, **kwargs)
         for c in contf.collections:
             c.set_cmap(cmap)
         ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999),
@@ -879,7 +879,7 @@ def quantile_plot_interval(q):
 
 
 def normalize_kwargs(kwargs, alias_mapping=None, drop=None):
-    """Helper function to normalize kwarg inputs.
+    """Normalize kwarg inputs.
 
     Works the same way as cbook.normalize_kwargs, but additionally allows to
     drop kwargs.

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -541,8 +541,7 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
                                          linestyles=['linestyle', 'ls'],
                                          color=['c'],
                                          facecolor=['fc'],
-                                         edgecolor=['ec']),
-                                    forbidden=['colors'])
+                                         edgecolor=['ec']))
     xmin = kwargs.pop('xmin', None)
     xmax = kwargs.pop('xmax', None)
     ymin = kwargs.pop('ymin', None)

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -583,18 +583,18 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
 
     contours = iso_probability_contours_from_samples(p, weights=w)
 
-    cbar = None
     if facecolor is not None:
         linewidths = kwargs.pop('linewidths', 0.5)
         cmap = kwargs.pop('cmap', basic_cmap(facecolor))
-        cbar = ax.tricontourf(tri, p, contours, cmap=cmap, zorder=zorder,
+        contf = ax.tricontourf(tri, p, contours, cmap=cmap, zorder=zorder,
                               vmin=0, vmax=p.max(), *args, **kwargs)
-        for c in cbar.collections:
+        for c in contf.collections:
             c.set_cmap(cmap)
         ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999),
                                      ec=cmap(0.32), lw=2, label=label)]
         cmap = None
     else:
+        contf = None
         cmap = kwargs.pop('cmap', None)
         edgecolor = edgecolor if cmap is None else None
         linewidths = kwargs.pop('linewidths', 1.5)
@@ -604,11 +604,10 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     cont = ax.tricontour(tri, p, contours, zorder=zorder, vmin=0, vmax=p.max(),
                          linewidths=linewidths, colors=edgecolor, cmap=cmap,
                          *args, **kwargs)
-    cbar = cont if cbar is None else cbar
 
     ax.set_xlim(*check_bounds(tri.x, xmin, xmax), auto=True)
     ax.set_ylim(*check_bounds(tri.y, ymin, ymax), auto=True)
-    return cbar
+    return contf, cont
 
 
 def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -326,6 +326,9 @@ def kde_plot_1d(ax, data, *args, **kwargs):
     xmax = kwargs.pop('xmax', None)
     weights = kwargs.pop('weights', None)
     ncompress = kwargs.pop('ncompress', 1000)
+    cmap = kwargs.pop('cmap', None)
+    color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
+                                 if cmap is None else cmap(2/3)))
     q = kwargs.pop('q', '5sigma')
     q = quantile_plot_interval(q=q)
 
@@ -345,7 +348,7 @@ def kde_plot_1d(ax, data, *args, **kwargs):
     sigma = np.sqrt(kde.covariance[0, 0])
     pp = cut_and_normalise_gaussian(x[i], p[i], sigma, xmin, xmax)
     pp /= pp.max()
-    ans = ax.plot(x[i], pp, *args, **kwargs)
+    ans = ax.plot(x[i], pp, color=color, *args, **kwargs)
     ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
     return ans
 
@@ -717,8 +720,11 @@ def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
     kwargs.pop('q', None)
     kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
     markersize = kwargs.pop('markersize', 1)
+    cmap = kwargs.pop('cmap', None)
+    color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
+                                 if cmap is None else cmap(2/3)))
 
-    points = ax.plot(data_x, data_y, 'o', markersize=markersize,
+    points = ax.plot(data_x, data_y, 'o', color=color, markersize=markersize,
                      *args, **kwargs)
     ax.set_xlim(*check_bounds(data_x, xmin, xmax), auto=True)
     ax.set_ylim(*check_bounds(data_y, ymin, ymax), auto=True)

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -271,7 +271,7 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
     xmax = kwargs.pop('xmax', None)
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
-                                 if cmap is None else cmap(2. / 3.)))
+                                 if cmap is None else cmap(0.68)))
     q = kwargs.pop('q', '5sigma')
     q = quantile_plot_interval(q=q)
 
@@ -335,7 +335,7 @@ def kde_plot_1d(ax, data, *args, **kwargs):
     ncompress = kwargs.pop('ncompress', 1000)
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
-                                 if cmap is None else cmap(2. / 3.)))
+                                 if cmap is None else cmap(0.68)))
     q = kwargs.pop('q', '5sigma')
     q = quantile_plot_interval(q=q)
 
@@ -408,7 +408,7 @@ def hist_plot_1d(ax, data, *args, **kwargs):
     histtype = kwargs.pop('histtype', 'bar')
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
-                                 if cmap is None else cmap(2. / 3.)))
+                                 if cmap is None else cmap(0.68)))
 
     if plotter == 'astropyhist':
         try:
@@ -755,7 +755,7 @@ def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
     markersize = kwargs.pop('markersize', 1)
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
-                                 if cmap is None else cmap(2. / 3.)))
+                                 if cmap is None else cmap(0.68)))
 
     points = ax.plot(data_x, data_y, 'o', color=color, markersize=markersize,
                      *args, **kwargs)

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -511,7 +511,8 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
         contf = None
         cmap = kwargs.pop('cmap', None)
         edgecolor = edgecolor if cmap is None else None
-        linewidths = kwargs.pop('linewidths', 1.5)
+        linewidths = kwargs.pop('linewidths',
+                                plt.rcParams.get('lines.linewidth'))
         ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=None, ec=edgecolor,
                                      lw=2, label=label)]
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -528,9 +528,11 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     """
     kwargs = cbook.normalize_kwargs(kwargs,
                                     dict(linewidths=['linewidth', 'lw'],
+                                         linestyles=['linestyle', 'ls'],
                                          color=['c'],
                                          facecolor=['fc'],
-                                         edgecolor=['ec']))
+                                         edgecolor=['ec']),
+                                    forbidden=['colors'])
     xmin = kwargs.pop('xmin', None)
     xmax = kwargs.pop('xmax', None)
     ymin = kwargs.pop('ymin', None)
@@ -541,7 +543,7 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     zorder = kwargs.pop('zorder', 1)
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
     facecolor = kwargs.pop('facecolor', color)
-    edgecolor = kwargs.pop('edgecolor', 'k')
+    edgecolor = kwargs.pop('edgecolor', color if facecolor is None else 'k')
     kwargs.pop('q', None)
 
     if len(data_x) == 0 or len(data_y) == 0:
@@ -582,13 +584,17 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
             c.set_cmap(cmap)
         ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999),
                                      ec=cmap(0.32), lw=2, label=label)]
+        cmap = None
     else:
+        cmap = kwargs.pop('cmap', None)
+        edgecolor = edgecolor if cmap is None else None
         linewidths = kwargs.pop('linewidths', 1.5)
         ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=None, ec=edgecolor,
                                      lw=2, label=label)]
 
     ax.tricontour(tri, p, contours, zorder=zorder, vmin=0, vmax=p.max(),
-                  linewidths=linewidths, colors=edgecolor, *args, **kwargs)
+                  linewidths=linewidths, colors=edgecolor, cmap=cmap,
+                  *args, **kwargs)
 
     ax.set_xlim(*check_bounds(tri.x, xmin, xmax), auto=True)
     ax.set_ylim(*check_bounds(tri.y, ymin, ymax), auto=True)

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -602,9 +602,10 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
         ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=None, ec=edgecolor,
                                      lw=2, label=label)]
 
-    ax.tricontour(tri, p, contours, zorder=zorder, vmin=0, vmax=p.max(),
-                  linewidths=linewidths, colors=edgecolor, cmap=cmap,
-                  *args, **kwargs)
+    cont = ax.tricontour(tri, p, contours, zorder=zorder, vmin=0, vmax=p.max(),
+                         linewidths=linewidths, colors=edgecolor, cmap=cmap,
+                         *args, **kwargs)
+    cbar = cont if cbar is None else cbar
 
     ax.set_xlim(*check_bounds(tri.x, xmin, xmax), auto=True)
     ax.set_ylim(*check_bounds(tri.y, ymin, ymax), auto=True)

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -359,3 +359,16 @@ def sample_compression_1d(x, w=None, n=1000):
 def is_int(x):
     """Test whether x is an integer."""
     return isinstance(x, int) or isinstance(x, np.integer)
+
+
+def match_contour_to_contourf(contours, vmin, vmax):
+    """Get needed `vmin, vmax` to match `contour` colors to `contourf` colors.
+
+    `contourf` uses the arithmetic mean of contour levels to assign colors,
+    whereas `contour` uses the contour level directly. To get the same colors
+    for `contour` lines as for `contourf` faces, we need some fiddly algebra.
+    """
+    c0, c1, c2 = contours
+    vmin = (c0 * c2 - c1 ** 2 + 2 * vmin * (c1 - c0)) / (c2 - c0)
+    vmax = (c0 * c2 - c1 ** 2 + 2 * vmax * (c1 - c0)) / (c2 - c0)
+    return vmin, vmax

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -51,7 +51,8 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "from anesthetic import MCMCSamples\n",
+    "import matplotlib.pyplot as plt\n",
+    "from anesthetic import MCMCSamples, make_2d_axes\n",
     "mcmc_root = 'plikHM_TTTEEE_lowl_lowE_lensing/base_plikHM_TTTEEE_lowl_lowE_lensing'\n",
     "mcmc = MCMCSamples(root=mcmc_root)"
    ]
@@ -151,6 +152,70 @@
    "outputs": [],
    "source": [
     "mcmc.plot_2d([['omegabh2','omegach2','H0'], ['H0','omegach2']]);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Changing the appearance\n",
+    "\n",
+    "Anesthetic tries to follow matplotlib conventions as much as possible, so \n",
+    "most changes to the appearance should be relatively straight forward. \n",
+    "Here are some examples:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* **figure size**:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(5, 5))\n",
+    "fig, axes = make_2d_axes(['omegabh2', 'omegach2', 'H0'], fig=fig, tex=mcmc.tex)\n",
+    "mcmc.plot_2d(axes);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* **legends**:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = make_2d_axes(['omegabh2', 'omegach2', 'H0'], tex=mcmc.tex)\n",
+    "mcmc.plot_2d(axes, label='Posterior');\n",
+    "axes.iloc[-1, 0].legend(bbox_to_anchor=(len(axes), len(axes)), loc='upper left');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* **unfilled contours**:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = make_2d_axes(['omegabh2', 'omegach2', 'H0'], tex=mcmc.tex)\n",
+    "mcmc.plot_2d(axes, fc=None);"
    ]
   },
   {
@@ -356,8 +421,7 @@
    "metadata": {},
    "source": [
     "With nested samples, we can plot the prior (or any temperature), by\n",
-    " passing beta=0. We also introduce here the helper function ``get_legend_proxy``\n",
-    " for creating figure legends."
+    " passing beta=0. We also introduce here how to create figure legends."
    ]
   },
   {
@@ -410,7 +474,25 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -205,7 +205,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* **unfilled contours**:"
+    "* **unfilled contours** &nbsp; & &nbsp; **modifying individual axes**:"
    ]
   },
   {
@@ -215,7 +215,9 @@
    "outputs": [],
    "source": [
     "fig, axes = make_2d_axes(['omegabh2', 'omegach2', 'H0'], tex=mcmc.tex)\n",
-    "mcmc.plot_2d(axes, fc=None);"
+    "mcmc.plot_2d(axes.iloc[0:1, :], types=dict(upper='kde', lower='kde', diagonal='kde'), fc=None);\n",
+    "mcmc.plot_2d(axes.iloc[1:2, :], types=dict(upper='kde', lower='kde', diagonal='kde'), fc=None, cmap=plt.cm.Oranges, lw=3);\n",
+    "mcmc.plot_2d(axes.iloc[2:3, :], types=dict(upper='kde', lower='kde', diagonal='kde'), fc='C2', ec='C3', c='C4', lw=2);"
    ]
   },
   {

--- a/demo.py
+++ b/demo.py
@@ -71,10 +71,12 @@ fig, axes = make_2d_axes(['omegabh2', 'omegach2', 'H0'], tex=mcmc.tex)
 mcmc.plot_2d(axes, label='Posterior');
 axes.iloc[-1, 0].legend(bbox_to_anchor=(len(axes), len(axes)), loc='upper left');
 
-#| * unfilled contours:
+#| * unfilled contours  &  modifying individual axes:
 
 fig, axes = make_2d_axes(['omegabh2', 'omegach2', 'H0'], tex=mcmc.tex)
-mcmc.plot_2d(axes, fc=None);
+mcmc.plot_2d(axes.iloc[0:1, :], types=dict(upper='kde', lower='kde', diagonal='kde'), fc=None);
+mcmc.plot_2d(axes.iloc[1:2, :], types=dict(upper='kde', lower='kde', diagonal='kde'), fc=None, cmap=plt.cm.Oranges, lw=3);
+mcmc.plot_2d(axes.iloc[2:3, :], types=dict(upper='kde', lower='kde', diagonal='kde'), fc='C2', ec='C3', c='C4', lw=2);
 
 #| ## Defining new parameters
 #|

--- a/demo.py
+++ b/demo.py
@@ -23,8 +23,8 @@ for filename in ["plikHM_TTTEEE_lowl_lowE_lensing.tar.gz","plikHM_TTTEEE_lowl_lo
 #| ## Marginalised posterior plotting
 #| Import anesthetic and load the MCMC samples:
 
-%matplotlib inline
-from anesthetic import MCMCSamples
+import matplotlib.pyplot as plt
+from anesthetic import MCMCSamples, make_2d_axes
 mcmc_root = 'plikHM_TTTEEE_lowl_lowE_lensing/base_plikHM_TTTEEE_lowl_lowE_lensing'
 mcmc = MCMCSamples(root=mcmc_root)
 
@@ -52,6 +52,29 @@ mcmc.plot_2d([['omegabh2','omegach2','H0'], ['logA', 'ns']]);
 #| Rectangle plots are pretty flexible with what they can do:
 
 mcmc.plot_2d([['omegabh2','omegach2','H0'], ['H0','omegach2']]);
+
+#| ## Changing the appearance
+#| 
+#| Anesthetic tries to follow matplotlib conventions as much as possible, so 
+#| most changes to the appearance should be relatively straight forward. 
+#| Here are some examples:
+#| 
+#| * figure size:
+
+fig = plt.figure(figsize=(5, 5))
+fig, axes = make_2d_axes(['omegabh2', 'omegach2', 'H0'], fig=fig, tex=mcmc.tex)
+mcmc.plot_2d(axes);
+
+#| * legends:
+
+fig, axes = make_2d_axes(['omegabh2', 'omegach2', 'H0'], tex=mcmc.tex)
+mcmc.plot_2d(axes, label='Posterior');
+axes.iloc[-1, 0].legend(bbox_to_anchor=(len(axes), len(axes)), loc='upper left');
+
+#| * unfilled contours:
+
+fig, axes = make_2d_axes(['omegabh2', 'omegach2', 'H0'], tex=mcmc.tex)
+mcmc.plot_2d(axes, fc=None);
 
 #| ## Defining new parameters
 #|
@@ -120,8 +143,7 @@ fig, axes = mcmc.plot_2d(['sigma8','omegab'])
 nested.plot_2d(axes=axes);
 
 #| With nested samples, we can plot the prior (or any temperature), by
-#| passing beta=0. We also introduce here the helper function ``get_legend_proxy``
-#| for creating figure legends.
+#| passing beta=0. We also introduce here how to create figure legends."
 
 prior = nested.set_beta(0)
 fig, axes = prior.plot_2d(['ns','tau'], label='prior')

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -202,6 +202,8 @@ def test_kde_plot_1d(plot_1d):
         # Check arguments are passed onward to underlying function
         line, = plot_1d(ax, data, color='r')
         assert(line.get_color() == 'r')
+        line, = plot_1d(ax, data, cmap=plt.cm.Blues)
+        assert(line.get_color() == plt.cm.Blues(2 / 3))
 
         # Check xmin
         xmin = -0.5
@@ -265,9 +267,16 @@ def test_hist_plot_1d():
                                 color='r', alpha=0.5, plotter=p)
             cc = ColorConverter.to_rgba('r', alpha=0.5)
             assert(np.all([b.get_fc() == cc for b in bars]))
+            bars = hist_plot_1d(ax, data, histtype='bar',
+                                cmap=plt.cm.viridis, alpha=0.5, plotter=p)
+            cc = ColorConverter.to_rgba(plt.cm.viridis(2 / 3), alpha=0.5)
+            assert(np.all([b.get_fc() == cc for b in bars]))
             polygon, = hist_plot_1d(ax, data, histtype='step',
                                     color='r', alpha=0.5, plotter=p)
             assert(polygon.get_ec() == ColorConverter.to_rgba('r', alpha=0.5))
+            polygon, = hist_plot_1d(ax, data, histtype='step',
+                                    cmap=plt.cm.viridis, color='r', plotter=p)
+            assert(polygon.get_ec() == ColorConverter.to_rgba('r'))
 
             # Check xmin
             for xmin in [-np.inf, -0.5]:
@@ -382,6 +391,14 @@ def test_contour_plot_2d(contour_plot_2d):
         ax = plt.gca()
         contour_plot_2d(ax, data_x, data_y, q=0)
         plt.close()
+
+        #Check unfilled
+        ax = plt.gca()
+        contour_plot_2d(ax, data_x, data_y, edgecolor='C0')
+        contour_plot_2d(ax, data_x, data_y, facecolor=None, ec='C1')
+        contour_plot_2d(ax, data_x, data_y, fc=None, cmap=plt.cm.viridis)
+        plt.close()
+
     except ImportError:
         if 'fastkde' not in sys.modules:
             pass
@@ -414,6 +431,13 @@ def test_scatter_plot_2d():
     ax = plt.gca()
     scatter_plot_2d(ax, data_x, data_y, ymax=ymax)
     assert(ax.get_ylim()[1] <= ymax)
+    plt.close()
+
+    ax = plt.gca()
+    points, = scatter_plot_2d(ax, data_x, data_y, color='C0')
+    assert (points.get_color() == 'C0')
+    points, = scatter_plot_2d(ax, data_x, data_y, cmap=plt.cm.viridis)
+    assert (points.get_color() == plt.cm.viridis(2 / 3))
     plt.close()
 
     # Check q

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -341,11 +341,13 @@ def test_contour_plot_2d(contour_plot_2d):
         np.random.seed(1)
         data_x = np.random.randn(1000)
         data_y = np.random.randn(1000)
-        c = contour_plot_2d(ax, data_x, data_y)
+        cf, ct = contour_plot_2d(ax, data_x, data_y)
         if contour_plot_2d is fastkde_contour_plot_2d:
-            assert(isinstance(c, QuadContourSet))
+            assert(isinstance(cf, QuadContourSet))
+            assert(isinstance(ct, QuadContourSet))
         elif contour_plot_2d is kde_contour_plot_2d:
-            assert(isinstance(c, TriContourSet))
+            assert(isinstance(cf, TriContourSet))
+            assert(isinstance(ct, TriContourSet))
 
         xmin, xmax, ymin, ymax = -0.5, 0.5, -0.5, 0.5
 
@@ -394,11 +396,17 @@ def test_contour_plot_2d(contour_plot_2d):
 
         # Check unfilled
         ax = plt.gca()
-        contour_plot_2d(ax, data_x, data_y, edgecolor='C0')
-        p = contour_plot_2d(ax, data_x, data_y, facecolor=None, ec='C1')
-        assert p.colors == 'C1'
-        p = contour_plot_2d(ax, data_x, data_y, fc=None, cmap=plt.cm.viridis)
-        assert p.get_cmap() == plt.cm.viridis
+        cf, ct = contour_plot_2d(ax, data_x, data_y, edgecolor='C0')
+        assert ct.colors == 'C0'
+        cf, ct = contour_plot_2d(ax, data_x, data_y, ec='C0', cmap=plt.cm.Reds)
+        assert cf.get_cmap() == plt.cm.Reds
+        assert ct.colors == 'C0'
+        cf, ct = contour_plot_2d(ax, data_x, data_y, facecolor=None, ec='C1')
+        assert cf is None
+        assert ct.colors == 'C1'
+        cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None, cmap=plt.cm.Reds)
+        assert cf is None
+        assert ct.get_cmap() == plt.cm.Reds
         plt.close()
 
     except ImportError:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -392,7 +392,7 @@ def test_contour_plot_2d(contour_plot_2d):
         contour_plot_2d(ax, data_x, data_y, q=0)
         plt.close()
 
-        #Check unfilled
+        # Check unfilled
         ax = plt.gca()
         contour_plot_2d(ax, data_x, data_y, edgecolor='C0')
         contour_plot_2d(ax, data_x, data_y, facecolor=None, ec='C1')

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -334,9 +334,8 @@ def test_hist_plot_2d():
     assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
 
 
-# @pytest.mark.parametrize('contour_plot_2d', [kde_contour_plot_2d,
-#                                              fastkde_contour_plot_2d])
-@pytest.mark.parametrize('contour_plot_2d', [kde_contour_plot_2d])
+@pytest.mark.parametrize('contour_plot_2d', [kde_contour_plot_2d,
+                                             fastkde_contour_plot_2d])
 def test_contour_plot_2d(contour_plot_2d):
     try:
         ax = plt.gca()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -203,7 +203,7 @@ def test_kde_plot_1d(plot_1d):
         line, = plot_1d(ax, data, color='r')
         assert(line.get_color() == 'r')
         line, = plot_1d(ax, data, cmap=plt.cm.Blues)
-        assert(line.get_color() == plt.cm.Blues(2 / 3))
+        assert(line.get_color() == plt.cm.Blues(0.68))
 
         # Check xmin
         xmin = -0.5
@@ -269,7 +269,7 @@ def test_hist_plot_1d():
             assert(np.all([b.get_fc() == cc for b in bars]))
             bars = hist_plot_1d(ax, data, histtype='bar',
                                 cmap=plt.cm.viridis, alpha=0.5, plotter=p)
-            cc = ColorConverter.to_rgba(plt.cm.viridis(2 / 3), alpha=0.5)
+            cc = ColorConverter.to_rgba(plt.cm.viridis(0.68), alpha=0.5)
             assert(np.all([b.get_fc() == cc for b in bars]))
             polygon, = hist_plot_1d(ax, data, histtype='step',
                                     color='r', alpha=0.5, plotter=p)
@@ -447,7 +447,7 @@ def test_scatter_plot_2d():
     points, = scatter_plot_2d(ax, data_x, data_y, color='C0', lw=1)
     assert (points.get_color() == 'C0')
     points, = scatter_plot_2d(ax, data_x, data_y, cmap=plt.cm.viridis)
-    assert (points.get_color() == plt.cm.viridis(2 / 3))
+    assert (points.get_color() == plt.cm.viridis(0.68))
     points, = scatter_plot_2d(ax, data_x, data_y, c='C0', fc='C1', ec='C2')
     assert (points.get_color() == 'C0')
     assert (points.get_markerfacecolor() == 'C1')

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -444,10 +444,14 @@ def test_scatter_plot_2d():
     plt.close()
 
     ax = plt.gca()
-    points, = scatter_plot_2d(ax, data_x, data_y, color='C0')
+    points, = scatter_plot_2d(ax, data_x, data_y, color='C0', lw=1)
     assert (points.get_color() == 'C0')
     points, = scatter_plot_2d(ax, data_x, data_y, cmap=plt.cm.viridis)
     assert (points.get_color() == plt.cm.viridis(2 / 3))
+    points, = scatter_plot_2d(ax, data_x, data_y, c='C0', fc='C1', ec='C2')
+    assert (points.get_color() == 'C0')
+    assert (points.get_markerfacecolor() == 'C1')
+    assert (points.get_markeredgecolor() == 'C2')
     plt.close()
 
     # Check q

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -395,8 +395,10 @@ def test_contour_plot_2d(contour_plot_2d):
         # Check unfilled
         ax = plt.gca()
         contour_plot_2d(ax, data_x, data_y, edgecolor='C0')
-        contour_plot_2d(ax, data_x, data_y, facecolor=None, ec='C1')
-        contour_plot_2d(ax, data_x, data_y, fc=None, cmap=plt.cm.viridis)
+        p = contour_plot_2d(ax, data_x, data_y, facecolor=None, ec='C1')
+        assert p.colors == 'C1'
+        p = contour_plot_2d(ax, data_x, data_y, fc=None, cmap=plt.cm.viridis)
+        assert p.get_cmap() == plt.cm.viridis
         plt.close()
 
     except ImportError:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -7,7 +7,8 @@ import matplotlib.gridspec as gs
 from anesthetic.plot import (make_1d_axes, make_2d_axes, kde_plot_1d,
                              fastkde_plot_1d, hist_plot_1d, hist_plot_2d,
                              fastkde_contour_plot_2d, kde_contour_plot_2d,
-                             scatter_plot_2d, quantile_plot_interval)
+                             scatter_plot_2d, quantile_plot_interval,
+                             basic_cmap)
 from numpy.testing import assert_array_equal
 
 from matplotlib.contour import QuadContourSet
@@ -333,8 +334,9 @@ def test_hist_plot_2d():
     assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
 
 
-@pytest.mark.parametrize('contour_plot_2d', [kde_contour_plot_2d,
-                                             fastkde_contour_plot_2d])
+# @pytest.mark.parametrize('contour_plot_2d', [kde_contour_plot_2d,
+#                                              fastkde_contour_plot_2d])
+@pytest.mark.parametrize('contour_plot_2d', [kde_contour_plot_2d])
 def test_contour_plot_2d(contour_plot_2d):
     try:
         ax = plt.gca()
@@ -395,18 +397,25 @@ def test_contour_plot_2d(contour_plot_2d):
         plt.close()
 
         # Check unfilled
+        cmap = basic_cmap('C2')
         ax = plt.gca()
+        cf1, ct1 = contour_plot_2d(ax, data_x, data_y, facecolor='C2')
+        cf2, ct2 = contour_plot_2d(ax, data_x, data_y, fc='None', cmap=cmap)
+        # filled `contourf` and unfilled `contour` colors are the same:
+        assert cf1.tcolors[0] == ct2.tcolors[0]
+        assert cf1.tcolors[1] == ct2.tcolors[1]
         cf, ct = contour_plot_2d(ax, data_x, data_y, edgecolor='C0')
         assert ct.colors == 'C0'
         cf, ct = contour_plot_2d(ax, data_x, data_y, ec='C0', cmap=plt.cm.Reds)
         assert cf.get_cmap() == plt.cm.Reds
         assert ct.colors == 'C0'
-        cf, ct = contour_plot_2d(ax, data_x, data_y, facecolor=None, ec='C1')
+        cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None, ec='C1')
         assert cf is None
         assert ct.colors == 'C1'
         cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None, cmap=plt.cm.Reds)
         assert cf is None
         assert ct.get_cmap() == plt.cm.Reds
+        assert ct.colors is None
         plt.close()
 
     except ImportError:


### PR DESCRIPTION
Been wanting the option to create unfilled contours for  a while. Particularly useful when faced with slim contours such as for inflation models in an ns-r-plot, which basically only consist of contour lines and thus all appear black. 

Also, if `cmap` is provided instead of `color`, then `color` is set to the colour of the inner contours for line plots or scatter plots.

# Todo:

- [x] Adapt changes also for `fastkde_plot_2d` once happy with changes for `kde_plot_2d`.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
