### PR TITLE
optional normalisation by area instead of by maximum

### DIFF
--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -382,6 +382,7 @@ def kde_plot_1d(ax, data, *args, **kwargs):
     xmax = kwargs.pop('xmax', None)
     weights = kwargs.pop('weights', None)
     ncompress = kwargs.pop('ncompress', 1000)
+    density = kwargs.pop('density', False)
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
                                  if cmap is None else cmap(0.68)))
@@ -413,7 +414,8 @@ def kde_plot_1d(ax, data, *args, **kwargs):
     sigma = np.sqrt(kde.covariance[0, 0])
     pp = cut_and_normalise_gaussian(x[i], p[i], sigma, xmin, xmax)
     pp /= pp.max()
-    ans = ax.plot(x[i], pp, color=color, *args, **kwargs)
+    area = np.trapz(x=x[i], y=pp) if density else 1
+    ans = ax.plot(x[i], pp/area, color=color, *args, **kwargs)
     ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
 
     if facecolor and facecolor not in [None, 'None', 'none']:
@@ -477,6 +479,7 @@ def hist_plot_1d(ax, data, *args, **kwargs):
     if xmax is None or not np.isfinite(xmax):
         xmax = quantile(data, 0.99, weights)
     histtype = kwargs.pop('histtype', 'bar')
+    density = kwargs.get('density', False)
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
                                  if cmap is None else cmap(0.68)))
@@ -492,15 +495,16 @@ def hist_plot_1d(ax, data, *args, **kwargs):
                                  histtype=histtype, weights=weights,
                                  *args, **kwargs)
 
-    if histtype == 'bar':
+    if histtype == 'bar' and not density:
         for b in bars:
             b.set_height(b.get_height() / h.max())
-    elif histtype == 'step' or histtype == 'stepfilled':
+    elif (histtype == 'step' or histtype == 'stepfilled') and not density:
         trans = Affine2D().scale(sx=1, sy=1./h.max()) + ax.transData
         bars[0].set_transform(trans)
 
     ax.set_xlim(*check_bounds(edges, xmin, xmax), auto=True)
-    ax.set_ylim(0, 1.1)
+    if not density:
+        ax.set_ylim(0, 1.1)
     return bars
 
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -283,6 +283,7 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
 
     xmin = kwargs.pop('xmin', None)
     xmax = kwargs.pop('xmax', None)
+    density = kwargs.pop('density', False)
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
                                  if cmap is None else cmap(0.68)))
@@ -305,7 +306,8 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
     p /= p.max()
     i = ((x > quantile(x, q[0], p)) & (x < quantile(x, q[1], p)))
 
-    ans = ax.plot(x[i], p[i], color=color, *args, **kwargs)
+    area = np.trapz(x=x[i], y=p[i]) if density else 1
+    ans = ax.plot(x[i], p[i]/area, color=color, *args, **kwargs)
     ax.set_xlim(xmin, xmax, auto=True)
 
     if facecolor and facecolor not in [None, 'None', 'none']:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -381,6 +381,12 @@ def test_1d_density_kwarg(s):
     kde_height = x2y(0)
     assert(kde_height == pytest.approx(1, rel=0.1))
 
+    # fastkde density = False:
+    f = fastkde_plot_1d(ax, x, density=False)[0]
+    x2y = interp1d(f.get_xdata(), f.get_ydata(), 'cubic', assume_sorted=True)
+    fastkde_height = x2y(0)
+    assert(fastkde_height == pytest.approx(1, rel=0.1))
+
     # hist density = True:
     h = hist_plot_1d(ax, x, density=True, bins=np.linspace(-5.5, 5.5, 12))
     bar_height = h.get_children()[len(h.get_children()) // 2].get_height()
@@ -392,6 +398,12 @@ def test_1d_density_kwarg(s):
     kde_height = x2y(0)
     gauss_norm = 1 / np.sqrt(2 * np.pi * s**2)
     assert(kde_height == pytest.approx(gauss_norm, rel=0.1))
+
+    # fastkde density = True:
+    f = fastkde_plot_1d(ax, x, density=True)[0]
+    x2y = interp1d(f.get_xdata(), f.get_ydata(), 'cubic', assume_sorted=True)
+    fastkde_height = x2y(0)
+    assert(fastkde_height == pytest.approx(gauss_norm, rel=0.1))
     plt.close("all")
 
 


### PR DESCRIPTION
This implements the `density` kwarg to 1d plots to allow for normalisation by area instead of setting the posterior maximum to one. Do we like this? Then I would go ahead with this.

I chose the kwarg `density` in line with matplotlib's `density` kwarg for `plt.hist` which already implements exactly that.

Example behaviour:

```python
import numpy as np
import matplotlib.pyplot as plt
from anesthetic import NestedSamples, MCMCSamples, make_1d_axes, make_2d_axes
from anesthetic.plot import kde_plot_1d, hist_plot_1d

params = ["x0", "x1", "x2"]
x0 = np.random.normal(loc=0, scale=1.0, size=2000)
x1 = np.random.normal(loc=1, scale=2.0, size=2000)
x2 = np.random.normal(loc=2, scale=0.5, size=2000)

fig, axes = plt.subplots(2, 2)
kde_plot_1d(axes[0, 0], x0)
kde_plot_1d(axes[0, 0], x1)
kde_plot_1d(axes[0, 0], x2)
hist_plot_1d(axes[0, 1], x0, bins=20, alpha=0.5)
hist_plot_1d(axes[0, 1], x1, bins=20, alpha=0.5)
hist_plot_1d(axes[0, 1], x2, bins=20, alpha=0.5)
kde_plot_1d(axes[1, 0], x0, density=True)
kde_plot_1d(axes[1, 0], x1, density=True)
kde_plot_1d(axes[1, 0], x2, density=True)
hist_plot_1d(axes[1, 1], x0, density=True, bins=20, alpha=0.5)
hist_plot_1d(axes[1, 1], x1, density=True, bins=20, alpha=0.5)
hist_plot_1d(axes[1, 1], x2, density=True, bins=20, alpha=0.5)
for ax in axes.flatten():
    ax.set_xlim(-7, 7)
```
![image](https://user-images.githubusercontent.com/18258042/113978103-5f362680-97f8-11eb-94d2-636c98a6ccdc.png)

Top row shows `density=False` and bottom row shows `density=True`.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
