### PR TITLE
adapt to breaking chanes in matplotlib API version 3.5.0

### DIFF
--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -292,7 +292,6 @@ def make_2d_axes(params, **kwargs):
                     axes[x][y].twin = axes[x][y].twinx()
                     axes[x][y].twin.set_yticks([])
                     axes[x][y].twin.set_ylim(0, 1.1)
-                    axes[x][y].set_zorder(axes[x][y].twin.get_zorder() + 1)
                     make_diagonal(axes[x][y])
                     axes[x][y].position = 'diagonal'
                     axes[x][y].twin.xaxis.set_major_locator(

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -293,10 +293,6 @@ def make_2d_axes(params, **kwargs):
                     axes[x][y].twin.set_yticks([])
                     axes[x][y].twin.set_ylim(0, 1.1)
                     axes[x][y].set_zorder(axes[x][y].twin.get_zorder() + 1)
-                    axes[x][y].lines = axes[x][y].twin.lines
-                    axes[x][y].patches = axes[x][y].twin.patches
-                    axes[x][y].collections = axes[x][y].twin.collections
-                    axes[x][y].containers = axes[x][y].twin.containers
                     make_diagonal(axes[x][y])
                     axes[x][y].position = 'diagonal'
                     axes[x][y].twin.xaxis.set_major_locator(
@@ -725,19 +721,19 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
                             *args, **kwargs)
         for c in contf.collections:
             c.set_cmap(cmap)
-        ax.patches += [plt.Rectangle((0, 0), 0, 0, lw=2, label=label,
-                                     fc=cmap(0.999), ec=cmap(0.32))]
+        ax.add_patch(plt.Rectangle((0, 0), 0, 0, lw=2, label=label,
+                                   fc=cmap(0.999), ec=cmap(0.32)))
         cmap = None
     else:
         linewidths = kwargs.pop('linewidths',
                                 plt.rcParams.get('lines.linewidth'))
         cmap = kwargs.pop('cmap', None)
         contf = None
-        ax.patches += [
+        ax.add_patch(
             plt.Rectangle((0, 0), 0, 0, lw=2, label=label,
                           fc='None' if cmap is None else cmap(0.999),
                           ec=edgecolor if cmap is None else cmap(0.32))
-        ]
+        )
         edgecolor = edgecolor if cmap is None else None
 
     vmin, vmax = match_contour_to_contourf(levels, vmin=0, vmax=pdf.max())
@@ -844,19 +840,19 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
                                vmin=0, vmax=p.max(), *args, **kwargs)
         for c in contf.collections:
             c.set_cmap(cmap)
-        ax.patches += [plt.Rectangle((0, 0), 0, 0, lw=2, label=label,
-                                     fc=cmap(0.999), ec=cmap(0.32))]
+        ax.add_patch(plt.Rectangle((0, 0), 0, 0, lw=2, label=label,
+                                   fc=cmap(0.999), ec=cmap(0.32)))
         cmap = None
     else:
         linewidths = kwargs.pop('linewidths',
                                 plt.rcParams.get('lines.linewidth'))
         cmap = kwargs.pop('cmap', None)
         contf = None
-        ax.patches += [
+        ax.add_patch(
             plt.Rectangle((0, 0), 0, 0, lw=2, label=label,
                           fc='None' if cmap is None else cmap(0.999),
                           ec=edgecolor if cmap is None else cmap(0.32))
-        ]
+        )
         edgecolor = edgecolor if cmap is None else None
 
     vmin, vmax = match_contour_to_contourf(levels, vmin=0, vmax=p.max())
@@ -946,8 +942,8 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
         image = ax.pcolormesh(x, y, pdf.T, cmap=cmap, vmin=vmin,
                               *args, **kwargs)
 
-    ax.patches += [plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999), ec=cmap(0.32),
-                                 lw=2, label=label)]
+    ax.add_patch(plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999), ec=cmap(0.32),
+                               lw=2, label=label))
 
     ax.set_xlim(*check_bounds(x, xmin, xmax), auto=True)
     ax.set_ylim(*check_bounds(y, ymin, ymax), auto=True)

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -1052,6 +1052,7 @@ def normalize_kwargs(kwargs, alias_mapping=None, drop=None):
 
 
 def set_colors(c, fc, ec, cmap):
+    """Navigate interplay between possible color inputs {c, fc, ec, cmap}."""
     if fc in [None, 'None', 'none']:
         # unfilled contours
         if ec is None and cmap is None:

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -1062,7 +1062,7 @@ def set_colors(c, fc, ec, cmap):
             fc = c
         if ec is None and cmap is None:
             ec = c
-            cmap = basic_cmap(c)
+            cmap = basic_cmap(fc)
         elif ec is None:
             ec = (cmap(1.),)
         elif cmap is None:

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -1017,6 +1017,13 @@ def make_diagonal(ax):
                              xmin=ymin, xmax=ymax)
             return super().set_ylim(bottom=bottom, top=top, emit=emit,
                                     auto=auto, ymin=ymin, ymax=ymax)
+
+        def get_legend_handles_labels(self, *args, **kwargs):
+            return self.twin.get_legend_handles_labels(*args, **kwargs)
+
+        def legend(self, *args, **kwargs):
+            return self.twin.legend(*args, **kwargs)
+
     ax.__class__ = DiagonalAxes
 
 

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -694,8 +694,11 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     zorder = kwargs.pop('zorder', 1)
     levels = kwargs.pop('levels', [0.95, 0.68])
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
-    facecolor = kwargs.pop('facecolor', color)
-    edgecolor = kwargs.pop('edgecolor', color)
+    facecolor = kwargs.pop('facecolor', True)
+    edgecolor = kwargs.pop('edgecolor', None)
+    cmap = kwargs.pop('cmap', None)
+    facecolor, edgecolor, cmap = set_colors(c=color, fc=facecolor,
+                                            ec=edgecolor, cmap=cmap)
     kwargs.pop('q', None)
 
     if len(data_x) == 0 or len(data_y) == 0:
@@ -715,7 +718,6 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
 
     if facecolor not in [None, 'None', 'none']:
         linewidths = kwargs.pop('linewidths', 0.5)
-        cmap = kwargs.pop('cmap', basic_cmap(facecolor))
         contf = ax.contourf(x[i], y[j], pdf[np.ix_(j, i)], levels, cmap=cmap,
                             zorder=zorder, vmin=0, vmax=pdf.max(),
                             *args, **kwargs)
@@ -727,14 +729,12 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     else:
         linewidths = kwargs.pop('linewidths',
                                 plt.rcParams.get('lines.linewidth'))
-        cmap = kwargs.pop('cmap', None)
         contf = None
         ax.add_patch(
             plt.Rectangle((0, 0), 0, 0, lw=2, label=label,
                           fc='None' if cmap is None else cmap(0.999),
                           ec=edgecolor if cmap is None else cmap(0.32))
         )
-        edgecolor = edgecolor if cmap is None else None
 
     vmin, vmax = match_contour_to_contourf(levels, vmin=0, vmax=pdf.max())
     cont = ax.contour(x[i], y[j], pdf[np.ix_(j, i)], levels, zorder=zorder,
@@ -800,8 +800,11 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     zorder = kwargs.pop('zorder', 1)
     levels = kwargs.pop('levels', [0.95, 0.68])
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
-    facecolor = kwargs.pop('facecolor', color)
-    edgecolor = kwargs.pop('edgecolor', color)
+    facecolor = kwargs.pop('facecolor', True)
+    edgecolor = kwargs.pop('edgecolor', None)
+    cmap = kwargs.pop('cmap', None)
+    facecolor, edgecolor, cmap = set_colors(c=color, fc=facecolor,
+                                            ec=edgecolor, cmap=cmap)
     kwargs.pop('q', None)
 
     if len(data_x) == 0 or len(data_y) == 0:
@@ -835,7 +838,6 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
 
     if facecolor not in [None, 'None', 'none']:
         linewidths = kwargs.pop('linewidths', 0.5)
-        cmap = kwargs.pop('cmap', basic_cmap(facecolor))
         contf = ax.tricontourf(tri, p, levels=levels, cmap=cmap, zorder=zorder,
                                vmin=0, vmax=p.max(), *args, **kwargs)
         for c in contf.collections:
@@ -846,14 +848,12 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     else:
         linewidths = kwargs.pop('linewidths',
                                 plt.rcParams.get('lines.linewidth'))
-        cmap = kwargs.pop('cmap', None)
         contf = None
         ax.add_patch(
             plt.Rectangle((0, 0), 0, 0, lw=2, label=label,
                           fc='None' if cmap is None else cmap(0.999),
                           ec=edgecolor if cmap is None else cmap(0.32))
         )
-        edgecolor = edgecolor if cmap is None else None
 
     vmin, vmax = match_contour_to_contourf(levels, vmin=0, vmax=p.max())
     cont = ax.tricontour(tri, p, levels=levels, zorder=zorder,
@@ -1049,3 +1049,22 @@ def normalize_kwargs(kwargs, alias_mapping=None, drop=None):
     for key in set(drop) & set(kwargs.keys()):
         kwargs.pop(key)
     return kwargs
+
+
+def set_colors(c, fc, ec, cmap):
+    if fc in [None, 'None', 'none']:
+        # unfilled contours
+        if ec is None and cmap is None:
+            cmap = basic_cmap(c)
+    else:
+        # filled contours
+        if fc is True:
+            fc = c
+        if ec is None and cmap is None:
+            ec = c
+            cmap = basic_cmap(c)
+        elif ec is None:
+            ec = (cmap(1.),)
+        elif cmap is None:
+            cmap = basic_cmap(fc)
+    return fc, ec, cmap

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -15,7 +15,7 @@ from matplotlib.contour import QuadContourSet
 from matplotlib.tri import TriContourSet
 from matplotlib.lines import Line2D
 from matplotlib.patches import Patch, Polygon
-from matplotlib.colors import ColorConverter, to_rgba
+from matplotlib.colors import ColorConverter, to_rgba, rgb2hex
 from matplotlib.figure import Figure
 from pandas.core.series import Series
 from pandas.core.frame import DataFrame
@@ -546,13 +546,23 @@ def test_contour_plot_2d(contour_plot_2d):
         cf, ct = contour_plot_2d(ax, data_x, data_y, ec='C0', cmap=plt.cm.Reds)
         assert cf.get_cmap() == plt.cm.Reds
         assert ct.colors == 'C0'
+        plt.close("all")
+        ax = plt.gca()
+        cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None)
+        assert cf is None
+        assert ct.colors is None
+        assert ct.get_cmap() == basic_cmap(rgb2hex('C0'))
+        cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None, c='C3')
+        assert cf is None
+        assert ct.colors is None
+        assert ct.get_cmap() == basic_cmap('C3')
         cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None, ec='C1')
         assert cf is None
         assert ct.colors == 'C1'
         cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None, cmap=plt.cm.Reds)
         assert cf is None
-        assert ct.get_cmap() == plt.cm.Reds
         assert ct.colors is None
+        assert ct.get_cmap() == plt.cm.Reds
         plt.close("all")
 
         # Check limits, Gaussian (i.e. limits reduced to relevant data range)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -605,12 +605,12 @@ def test_contour_plot_2d_levels(contour_plot_2d, levels):
 
         # assert that color between filled and unfilled contours matches
         # first level
-        color1 = ax1.get_children()[0].get_facecolor()  # filled face color
-        color2 = ax2.get_children()[0].get_edgecolor()  # unfilled line color
+        color1 = ax1.collections[0].get_facecolor()  # filled face color
+        color2 = ax2.collections[0].get_edgecolor()  # unfilled line color
         assert_array_equal(color1, color2)
         # last level
-        color1 = ax1.get_children()[len(levels)-1].get_facecolor()
-        color2 = ax2.get_children()[len(levels)-1].get_edgecolor()
+        color1 = ax1.collections[len(levels)-1].get_facecolor()
+        color2 = ax2.collections[len(levels)-1].get_edgecolor()
         assert_array_equal(color1, color2)
 
         plt.close("all")

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -15,7 +15,7 @@ from matplotlib.contour import QuadContourSet
 from matplotlib.tri import TriContourSet
 from matplotlib.lines import Line2D
 from matplotlib.patches import Patch, Polygon
-from matplotlib.colors import ColorConverter, to_rgba, rgb2hex
+from matplotlib.colors import ColorConverter, to_rgba
 from matplotlib.figure import Figure
 from pandas.core.series import Series
 from pandas.core.frame import DataFrame
@@ -546,12 +546,6 @@ def test_contour_plot_2d(contour_plot_2d):
         cf, ct = contour_plot_2d(ax, data_x, data_y, ec='C0', cmap=plt.cm.Reds)
         assert cf.get_cmap() == plt.cm.Reds
         assert ct.colors == 'C0'
-        plt.close("all")
-        ax = plt.gca()
-        cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None)
-        assert cf is None
-        assert ct.colors is None
-        assert ct.get_cmap() == basic_cmap(rgb2hex('C0'))
         cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None, c='C3')
         assert cf is None
         assert ct.colors is None

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -546,10 +546,16 @@ def test_contour_plot_2d(contour_plot_2d):
         cf, ct = contour_plot_2d(ax, data_x, data_y, ec='C0', cmap=plt.cm.Reds)
         assert cf.get_cmap() == plt.cm.Reds
         assert ct.colors == 'C0'
+        plt.close("all")
+        ax = plt.gca()
+        cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None)
+        assert cf is None
+        assert ct.colors is None
+        assert ct.get_cmap()(1.) == to_rgba('C0')
         cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None, c='C3')
         assert cf is None
         assert ct.colors is None
-        assert ct.get_cmap() == basic_cmap('C3')
+        assert ct.get_cmap()(1.) == to_rgba('C3')
         cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None, ec='C1')
         assert cf is None
         assert ct.colors == 'C1'

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -212,6 +212,9 @@ def test_plot_2d_legend():
     for y, row in axes.iterrows():
         for x, ax in row.iteritems():
             if ax is not None:
+                leg = ax.legend()
+                assert(leg.get_texts()[0].get_text() == 'l1')
+                assert(leg.get_texts()[1].get_text() == 'l2')
                 handles, labels = ax.get_legend_handles_labels()
                 assert(labels == ['l1', 'l2'])
                 if x == y:
@@ -228,6 +231,9 @@ def test_plot_2d_legend():
     for y, row in axes.iterrows():
         for x, ax in row.iteritems():
             if ax is not None:
+                leg = ax.legend()
+                assert(leg.get_texts()[0].get_text() == 'l1')
+                assert(leg.get_texts()[1].get_text() == 'l2')
                 handles, labels = ax.get_legend_handles_labels()
                 assert(labels == ['l1', 'l2'])
                 if x == y:


### PR DESCRIPTION
# Description

This PR addresses the API change in [matplotlib version 3.5.0](https://matplotlib.org/3.5.0/api/prev_api_changes/api_changes_3.5.0.html#axes-children-are-no-longer-separated-by-type) that currently breaks our code/tests, as raised by Stefan in #183.

Fixes #183 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
