### PR TITLE
fix `MCMCSamples.importance_sample`

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -370,8 +370,11 @@ class MCMCSamples(WeightedDataFrame):
         """
         samples = self.copy()
         if action == 'add':
+            samples.weights *= np.exp(logL_new - logL_new.max())
             samples.logL += logL_new
         elif action == 'replace':
+            logL_new2 = logL_new - samples.logL
+            samples.weights *= np.exp(logL_new2 - logL_new2.max())
             samples.logL = logL_new
         elif action == 'mask':
             samples = samples[logL_new]


### PR DESCRIPTION
As mentioned in #133, `MCMCSamples.importance_sample` is not adjusting the weights (which it should).

Fixes #133 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
