### PR TITLE
change default edgecolor: match facecolor

### DIFF
--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -549,8 +549,7 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     levels = kwargs.pop('levels', [0.68, 0.95])
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
     facecolor = kwargs.pop('facecolor', color)
-    edgecolor = kwargs.pop(
-        'edgecolor', color if facecolor in [None, 'None', 'none'] else 'k')
+    edgecolor = kwargs.pop('edgecolor', color)
     kwargs.pop('q', None)
 
     if len(data_x) == 0 or len(data_y) == 0:
@@ -650,8 +649,7 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     zorder = kwargs.pop('zorder', 1)
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
     facecolor = kwargs.pop('facecolor', color)
-    edgecolor = kwargs.pop(
-        'edgecolor', color if facecolor in [None, 'None', 'none'] else 'k')
+    edgecolor = kwargs.pop('edgecolor', color)
     kwargs.pop('q', None)
 
     if len(data_x) == 0 or len(data_y) == 0:


### PR DESCRIPTION
This implements the suggestion from #140 to match the edgecolor from contourplots to the facecolor by default.

Fixes #140 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
