### PR TITLE
Fixing unexpected behaviour associated with reset_index

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley and Lukas Hergt
-:Version: 2.0.0-beta.10
+:Version: 2.0.0-beta.11
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -754,7 +754,7 @@ class NestedSamples(MCMCSamples):
                               "\nDropping the invalid samples." %
                               (n_bad, len(samples), n_equal),
                               RuntimeWarning)
-                samples = samples[~invalid].reset_index()
+                samples = samples[~invalid].reset_index(drop=True)
 
             samples['nlive'] = compute_nlive(samples.logL, samples.logL_birth)
 


### PR DESCRIPTION
# Description

When dropping points associated with unordered likelihoods (which raises a
warning as of #159), since the pandas `reset_index` function has `drop=False`
by default, this has the unexpected behaviour of creating an extra `index`
column. This PR adjusts this by explicitly setting `drop=True` it does earlier
in the function

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works
