### PR TITLE
Fix for unsorted logL construction bug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ anesthetic: nested sampling visualisation
 =========================================
 :anesthetic: nested sampling visualisation
 :Author: Will Handley and Lukas Hergt
-:Version: 2.0.0-beta.11
+:Version: 2.0.0-beta.12
 :Homepage: https://github.com/williamjameshandley/anesthetic
 :Documentation: http://anesthetic.readthedocs.io/
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -725,10 +725,12 @@ class NestedSamples(MCMCSamples):
             frame with contours resorted and nlive recomputed
             default: False
         """
-        samples = self.sort_values('logL').reset_index(drop=True)
+        samples = self.copy()
 
         if is_int(logL_birth):
             nlive = logL_birth
+            samples.sort_values('logL', inplace=True)
+            samples.reset_index(drop=True, inplace=True)
             samples['nlive'] = nlive
             descending = np.arange(nlive, 0, -1)
             samples.loc[len(samples)-nlive:, 'nlive'] = descending
@@ -756,6 +758,8 @@ class NestedSamples(MCMCSamples):
                               RuntimeWarning)
                 samples = samples[~invalid].reset_index(drop=True)
 
+            samples.sort_values('logL', inplace=True)
+            samples.reset_index(drop=True, inplace=True)
             samples['nlive'] = compute_nlive(samples.logL, samples.logL_birth)
 
         samples.tex['nlive'] = r'$n_{\rm live}$'

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -840,6 +840,16 @@ def test_recompute():
         mn.recompute()
 
 
+def test_unsorted():
+    np.random.seed(4)
+    pc = NestedSamples(root='./tests/example_data/pc')
+    i = np.random.choice(len(pc), len(pc), replace=False)
+    pc_resort = NestedSamples(data=pc.loc[i, ['x0', 'x1', 'x2', 'x3', 'x4']],
+                              logL=pc.loc[i, 'logL'],
+                              logL_birth=pc.loc[i, 'logL_birth'])
+    assert_array_equal(pc_resort, pc)
+
+
 def test_copy():
     np.random.seed(3)
     pc = NestedSamples(root='./tests/example_data/pc')


### PR DESCRIPTION
# Description

In the process of solving #182 with #186, I uncovered a somewhat nasty bug associated with a premature sort command in `NestedSamples.recompute`, present since #126. This affects arrays that are constructed or loaded which don't have sorted loglikelihood contours. The effect of the bug is to randomise the `logL_birth` contour. Whilst dead points are stored in loglikelihood order, live points are generally not. I believe that bug has remained hidden since 
1. in the most instances for a completed run with reasonable (i.e. default) termination criteria the effect of somewhat randomised live points shouldn't matter 
2. this doesn't affect polychord points due to the [line](https://github.com/williamjameshandley/anesthetic/blob/ad78c426be5b0b69a63314650f8cf3a8d1779437/anesthetic/read/polychordreader.py#L15) `data = np.unique(data, axis=0)` accounting for the fact that PolyChord at the end of a run after deleting all the dead points effectively ignores the live points file.
3. The `RunTimeWarning` behaviour for slightly unsorted loglikelihood contours #159, designed to ignore numerical rounding errors at the end of a run partially masks this.

The final point means that if you have been seeing the warnings `X out of Y samples have logL <= logL_birth,\nZ of which have logL == logL_birth."` then it would be worth re-running anesthetic calculations/plots after this is merged just in case.

First commit demonstrates this with a failing test, remaining commits fix.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
