### PR TITLE
bugfix for xlim for fastkde plots

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley and Lukas Hergt
-:Version: 2.0.0-beta.7
+:Version: 2.0.0-beta.8
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/anesthetic/kde.py
+++ b/anesthetic/kde.py
@@ -48,7 +48,7 @@ def fastkde_1d(d, xmin=None, xmax=None):
         p = p[x <= xmax]
         x = x[x <= xmax]
 
-    return x, p
+    return x, p, xmin, xmax
 
 
 def fastkde_2d(d_x, d_y, xmin=None, xmax=None, ymin=None, ymax=None):

--- a/anesthetic/kde.py
+++ b/anesthetic/kde.py
@@ -103,4 +103,4 @@ def fastkde_2d(d_x, d_y, xmin=None, xmax=None, ymin=None, ymax=None):
         p = p[y <= ymax, :]
         y = y[y <= ymax]
 
-    return x, y, p
+    return x, y, p, xmin, xmax, ymin, ymax

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -557,8 +557,9 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
         return np.zeros(0), np.zeros(0), np.zeros((0, 0))
 
     try:
-        x, y, pdf = fastkde_2d(data_x, data_y,
-                               xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
+        x, y, pdf, xmin, xmax, ymin, ymax = fastkde_2d(data_x, data_y,
+                                                       xmin=xmin, xmax=xmax,
+                                                       ymin=ymin, ymax=ymax)
     except NameError:
         raise ImportError("You need to install fastkde to use fastkde")
 
@@ -595,8 +596,8 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
                       vmin=vmin, vmax=vmax, linewidths=linewidths,
                       colors=edgecolor, cmap=cmap, *args, **kwargs)
 
-    ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
-    ax.set_ylim(*check_bounds(y[j], ymin, ymax), auto=True)
+    ax.set_xlim(xmin, xmax, auto=True)
+    ax.set_ylim(ymin, ymax, auto=True)
     return contf, cont
 
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -299,14 +299,14 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
     q = quantile_plot_interval(q=q)
 
     try:
-        x, p = fastkde_1d(data, xmin, xmax)
+        x, p, xmin, xmax = fastkde_1d(data, xmin, xmax)
     except NameError:
         raise ImportError("You need to install fastkde to use fastkde")
     p /= p.max()
     i = ((x > quantile(x, q[0], p)) & (x < quantile(x, q[1], p)))
 
     ans = ax.plot(x[i], p[i], color=color, *args, **kwargs)
-    ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
+    ax.set_xlim(xmin, xmax, auto=True)
 
     if facecolor and facecolor not in [None, 'None', 'none']:
         if facecolor is True:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -443,7 +443,32 @@ def test_contour_plot_2d(contour_plot_2d):
         assert cf is None
         assert ct.get_cmap() == plt.cm.Reds
         assert ct.colors is None
-        plt.close()
+        plt.close("all")
+
+        # Check limits, Gaussian (i.e. limits reduced to relevant data range)
+        fig, ax = plt.subplots()
+        data_x = np.random.randn(1000) * 0.01 + 0.5
+        data_y = np.random.randn(1000) * 0.01 + 0.5
+        contour_plot_2d(ax, data_x, data_y, xmin=0, xmax=1, ymin=0, ymax=1)
+        xmin, xmax = ax.get_xlim()
+        ymin, ymax = ax.get_ylim()
+        assert(xmin > 0.4)
+        assert(xmax < 0.6)
+        assert(ymin > 0.4)
+        assert(ymax < 0.6)
+        plt.close("all")
+        # Check limits, Uniform (i.e. data & limits span entire prior boundary)
+        fig, ax = plt.subplots()
+        data_x = np.random.uniform(size=1000)
+        data_y = np.random.uniform(size=1000)
+        contour_plot_2d(ax, data_x, data_y, xmin=0, xmax=1, ymin=0, ymax=1)
+        xmin, xmax = ax.get_xlim()
+        ymin, ymax = ax.get_ylim()
+        assert(xmin == 0)
+        assert(xmax == 1)
+        assert(ymin == 0)
+        assert(ymax == 1)
+        plt.close("all")
 
     except ImportError:
         if 'fastkde' not in sys.modules:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -239,6 +239,24 @@ def test_kde_plot_1d(plot_1d):
         line, fill = plot_1d(ax, data, fc=True, color='k', ec=None)
         assert(len(fill[0].get_edgecolor()) == 0)
         assert (to_rgba(line[0].get_color()) == to_rgba('k'))
+        plt.close("all")
+
+        # Check xlim, Gaussian (i.e. limits reduced to relevant data range)
+        fig, ax = plt.subplots()
+        data = np.random.randn(1000) * 0.01 + 0.5
+        plot_1d(ax, data, xmin=0, xmax=1)
+        xmin, xmax = ax.get_xlim()
+        assert(xmin > 0.4)
+        assert(xmax < 0.6)
+        plt.close("all")
+        # Check xlim, Uniform (i.e. data and limits span entire prior boundary)
+        fig, ax = plt.subplots()
+        data = np.random.uniform(size=1000)
+        plot_1d(ax, data, xmin=0, xmax=1)
+        xmin, xmax = ax.get_xlim()
+        assert(xmin == 0)
+        assert(xmax == 1)
+        plt.close("all")
 
     except ImportError:
         if 'fastkde' not in sys.modules:


### PR DESCRIPTION
As raised in #149 there is a slight difference in how `'kde'` and `'fastkde'` treat the plot limits (`xlim`).

I believe this is down to a bug in `fastkde_plot_1d` (and `2d`?) which checks _twice_ whether the data reach up to the prior boundary (corresponding function is called `check_bounds`). This leads to (unwanted) extra 

**Subtle point to note regarding intended default behaviour for `'kde'` plots _(different from `'hist'` default)_:** 
* When the data spans the entire prior volume (e.g. uniform likelihood to uniform prior), the limits should be set to the prior boundaries. 
* When the data is contained in a much smaller volume than the prior volume (e.g. Gaussian likelihood to uniform prior), then the plotting limits should be reduced accordingly.  

  (Feel free to comment/critique.)

&nbsp;

Fixes #149 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
