### PR TITLE
Freezing pandas at 1.0.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley
-:Version: 1.3.4
+:Version: 1.3.5
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scipy>=1.2.0
 numpy
-pandas
+pandas<=1.0.5
 matplotlib>=3.1.2

--- a/requirements_extras.txt
+++ b/requirements_extras.txt
@@ -1,6 +1,6 @@
 scipy
 numpy
-pandas
+pandas<=1.0.5
 matplotlib>=3.1.2
 fastkde
 astropy

--- a/requirements_extras.txt
+++ b/requirements_extras.txt
@@ -1,4 +1,4 @@
-scipy
+scipy>=1.2.0
 numpy
 pandas<=1.0.5
 matplotlib>=3.1.2

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='anesthetic',
       url='https://github.com/williamjameshandley/anesthetic',
       packages=find_packages(),
       scripts=['scripts/anesthetic'],
-      install_requires=['numpy', 'scipy', 'pandas<=1.0.5', 'matplotlib'],
+      install_requires=['numpy', 'scipy>=1.2.0', 'pandas<=1.0.5', 'matplotlib>=3.1.2'],
       setup_requires=['pytest-runner'],
       extras_require={
           'docs': ['sphinx', 'sphinx_rtd_theme', 'numpydoc'],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='anesthetic',
       url='https://github.com/williamjameshandley/anesthetic',
       packages=find_packages(),
       scripts=['scripts/anesthetic'],
-      install_requires=['numpy', 'scipy', 'pandas', 'matplotlib'],
+      install_requires=['numpy', 'scipy', 'pandas<=1.0.5', 'matplotlib'],
       setup_requires=['pytest-runner'],
       extras_require={
           'docs': ['sphinx', 'sphinx_rtd_theme', 'numpydoc'],


### PR DESCRIPTION
# Description

Following #115  which notes that master is now broken on account of the pandas update to 1.1, this PR freezes to pandas to 1.0.5 until #115 is resolved

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works