### PR TITLE
vmin=0 in 2d histograms

### DIFF
--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -788,8 +788,7 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
             pdf[pdf < cmin] = np.ma.masked
         if cmax is not None:
             pdf[pdf > cmax] = np.ma.masked
-        image = ax.pcolormesh(x, y, pdf.T, cmap=cmap,
-                              vmin=vmin, vmax=pdf.max(),
+        image = ax.pcolormesh(x, y, pdf.T, cmap=cmap, vmin=vmin,
                               *args, **kwargs)
 
     ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999), ec=cmap(0.32),

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -747,6 +747,7 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
     xmax = kwargs.pop('xmax', None)
     ymin = kwargs.pop('ymin', None)
     ymax = kwargs.pop('ymax', None)
+    vmin = kwargs.pop('vmin', 0)
     label = kwargs.pop('label', None)
     levels = kwargs.pop('levels', None)
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
@@ -770,7 +771,7 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
 
     if levels is None:
         pdf, x, y, image = ax.hist2d(data_x, data_y, weights=weights,
-                                     cmap=cmap, range=rge,
+                                     cmap=cmap, range=rge, vmin=vmin,
                                      *args, **kwargs)
     else:
         bins = kwargs.pop('bins', 10)
@@ -787,7 +788,8 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
             pdf[pdf < cmin] = np.ma.masked
         if cmax is not None:
             pdf[pdf > cmax] = np.ma.masked
-        image = ax.pcolormesh(x, y, pdf.T, cmap=cmap, vmin=0, vmax=pdf.max(),
+        image = ax.pcolormesh(x, y, pdf.T, cmap=cmap,
+                              vmin=vmin, vmax=pdf.max(),
                               *args, **kwargs)
 
     ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999), ec=cmap(0.32),


### PR DESCRIPTION
This addresses #156 which pointed out that `vmin` in 2d histograms needs to be set to zero in order for uniform distributions to appear uniform. 

Fixes #156 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
