### PR TITLE
Change in behaviour from RuntimeError to RuntimeWarning for invalid nested sampling runs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley and Lukas Hergt
-:Version: 2.0.0-beta.8
+:Version: 2.0.0-beta.9
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -7,6 +7,7 @@ import os
 import numpy as np
 import pandas
 import copy
+import warnings
 from collections.abc import Sequence
 from anesthetic.plot import (make_1d_axes, make_2d_axes, fastkde_plot_1d,
                              kde_plot_1d, hist_plot_1d, scatter_plot_2d,
@@ -738,9 +739,17 @@ class NestedSamples(MCMCSamples):
                 raise RuntimeError("Cannot recompute run without "
                                    "birth contours logL_birth.")
 
-            if (samples.logL <= samples.logL_birth).any():
-                raise RuntimeError("Not a valid nested sampling run. "
-                                   "Require logL > logL_birth.")
+            invalid = samples.logL <= samples.logL_birth
+            n_bad = invalid.sum()
+            if n_bad:
+                warnings.warn("%i out of %i samples have logL <= logL_birth."
+                              "\nThis may just indicate numerical rounding "
+                              "errors at the peak of the likelihood, but "
+                              "further investigation of the chains files is "
+                              "recommended."
+                              "\nDropping the invalid samples." %
+                              (n_bad, len(samples)), RuntimeWarning)
+                samples = samples[~invalid].reset_index()
 
             samples['nlive'] = compute_nlive(samples.logL, samples.logL_birth)
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -741,14 +741,17 @@ class NestedSamples(MCMCSamples):
 
             invalid = samples.logL <= samples.logL_birth
             n_bad = invalid.sum()
+            n_equal = (samples.logL == samples.logL_birth).sum()
             if n_bad:
-                warnings.warn("%i out of %i samples have logL <= logL_birth."
+                warnings.warn("%i out of %i samples have logL <= logL_birth,"
+                              "\n%i of which have logL == logL_birth."
                               "\nThis may just indicate numerical rounding "
                               "errors at the peak of the likelihood, but "
                               "further investigation of the chains files is "
                               "recommended."
                               "\nDropping the invalid samples." %
-                              (n_bad, len(samples)), RuntimeWarning)
+                              (n_bad, len(samples), n_equal),
+                              RuntimeWarning)
                 samples = samples[~invalid].reset_index()
 
             samples['nlive'] = compute_nlive(samples.logL, samples.logL_birth)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -870,7 +870,8 @@ def test_recompute():
 
     pc.loc[1000, 'logL'] = pc.logL_birth.iloc[1000]-1
     with pytest.warns(RuntimeWarning):
-        pc.recompute()
+        recompute = pc.recompute()
+    assert len(recompute) == len(pc) - 1
 
     mn = NestedSamples(root='./tests/example_data/mn_old')
     with pytest.raises(RuntimeError):

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -869,7 +869,7 @@ def test_recompute():
     assert recompute is not pc
 
     pc.loc[1000, 'logL'] = pc.logL_birth.iloc[1000]-1
-    with pytest.raises(RuntimeError):
+    with pytest.warns(RuntimeWarning):
         pc.recompute()
 
     mn = NestedSamples(root='./tests/example_data/mn_old')


### PR DESCRIPTION
# Description

This bug fixes adjusts the default behaviour. In general I have found that this error tends to occur due to floating point rounding errors at the end of the run, which can be safely discarded before recomputing the number of live points. This PR changes the behaviour to raising a RuntimeWarning with a message that indicates how many rows are discarded, and an encouragement for the user to inspect the chains files directly for anything that might be awry.

@sebhoof & @catherinewatkinson have also noted that this affects some of their pipelines -- any feedback for this potential fix would be much appreciated.

Fixes #141

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works
