### PR TITLE
GUI tests quick fix due to matplotlib 3.4 API change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scipy>=1.2.0
 numpy
 pandas>=1.1.0
-matplotlib>=3.4.0
+matplotlib>=3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scipy>=1.2.0
 numpy
 pandas>=1.1.0
-matplotlib>=3.3.0
+matplotlib>=3.4.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='anesthetic',
           'automated bins calculation': ['astropy'],
           'fast kernel density estimation': ['fastkde'],
           },
-      tests_require=['pytest'],
+      tests_require=['pytest', 'packaging'],
       include_package_data=True,
       license='MIT',
       classifiers=[

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -35,7 +35,7 @@ def test_gui():
     plotter.type.buttons.set_active(0)
 
     # Reload button
-    plotter.reload.button.observers[0]()
+    #plotter.reload.button.observers[0]()
 
     # Reset button
-    plotter.reset.button.observers[0]()
+    #plotter.reset.button.observers[0]()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -35,7 +35,7 @@ def test_gui():
     plotter.type.buttons.set_active(0)
 
     # Reload button
-    #plotter.reload.button.observers[0]()
+#   plotter.reload.button.observers[0]()
 
     # Reset button
-    #plotter.reset.button.observers[0]()
+#   plotter.reset.button.observers[0]()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -35,7 +35,7 @@ def test_gui():
     plotter.type.buttons.set_active(0)
 
     # Reload button
-    plotter.reload.button.observers[0](None)
+    plotter.reload.button.observers[0]()
 
     # Reset button
-    plotter.reset.button.observers[0](None)
+    plotter.reset.button.observers[0]()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,4 +1,6 @@
 import matplotlib_agg  # noqa: F401
+from packaging import version
+from matplotlib import __version__ as mpl_version
 from anesthetic import NestedSamples
 
 
@@ -34,8 +36,15 @@ def test_gui():
     assert(plotter.temperature() == 100)
     plotter.type.buttons.set_active(0)
 
-    # Reload button
-#   plotter.reload.button.observers[0]()
+    if version.parse(mpl_version) >= version.parse('3.4.0'):
+        # Reload button
+        plotter.reload.button.observers[0]()
 
-    # Reset button
-#   plotter.reset.button.observers[0]()
+        # Reset button
+        plotter.reset.button.observers[0]()
+    else:
+        # Reload button
+        plotter.reload.button.observers[0](None)
+
+        # Reset button
+        plotter.reset.button.observers[0](None)


### PR DESCRIPTION
The tests in #152 and #153 were failing, but this was actually down to an API change in matplotlib 3.4 that affected the GUI. This provides a quick fix to the GUI tests to make them pass. However with some new deprecation warnings from matplotlib it looks like we will soon have to adapt the GUI section accordingly. 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
