### PR TITLE
logzero masking at prior and likelihood level

### DIFF
--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -669,12 +669,12 @@ def test_logzero_mask_prior_level():
 
     V_prior = pi0[mask].weights.sum() / pi0.weights.sum()
     V_posterior = ns0[mask].weights.sum() / ns0.weights.sum()
-    logZ_V_mask = NS0.logZ.mean() + np.log(V_posterior) - np.log(V_prior)
+    logZ_V = NS0.logZ.mean() + np.log(V_posterior) - np.log(V_prior)
 
     ns1 = merge_nested_samples((ns0[mask],))
     NS1 = ns1.ns_output(nsamples=2000)
 
-    assert abs(NS1.logZ.mean() - logZ_V_mask) < NS1.logZ.std()
+    assert abs(NS1.logZ.mean() - logZ_V) < 1.5 * NS1.logZ.std()
 
 
 def test_logzero_mask_likelihood_level():
@@ -684,12 +684,11 @@ def test_logzero_mask_likelihood_level():
     mask = ((ns0.x0 > -0.3) & (ns0.x2 > 0.2) & (ns0.x4 < 3.5)).to_numpy()
 
     V_posterior = ns0[mask].weights.sum() / ns0.weights.sum()
-    logZ_V_mask = NS0.logZ.mean() + np.log(V_posterior)
+    logZ_V = NS0.logZ.mean() + np.log(V_posterior)
 
-    ns1 = merge_nested_samples((ns0,))
-    ns1.logL = np.where(mask, ns1.logL, -np.inf)
-    # ns1.logL_birth = np.where(mask, ns1.logL_birth, -np.inf)
-    ns1 = merge_nested_samples((ns1,))
+    ns1 = NestedSamples(root='./tests/example_data/pc')
+    ns1.logL = np.where(mask, ns1.logL, -1e30)
+    ns1 = merge_nested_samples((ns1[ns1.logL > ns1.logL_birth],))
     NS1 = ns1.ns_output(nsamples=2000)
 
-    assert abs(NS1.logZ.mean() - logZ_V_mask) < NS1.logZ.std()
+    assert abs(NS1.logZ.mean() - logZ_V) < 1.5 * NS1.logZ.std()


### PR DESCRIPTION
This introduces 2 tests:

1) Apply a logzero mask at the prior level (i.e. _discard_ samples completely). 

2) Apply a logzero mask at the likelihood level (i.e. set `logL` to `-inf`).

Both tests take two approaches each and compare those internally. 
The **first** approach applies the mask to the samples directly and 1) discards them or 2) sets the corresponding `logL` to `-inf` and then recomputes `ns_output()`. 
The **second** approach applies the mask to the weights and computes 1) prior and posterior volume change or 2) only posterior volume change to then infer the new log evidence.

This PR was suggested in #119 to see whether changes there affect the comparison here.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works


---


# MWE

```python
ns0 = NestedSamples(root="/home/hergtl/Documents/Projects/AnestheticPrj/anesthetic/tests/example_data/pc")
pi0 = ns0.set_beta(0)
NS0 = ns0.ns_output(nsamples=2000)

mask = ((ns0.x0 > -0.2) & (ns0.x2 > 0.2) & (ns0.x4 < 3.5)).to_numpy()


#######################
# volume re-weighting #
#######################
V_prior     = pi0[mask].weights.sum() / pi0.weights.sum()
V_posterior = ns0[mask].weights.sum() / ns0.weights.sum()
logZ_V1 = NS0.logZ.mean() + np.log(V_posterior)
logZ_V2 = NS0.logZ.mean() + np.log(V_posterior) - np.log(V_prior)


####################
# assign logL=-inf #
####################
ns1 = merge_nested_samples((ns0, ))
ns1.logL = np.where(mask, ns1.logL, -np.inf)
ns1.logL_birth = np.where(mask, ns1.logL_birth, -np.inf)
ns1 = merge_nested_samples((ns1, ))
NS1 = ns1.ns_output(nsamples=2000)


###########
# discard #
###########
ns2 = merge_nested_samples((ns0[mask], ))
NS2 = ns2.ns_output(nsamples=2000)


##################
# posterior plot #
##################
fig = plt.figure(figsize=(7, 7))
fig, axes = make_2d_axes(['x0', 'x2', 'x4'], fig=fig)
ns0.plot_2d(axes, c='C0', ec='C0', alpha=0.7, label="0")
ns1.plot_2d(axes, c='C1', ec='C1', alpha=0.7, label="1, assign logL=-inf")
ns2.plot_2d(axes, c='C2', ec='C2', alpha=0.7, label="2, discard")
axes['x0']['x0'].set_xlim(ns0.x0.min(), ns0.x0.max())
axes['x2']['x2'].set_xlim(ns0.x2.min(), ns0.x2.max())
axes['x4']['x4'].set_xlim(ns0.x4.min(), ns0.x4.max())
axes.iloc[-1, 0].legend(bbox_to_anchor=(len(axes), len(axes)), loc='upper left');
fig.savefig("logzero_masking_posterior.png")


#################
# evidence plot #
#################
fig = plt.figure(figsize=(5, 5))
fig, axes = make_1d_axes(['logZ'], fig=fig)
NS0.plot_1d(axes, label="0")
NS1.plot_1d(axes, label="1, assign logL=-inf")
NS2.plot_1d(axes, label="2, discard")
axes['logZ'].axvline(logZ_V1, c='C1')
axes['logZ'].axvline(logZ_V2, c='C2')
axes['logZ'].set_xticks(np.arange(-8, -1, 1))
axes['logZ'].legend(bbox_to_anchor=(1, 1));
fig.savefig("logzero_masking_evidences.png")
```


### Posterior plot

![logzero_masking_posterior](https://user-images.githubusercontent.com/18258042/90538989-2d902280-e177-11ea-8a6c-8c4fbc1ee175.png)


### Evidence plot

The vertical lines come from the volume re-weighting and the posteriors from the masked samples.

Note that for the orange posterior _both_ `logL` and `logL_birth` were set to `-inf`, else we'd get a ValueError. Is that ValueError expected? Or does it hint that there might be a bug?

![logzero_masking_evidences](https://user-images.githubusercontent.com/18258042/90538987-2cf78c00-e177-11ea-9b70-f4ba963e8078.png)
