### PR TITLE
Upgrade to quantile function arising from pandas 1.3.0 internals change

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
 
     - name: Test with pytest
       shell: bash -l {0}
-      run: pytest --cov=anesthetic -n auto tests
+      run: pytest -m pytest --cov=anesthetic -n auto tests
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,10 @@ jobs:
 
     - name: Test with pytest
       shell: bash -l {0}
-      run: pytest -m pytest --cov=anesthetic -n auto tests
+      run: |
+        pwd
+        ls
+        pytest -m pytest --cov=anesthetic -n auto tests
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,10 +80,7 @@ jobs:
 
     - name: Test with pytest
       shell: bash -l {0}
-      run: |
-        pwd
-        ls
-        python -m pytest --cov=anesthetic -n auto tests
+      run: python -m pytest --cov=anesthetic -n auto tests
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         pwd
         ls
-        pytest -m pytest --cov=anesthetic -n auto tests
+        python -m pytest --cov=anesthetic -n auto tests
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -68,7 +68,7 @@ def compress_weights(w, u=None, nsamples=None):
     return (integer + extra).astype(int)
 
 
-def quantile(a, q, w=None):
+def quantile(a, q, w=None, interpolation='linear'):
     """Compute the weighted quantile for a one dimensional array."""
     if w is None:
         w = np.ones_like(a)
@@ -78,7 +78,7 @@ def quantile(a, q, w=None):
     c = np.cumsum(w[i[1:]]+w[i[:-1]])
     c /= c[-1]
     c = np.concatenate(([0.], c))
-    icdf = interp1d(c, a[i])
+    icdf = interp1d(c, a[i], kind=interpolation)
     quant = icdf(q)
     if isinstance(q, float):
         quant = float(quant)

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -127,9 +127,11 @@ class WeightedSeries(_WeightedObject, Series):
         """Weighted standard error of the mean."""
         return np.sqrt(self.var(skipna=skipna)/self.neff())
 
-    def quantile(self, q=0.5, **kwargs):
+    def quantile(self, q=0.5, numeric_only=True, interpolation='linear'):
         """Weighted quantile of the sampled distribution."""
-        return quantile(self.values, q, self.weights, **kwargs)
+        if not numeric_only:
+            raise NotImplementedError("numeric_only kwarg not implemented")
+        return quantile(self.values, q, self.weights, interpolation)
 
     def compress(self, nsamples=None):
         """Reduce the number of samples by discarding low-weights.
@@ -266,8 +268,11 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
         n = self.neff() if axis == 0 else self.shape[1]
         return np.sqrt(self.var(axis=axis, skipna=skipna)/n)
 
-    def quantile(self, q=0.5, axis=0, **kwargs):
+    def quantile(self, q=0.5, axis=0, numeric_only=True,
+                 interpolation='linear'):
         """Weighted quantile of the sampled distribution."""
+        if not numeric_only:
+            raise NotImplementedError("numeric_only kwarg not implemented")
         if axis == 0:
             data = np.array([c.quantile(q) for _, c in self.iteritems()])
             if np.isscalar(q):
@@ -275,7 +280,8 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
             else:
                 return DataFrame(data.T, columns=self.columns, index=q)
         else:
-            return super().quantile(q=q, axis=axis, **kwargs)
+            return super().quantile(q=q, axis=axis, numeric_only=numeric_only,
+                                    interpolation=interpolation)
 
     def compress(self, nsamples=None):
         """Reduce the number of samples by discarding low-weights.

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -127,9 +127,9 @@ class WeightedSeries(_WeightedObject, Series):
         """Weighted standard error of the mean."""
         return np.sqrt(self.var(skipna=skipna)/self.neff())
 
-    def quantile(self, q=0.5):
+    def quantile(self, q=0.5, **kwargs):
         """Weighted quantile of the sampled distribution."""
-        return quantile(self.values, q, self.weights)
+        return quantile(self.values, q, self.weights, **kwargs)
 
     def compress(self, nsamples=None):
         """Reduce the number of samples by discarding low-weights.
@@ -266,7 +266,7 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
         n = self.neff() if axis == 0 else self.shape[1]
         return np.sqrt(self.var(axis=axis, skipna=skipna)/n)
 
-    def quantile(self, q=0.5, axis=0):
+    def quantile(self, q=0.5, axis=0, **kwargs):
         """Weighted quantile of the sampled distribution."""
         if axis == 0:
             data = np.array([c.quantile(q) for _, c in self.iteritems()])
@@ -275,7 +275,7 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
             else:
                 return DataFrame(data.T, columns=self.columns, index=q)
         else:
-            return super().quantile(q=q, axis=axis)
+            return super().quantile(q=q, axis=axis, **kwargs)
 
     def compress(self, nsamples=None):
         """Reduce the number of samples by discarding low-weights.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scipy>=1.2.0
 numpy
-pandas>=1.1.0
+pandas>=1.1.0,<1.3.0
 matplotlib>=3.3.0

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -203,6 +203,9 @@ def test_WeightedDataFrame_quantile():
     quantile = df.quantile(qs, axis=1)
     assert isinstance(quantile, WeightedDataFrame)
 
+    with pytest.raises(NotImplementedError):
+        df.quantile(numeric_only=False)
+
 
 def test_WeightedDataFrame_hist():
     plt.figure()
@@ -404,6 +407,9 @@ def test_WeightedSeries_quantile():
         assert_allclose(quantile, q, atol=1e-2)
 
     assert_allclose(series.quantile(qs), qs, atol=1e-2)
+
+    with pytest.raises(NotImplementedError):
+        series.quantile(numeric_only=False)
 
 
 def test_WeightedSeries_hist():


### PR DESCRIPTION
The failing tests in #153, #162, #163, #167, and #168 appear to be a result of problems in pandas itself, introduced in pandas 1.3.0.
Setting pandas requirements to `pandas<1.3.0` to test this hypothesis.
EDIT: Confirmed, setting `pandas<1.3.0` let's tests pass (once conda CI got fixed).

---

The problem in the failing tests turns out, that pandas `quantile` is calling itself with the kwargs `axis`, `numeric_only` and `interpolation`. However anesthetic's inherited `WeightedDataFrame` overwrites that method without allowing for all these kwargs. In the self call this then results in a TypeError.

This is pandas `quantile` method calling itself:

```python
    def quantile(
        self,
        q=0.5,
        axis: Axis = 0,
        numeric_only: bool = True,
        interpolation: str = "linear",
    ):
    """
    [...]
    """
        validate_percentile(q)
    
        if not is_list_like(q):
            # BlockManager.quantile expects listlike, so we wrap and unwrap here
>           res = self.quantile(
                [q], axis=axis, numeric_only=numeric_only, interpolation=interpolation
            )
```

This is the TypeError thrown by pytest:

```python
E           TypeError: quantile() got an unexpected keyword argument 'numeric_only'
```

Adding `**kwargs` to anesthetics `quantile` function solves this issue (see [c174ef0](https://github.com/williamjameshandley/anesthetic/pull/170/commits/c174ef0d6309b8bcd01f5bff3987507f6be1a346)).

---

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
