### PR TITLE
auto update limits of derived parameters

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -159,6 +159,7 @@ class MCMCSamples(WeightedDataFrame):
             Pandas array of axes objects
 
         """
+        self._set_automatic_limits()
         plot_type = kwargs.pop('plot_type', 'kde')
         do_1d_plot = paramname_y is None or paramname_x == paramname_y
         kwargs['label'] = kwargs.get('label', self.label)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -632,6 +632,15 @@ def test_limit_assignment():
     assert ns.limits['logL'][1] == 5.748335384373301
     assert ns.limits['nlive'][0] == 1
     assert ns.limits['nlive'][1] == 125
+    # limits for derived parameters:
+    ns['x5'] = ns.x0 + ns.x1
+    assert 'x5' in ns.columns and 'x5' not in ns.limits
+    ns.plot_1d(['x5'])
+    assert 'x5' in ns.columns and 'x5' in ns.limits
+    ns['x6'] = ns.x2 + ns.x3
+    assert 'x6' in ns.columns and 'x6' not in ns.limits
+    ns.plot_2d(['x5', 'x6'])
+    assert 'x6' in ns.columns and 'x6' in ns.limits
 
 
 def test_xmin_xmax_1d():


### PR DESCRIPTION
As addressed in #165, when one uses an `MCMCSamples` or `NestedSamples` instance to create new derived parameters, the corresponding limits are not automatically updated. This PR calls `self._set_automatic_limits()` at the start of the generic `plot`, thus ensuring that the limits of any new derived parameters are updated before plotting them.

Fixes #165 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
