### PR TITLE
Added code to compute insertion indices

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -11,7 +11,7 @@ from anesthetic.plot import (make_1d_axes, make_2d_axes, fastkde_plot_1d,
                              fastkde_contour_plot_2d,
                              kde_contour_plot_2d, hist_plot_2d)
 from anesthetic.read.samplereader import SampleReader
-from anesthetic.utils import (compute_nlive, compute_insertion_indices,
+from anesthetic.utils import (compute_nlive, compute_insertion_indexes,
                               is_int, logsumexp)
 from anesthetic.gui.plot import RunPlotter
 from anesthetic.weighted_pandas import WeightedDataFrame, WeightedSeries
@@ -653,8 +653,8 @@ class NestedSamples(MCMCSamples):
         self.tex['nlive'] = r'$n_{\rm live}$'
         self.beta = self._beta
 
-    def _compute_insertion_indices(self):
-        self['insertion'] = compute_insertion_indices(self.logL.values,
+    def _compute_insertion_indexes(self):
+        self['insertion'] = compute_insertion_indexes(self.logL.values,
                                                       self.logL_birth.values)
 
     _metadata = MCMCSamples._metadata + ['_beta']

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -11,7 +11,8 @@ from anesthetic.plot import (make_1d_axes, make_2d_axes, fastkde_plot_1d,
                              fastkde_contour_plot_2d,
                              kde_contour_plot_2d, hist_plot_2d)
 from anesthetic.read.samplereader import SampleReader
-from anesthetic.utils import compute_nlive, is_int, logsumexp
+from anesthetic.utils import (compute_nlive, compute_insertion_indices,
+                              is_int, logsumexp)
 from anesthetic.gui.plot import RunPlotter
 from anesthetic.weighted_pandas import WeightedDataFrame, WeightedSeries
 
@@ -651,6 +652,10 @@ class NestedSamples(MCMCSamples):
 
         self.tex['nlive'] = r'$n_{\rm live}$'
         self.beta = self._beta
+
+    def _compute_insertion_indices(self):
+        self['insertion'] = compute_insertion_indices(self.logL.values,
+                                                      self.logL_birth.values)
 
     _metadata = MCMCSamples._metadata + ['_beta']
 

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -429,11 +429,11 @@ def insertion_p_value(indexes, nlive, batch=0):
         Kolmogorov-Smirnov test results:
             D: Kolmogorov-Smirnov statistic
             sample_size: sample size
-            p_value: p-value
+            p-value: p-value
             # if batch != 0
             iterations: bounds of batch with minimum p-value
             nbatches: the number of batches in total
-            p_value_uncorrected: p_value without Bonferroni correction
+            uncorrected p-value: p-value without Bonferroni correction
     """
     if batch == 0:
         bins = np.arange(-0.5, nlive + 0.5, 1.)
@@ -448,19 +448,19 @@ def insertion_p_value(indexes, nlive, batch=0):
         ks_result = {}
         ks_result["D"] = D
         ks_result["sample_size"] = sample_size
-        ks_result["p_value"] = kstwobign.sf(K)
+        ks_result["p-value"] = kstwobign.sf(K)
         return ks_result
     else:
         batch = int(batch * nlive)
         batches = [indexes[i:i + batch] for i in range(0, len(indexes), batch)]
         ks_results = [insertion_p_value(c, nlive) for c in batches]
-        ks_result = min(ks_results, key=lambda t: t["p_value"])
+        ks_result = min(ks_results, key=lambda t: t["p-value"])
         index = ks_results.index(ks_result)
 
         ks_result["iterations"] = (index * batch, (index + 1) * batch)
         ks_result["nbatches"] = n = len(batches)
-        ks_result["p_value_uncorrected"] = p = ks_result["p_value"]
-        ks_result["p_value"] = 1. - (1. - p)**n
-        if ks_result["p_value"] == 0.:
-            ks_result["p_value"] = p * n
+        ks_result["uncorrected p-value"] = p = ks_result["p-value"]
+        ks_result["p-value"] = 1. - (1. - p)**n
+        if ks_result["p-value"] == 0.:
+            ks_result["p-value"] = p * n
         return ks_result

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -189,6 +189,30 @@ def compute_nlive(death, birth):
     return nlive.values
 
 
+def compute_insertion_indices(death, birth):
+    """Compute the live point insertion index for each point.
+
+    For more detail, see https://arxiv.org/abs/2006.03371
+
+    Parameters
+    ----------
+    death, birth : array-like
+        list of birth and death contours
+
+    Returns
+    -------
+    indices: np.array
+        live point index at which each live point was inserted
+    """
+    indices = np.zeros_like(birth, dtype=int)
+    for i, (b, d) in enumerate(zip(birth, death)):
+        i_live = (death > b) & (birth <= b)
+        live = death[i_live]
+        live.sort()
+        indices[i] = np.searchsorted(live, d)
+    return indices
+
+
 def unique(a):
     """Find unique elements, retaining order."""
     b = []

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas
 from scipy import special
 from scipy.interpolate import interp1d
+from scipy.stats import kstwobign
 from matplotlib.tri import Triangulation
 
 
@@ -189,7 +190,7 @@ def compute_nlive(death, birth):
     return nlive.values
 
 
-def compute_insertion_indices(death, birth):
+def compute_insertion_indexes(death, birth):
     """Compute the live point insertion index for each point.
 
     For more detail, see https://arxiv.org/abs/2006.03371
@@ -201,16 +202,16 @@ def compute_insertion_indices(death, birth):
 
     Returns
     -------
-    indices: np.array
+    indexes: np.array
         live point index at which each live point was inserted
     """
-    indices = np.zeros_like(birth, dtype=int)
+    indexes = np.zeros_like(birth, dtype=int)
     for i, (b, d) in enumerate(zip(birth, death)):
         i_live = (death > b) & (birth <= b)
         live = death[i_live]
         live.sort()
-        indices[i] = np.searchsorted(live, d)
-    return indices
+        indexes[i] = np.searchsorted(live, d)
+    return indexes
 
 
 def unique(a):
@@ -396,3 +397,70 @@ def match_contour_to_contourf(contours, vmin, vmax):
     vmin = (c0 * c2 - c1 ** 2 + 2 * vmin * (c1 - c0)) / (c2 - c0)
     vmax = (c0 * c2 - c1 ** 2 + 2 * vmax * (c1 - c0)) / (c2 - c0)
     return vmin, vmax
+
+
+def insertion_p_value(indexes, nlive, batch=0):
+    """Compute the p-value from insertion indexes, assuming constant nlive.
+
+    Note that this function doesn't use scipy.stats.kstest as the latter
+    assumes continuous distributions.
+
+    For more detail, see https://arxiv.org/abs/2006.03371
+
+    For a rolling test, you should provide the optional parameter batch!=0. In
+    this case the test computes the p value on consecutive batches of size
+    nlive * batch, selects the smallest one and adjusts for multiple
+    comparisons using a Bonferroni correction.
+
+    Parameters
+    ----------
+    indexes: array-like
+        list of insertion indexes, sorted by death contour
+
+    nlive: int
+        number of live points
+
+    batch: float
+        batch size in units of nlive for a rolling p-value
+
+    Returns
+    -------
+    ks_result: dict
+        Kolmogorov-Smirnov test results:
+            D: Kolmogorov-Smirnov statistic
+            sample_size: sample size
+            p_value: p-value
+            # if batch != 0
+            iterations: bounds of batch with minimum p-value
+            nbatches: the number of batches in total
+            p_value_uncorrected: p_value without Bonferroni correction
+    """
+    if batch == 0:
+        bins = np.arange(-0.5, nlive + 0.5, 1.)
+        empirical_pmf = np.histogram(indexes, bins=bins, density=True)[0]
+        empirical_cmf = np.cumsum(empirical_pmf)
+        uniform_cmf = np.arange(1., nlive + 1., 1.) / nlive
+
+        D = abs(empirical_cmf - uniform_cmf).max()
+        sample_size = len(indexes)
+        K = D * np.sqrt(sample_size)
+
+        ks_result = {}
+        ks_result["D"] = D
+        ks_result["sample_size"] = sample_size
+        ks_result["p_value"] = kstwobign.sf(K)
+        return ks_result
+    else:
+        batch = int(batch * nlive)
+        batches = [indexes[i:i + batch] for i in range(0, len(indexes), batch)]
+        ks_results = [insertion_p_value(c, nlive) for c in batches]
+        ks_result = min(ks_results, key=lambda t: t["p_value"])
+        index = ks_results.index(ks_result)
+
+        ks_result["iterations"] = (index * batch, (index + 1) * batch)
+        ks_result["nbatches"] = n = len(batches)
+        ks_result["p_value_uncorrected"] = p = ks_result["p_value"]
+        ks_result["p_value"] = 1. - (1. - p)**n
+        if ks_result["p_value"] == 0.:
+            ks_result["p_value"] = p * n
+        return ks_result

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -613,7 +613,7 @@ def test_compute_insertion():
     np.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     assert 'insertion' not in ns
-    ns._compute_insertion_indices()
+    ns._compute_insertion_indexes()
     assert 'insertion' in ns
 
     nlive = ns.nlive.mode()[0]


### PR DESCRIPTION
# Description

This pull request implements some of the code that underpins https://arxiv.org/abs/2006.03371 

@andrewfowlie will likely have an opinion on which other pieces of code from
that paper are sufficiently general to make it into this paper

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works