### PR TITLE
Added prior and prior_points shortcuts

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -523,6 +523,10 @@ class NestedSamples(MCMCSamples):
             data.beta = beta
             return data
 
+    def prior(self, inplace=False):
+        """Re-weight samples at infinite temperature to get prior samples."""
+        return self.set_beta(beta=0, inplace=inplace)
+
     def ns_output(self, nsamples=200):
         """Compute Bayesian global quantities.
 
@@ -629,6 +633,10 @@ class NestedSamples(MCMCSamples):
     def posterior_points(self, beta=1):
         """Get equally weighted posterior points at temperature beta."""
         return self.set_beta(beta).compress(-1)
+
+    def prior_points(self, params=None):
+        """Get equally weighted prior points."""
+        return self.posterior_points(beta=0)
 
     def gui(self, params=None):
         """Construct a graphical user interface for viewing samples."""

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -10,6 +10,7 @@ from anesthetic import MCMCSamples, NestedSamples, make_1d_axes, make_2d_axes
 from anesthetic.samples import merge_nested_samples
 from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_array_less)
+from pandas.testing import assert_frame_equal
 from matplotlib.colors import to_hex
 from scipy.stats import ks_2samp, kstest
 from wedding_cake import WeddingCake
@@ -544,6 +545,13 @@ def test_beta_with_logL_infinities():
     ns.plot_1d(['x0', 'x1'])
 
 
+def test_prior():
+    ns = NestedSamples(root="./tests/example_data/pc")
+    prior = ns.prior()
+    assert prior.beta == 0
+    assert_frame_equal(prior, ns.set_beta(0))
+
+
 def test_live_points():
     np.random.seed(4)
     pc = NestedSamples(root="./tests/example_data/pc")
@@ -647,6 +655,11 @@ def test_posterior_points():
     ns = NestedSamples(root='./tests/example_data/pc')
     assert_array_equal(ns.posterior_points(), ns.posterior_points())
     assert_array_equal(ns.posterior_points(0.5), ns.posterior_points(0.5))
+
+
+def test_prior_points():
+    ns = NestedSamples(root='./tests/example_data/pc')
+    assert_array_equal(ns.prior_points(), ns.posterior_points(0))
 
 
 def test_NestedSamples_importance_sample():


### PR DESCRIPTION
- Added `NestedSamples.prior_points()` as alias for `NestedSamples.posterior_points(0)`.
- Added `NestedSamples.convert_to_prior()` as alias for `NestedSamples.set_beta(0)`. (Not sure if `NestedSamples.prior()` would be a better name).

Fixes #118 
