### PR TITLE
fix `axlines` and `axspans` for axes with `upper=False`

### DIFF
--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -83,10 +83,12 @@ class AxesDataFrame(pandas.DataFrame):
         for i, param in enumerate(params):
             if param in self.columns:
                 for ax in self.loc[:, param]:
-                    ax.axvline(values[i], **kwargs)
+                    if ax is not None:
+                        ax.axvline(values[i], **kwargs)
             if param in self.index:
                 for ax in self.loc[param, self.columns != param]:
-                    ax.axhline(values[i], **kwargs)
+                    if ax is not None:
+                        ax.axhline(values[i], **kwargs)
 
     def axspans(self, params, vmins, vmaxs, **kwargs):
         """Add vertical and horizontal spans across all axes.
@@ -118,10 +120,12 @@ class AxesDataFrame(pandas.DataFrame):
         for i, param in enumerate(params):
             if param in self.columns:
                 for ax in self.loc[:, param]:
-                    ax.axvspan(vmins[i], vmaxs[i], **kwargs)
+                    if ax is not None:
+                        ax.axvspan(vmins[i], vmaxs[i], **kwargs)
             if param in self.index:
                 for ax in self.loc[param, self.columns != param]:
-                    ax.axhspan(vmins[i], vmaxs[i], **kwargs)
+                    if ax is not None:
+                        ax.axhspan(vmins[i], vmaxs[i], **kwargs)
 
 
 def make_1d_axes(params, **kwargs):

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -223,11 +223,12 @@ def test_2d_axes_limits():
 @pytest.mark.parametrize('params, values', [('A', 0),
                                             (['A', 'C', 'E'], [0, 0, 0]),
                                             (['A', 'C', 'C'], [0, 0, 0.5])])
-def test_2d_axlines_axspans(axesparams, params, values):
+@pytest.mark.parametrize('upper', [True, False])
+def test_2d_axlines_axspans(axesparams, params, values, upper):
     values = np.array(values)
     line_kwargs = dict(c='k', ls='--', lw=0.5)
     span_kwargs = dict(c='k', alpha=0.5)
-    fig, axes = make_2d_axes(axesparams)
+    fig, axes = make_2d_axes(axesparams, upper=upper)
     axes.axlines(params, values, **line_kwargs)
     axes.axspans(params, values-0.1, values+0.1, **span_kwargs)
     plt.close("all")


### PR DESCRIPTION
For a description of the bug, see #174. This PR aims at fixing that bug.

Fixes #174 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
