### PR TITLE
axlines method to highlight specific parameter values across all subplots

### DIFF
--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -66,16 +66,20 @@ class AxesDataFrame(pandas.DataFrame):
         ----------
             params : str, list(str)
                 parameter label(s).
-                Should match the shape of `values`.
+                Should match the size of `values`.
             values : float, list(float)
                 value(s) at which vertical and horizontal lines shall be added.
-                Should match the shape of `params`.
+                Should match the size of `params`.
             kwargs
                 Any kwarg that can be passed to `plt.axvline` or `plt.axhline`.
 
         """
-        params = np.atleast_1d(params)
-        values = np.atleast_1d(values)
+        params = np.ravel(params)
+        values = np.ravel(values)
+        if params.size != values.size:
+            raise ValueError("The sizes of `params` and `values` must match "
+                             "exactly, but params.size=%s and values.size=%s."
+                             % (params.size, values.size))
         for i, param in enumerate(params):
             if param in self.columns:
                 for ax in self.loc[:, param]:

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -68,7 +68,7 @@ class AxesDataFrame(pandas.DataFrame):
                 parameter label(s).
                 Should match the shape of `values`.
             values : float, list(float)
-                value(s) at which vertical and horizontal lines should be added.
+                value(s) at which vertical and horizontal lines shall be added.
                 Should match the shape of `params`.
             kwargs
                 Any kwarg that can be passed to `plt.axvline` or `plt.axhline`.

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -64,10 +64,10 @@ class AxesDataFrame(pandas.DataFrame):
 
         Parameters
         ----------
-            params : str, list(str)
+            params : str or list(str)
                 parameter label(s).
                 Should match the size of `values`.
-            values : float, list(float)
+            values : float or list(float)
                 value(s) at which vertical and horizontal lines shall be added.
                 Should match the size of `params`.
             kwargs
@@ -87,6 +87,41 @@ class AxesDataFrame(pandas.DataFrame):
             if param in self.index:
                 for ax in self.loc[param, self.columns != param]:
                     ax.axhline(values[i], **kwargs)
+
+    def axspans(self, params, vmins, vmaxs, **kwargs):
+        """Add vertical and horizontal spans across all axes.
+
+        Parameters
+        ----------
+            params : str or list(str)
+                parameter label(s).
+                Should match the size of `vmins` and `vmaxs`.
+            vmins : float or list(float)
+                Minimum value of the vertical and horizontal axes spans.
+                Should match the size of `params`.
+            vmaxs : float or list(float)
+                Maximum value of the vertical and horizontal axes spans.
+                Should match the size of `params`.
+            kwargs
+                Any kwarg that can be passed to `plt.axvspan` or `plt.axhspan`.
+
+        """
+        kwargs = normalize_kwargs(kwargs, dict(color=['c']))
+        params = np.ravel(params)
+        vmins = np.ravel(vmins)
+        vmaxs = np.ravel(vmaxs)
+        if params.size != vmins.size:
+            raise ValueError("The sizes of `params`, `vmins` and `vmaxs` must "
+                             "match exactly, but params.size=%s, "
+                             "vmins.size=%s and vmaxs.size=%s."
+                             % (params.size, vmins.size, vmaxs.size))
+        for i, param in enumerate(params):
+            if param in self.columns:
+                for ax in self.loc[:, param]:
+                    ax.axvspan(vmins[i], vmaxs[i], **kwargs)
+            if param in self.index:
+                for ax in self.loc[param, self.columns != param]:
+                    ax.axhspan(vmins[i], vmaxs[i], **kwargs)
 
 
 def make_1d_axes(params, **kwargs):

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -37,6 +37,8 @@ from anesthetic.boundary import cut_and_normalise_gaussian
 
 
 class AxesSeries(pandas.Series):
+    """Anesthetic's axes version of `pandas.Series`."""
+
     @property
     def _constructor(self):
         return AxesSeries
@@ -47,6 +49,8 @@ class AxesSeries(pandas.Series):
 
 
 class AxesDataFrame(pandas.DataFrame):
+    """Anesthetic's axes version of `pandas.DataFrame`."""
+
     @property
     def _constructor(self):
         return AxesDataFrame
@@ -56,20 +60,19 @@ class AxesDataFrame(pandas.DataFrame):
         return AxesSeries
 
     def axlines(self, params, values, **kwargs):
-        """
-        Add vertical and horizontal lines across all axes for the given
-        parameter, value pairs.
+        """Add vertical and horizontal lines across all axes.
 
         Parameters
         ----------
-        params : str, list(str)
-            parameter label(s).
-            Should match the shape of `values`.
-        values : float, list(float)
-            value(s) at which vertical and horizontal lines should be added.
-            Should match the shape of `params`.
-        kwargs
-            Anything that can be passed to `plt.axvline` or `plt.axhline`.
+            params : str, list(str)
+                parameter label(s).
+                Should match the shape of `values`.
+            values : float, list(float)
+                value(s) at which vertical and horizontal lines should be added.
+                Should match the shape of `params`.
+            kwargs
+                Any kwarg that can be passed to `plt.axvline` or `plt.axhline`.
+
         """
         params = np.atleast_1d(params)
         values = np.atleast_1d(values)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -213,11 +213,12 @@ def test_2d_axlines_axspans(axesparams, params, values):
 def test_2d_axlines_axspans_error(params, values):
     values = np.array(values)
     axesparams = ['A', 'B', 'C', 'D']
+    fig, axes = make_2d_axes(axesparams)
     with pytest.raises(ValueError):
-        fig, axes = make_2d_axes(axesparams)
         axes.axlines(params, values)
+    with pytest.raises(ValueError):
         axes.axspans(params, values-0.1, values+0.1)
-        plt.close("all")
+    plt.close("all")
 
 
 @pytest.mark.parametrize('plot_1d', [kde_plot_1d, fastkde_plot_1d])

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -200,6 +200,7 @@ def test_2d_axlines(axesparams, params, values):
     kwargs = dict(c='k', ls='--', lw=0.5)
     fig, axes = make_2d_axes(axesparams)
     axes.axlines(params, values, **kwargs)
+    plt.close("all")
 
 
 @pytest.mark.parametrize('params, values', [('A', [0, 0]),
@@ -211,6 +212,7 @@ def test_2d_axlines_error(params, values):
         axesparams = ['A', 'B', 'C', 'D']
         fig, axes = make_2d_axes(axesparams)
         axes.axlines(params, values)
+        plt.close("all")
 
 
 @pytest.mark.parametrize('plot_1d', [kde_plot_1d, fastkde_plot_1d])

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -196,10 +196,13 @@ def test_2d_axes_limits():
 @pytest.mark.parametrize('params, values', [('A', 0),
                                             (['A', 'C', 'E'], [0, 0, 0]),
                                             (['A', 'C', 'C'], [0, 0, 0.5])])
-def test_2d_axlines(axesparams, params, values):
-    kwargs = dict(c='k', ls='--', lw=0.5)
+def test_2d_axlines_axspans(axesparams, params, values):
+    values = np.array(values)
+    line_kwargs = dict(c='k', ls='--', lw=0.5)
+    span_kwargs = dict(c='k', alpha=0.5)
     fig, axes = make_2d_axes(axesparams)
-    axes.axlines(params, values, **kwargs)
+    axes.axlines(params, values, **line_kwargs)
+    axes.axspans(params, values-0.1, values+0.1, **span_kwargs)
     plt.close("all")
 
 
@@ -207,11 +210,13 @@ def test_2d_axlines(axesparams, params, values):
                                             (['A', 'C'], 0),
                                             (['A', 'C'], [0, 0, 0.5]),
                                             (['A', 'C', 'C'], [0, 0])])
-def test_2d_axlines_error(params, values):
+def test_2d_axlines_axspans_error(params, values):
+    values = np.array(values)
+    axesparams = ['A', 'B', 'C', 'D']
     with pytest.raises(ValueError):
-        axesparams = ['A', 'B', 'C', 'D']
         fig, axes = make_2d_axes(axesparams)
         axes.axlines(params, values)
+        axes.axspans(params, values-0.1, values+0.1)
         plt.close("all")
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -190,6 +190,29 @@ def test_2d_axes_limits():
                 assert(axes[z][y].get_ylim() == (c, d))
 
 
+@pytest.mark.parametrize('axesparams', [['A', 'B', 'C', 'D'],
+                                        [['A', 'B', 'C', 'D'], ['A', 'B']],
+                                        [['A', 'B'], ['A', 'B', 'C', 'D']]])
+@pytest.mark.parametrize('params, values', [('A', 0),
+                                            (['A', 'C', 'E'], [0, 0, 0]),
+                                            (['A', 'C', 'C'], [0, 0, 0.5])])
+def test_2d_axlines(axesparams, params, values):
+    kwargs = dict(c='k', ls='--', lw=0.5)
+    fig, axes = make_2d_axes(axesparams)
+    axes.axlines(params, values, **kwargs)
+
+
+@pytest.mark.parametrize('params, values', [('A', [0, 0]),
+                                            (['A', 'C'], 0),
+                                            (['A', 'C'], [0, 0, 0.5]),
+                                            (['A', 'C', 'C'], [0, 0])])
+def test_2d_axlines_error(params, values):
+    with pytest.raises(ValueError):
+        axesparams = ['A', 'B', 'C', 'D']
+        fig, axes = make_2d_axes(axesparams)
+        axes.axlines(params, values)
+
+
 @pytest.mark.parametrize('plot_1d', [kde_plot_1d, fastkde_plot_1d])
 def test_kde_plot_1d(plot_1d):
     fig, ax = plt.subplots()


### PR DESCRIPTION
This PR addresses #164 and provides the method `axlines` that can be applied to the `axes` dataframe which adds vertical and horizontal lines to all subplots for a given parameter value. This is achieved by subclassing `pandas.Series` and `pandas.DataFrame` (we call the new objects `AxesSeries` and `AxesDataFrame` respectively) and then creating the new method `axlines` which broadcasts matplotlib's `axvline` and `axhline` across all axes.

Fixes #164 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
