### PR TITLE
Equally weighted live points

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -619,7 +619,7 @@ class NestedSamples(MCMCSamples):
 
         Returns
         -------
-        live_points: NestedSamples
+        live_points: MCMCSamples
             Live points at either:
                 - contour logL (if input is float)
                 - ith iteration (if input is integer)

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -631,7 +631,8 @@ class NestedSamples(MCMCSamples):
                 logL = float(self.logL[logL])
             except KeyError:
                 pass
-        return self[(self.logL > logL) & (self.logL_birth <= logL)]
+        i = (self.logL >= logL) & (self.logL_birth < logL)
+        return MCMCSamples(self[i], weights=np.ones(i.sum()))
 
     def posterior_points(self, beta=1):
         """Get equally weighted posterior points at temperature beta."""

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -621,8 +621,8 @@ class NestedSamples(MCMCSamples):
         live_points: NestedSamples
             Live points at either:
                 - contour logL (if input is float)
-                - ith contour (if input is integer)
-                - last generation contour if logL not provided
+                - ith iteration (if input is integer)
+                - last set of live points if no argument provided
         """
         if logL is None:
             logL = self.logL_birth.max()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -606,6 +606,8 @@ def test_live_points():
         live_points_from_index = pc.live_points(i)
         assert_array_equal(live_points_from_index, live_points)
 
+    assert pc.live_points(0).index[0][0] == 0
+
     last_live_points = pc.live_points()
     logL = pc.logL_birth.max()
     assert (last_live_points.logL >= logL).all()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -596,9 +596,9 @@ def test_live_points():
     np.random.seed(4)
     pc = NestedSamples(root="./tests/example_data/pc")
 
-    for i, logL in pc.logL.iloc[:-1].iteritems():
+    for i, logL in pc.logL.iloc[::49].iteritems():
         live_points = pc.live_points(logL)
-        assert len(live_points) == int(pc.nlive[i[0]+1])
+        assert len(live_points) == int(pc.nlive[i[0]])
 
         live_points_from_int = pc.live_points(i[0])
         assert_array_equal(live_points_from_int, live_points)
@@ -608,7 +608,7 @@ def test_live_points():
 
     last_live_points = pc.live_points()
     logL = pc.logL_birth.max()
-    assert (last_live_points.logL > logL).all()
+    assert (last_live_points.logL >= logL).all()
     assert len(last_live_points) == pc.nlive.mode()[0]
 
 

--- a/tests/wedding_cake.py
+++ b/tests/wedding_cake.py
@@ -76,7 +76,8 @@ class WeddingCake():
 
             samps = NestedSamples(points, logL=death_likes,
                                   logL_birth=birth_likes)
-            if samps.live_points().weights.sum()/samps.weights.sum() < 0.001:
+
+            if samps.iloc[-nlive:].weights.sum()/samps.weights.sum() < 0.001:
                 break
 
         death_likes = np.concatenate([death_likes, live_likes])


### PR DESCRIPTION
# Description

This PR adjusts so that `NestedSamples.live_points` 
- Returns equally weighted `MCMCSamples` (rather than posterior weighted `NestedSamples`
- changes the convention so that an integer argument now refers to the live point iteration before contour i is deleted, rather than after

Fixes #160

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works
