### PR TITLE
Implemented Samples.credibility_interval

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -348,9 +348,10 @@ class MCMCSamples(WeightedDataFrame):
         return fig, axes
 
     def credibility_interval(self, key, level=0.68, method="iso-probability"):
-        """Compute the marginalised credibility interval, also referred to as
-        confidence interval or iso-probability contours. Also options to
-        compute upper or lower limits instead.
+        """Compute the marginalised credibility interval.
+
+        Also referred to as confidence interval or iso-probability contours.
+        Also options to compute upper or lower limits instead.
 
         Note: This is based on the discrete set of points and weights without
         interpolation. Discretization error is determined by the (normalized)
@@ -369,6 +370,7 @@ class MCMCSamples(WeightedDataFrame):
             samples), or whether to compute one-sided limits "lower-limit" /
             "upper-limit" for which `level` fraction of the samples lie
             above / below the limit.
+
         Returns
         -------
         limit: tuple or float

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -374,7 +374,7 @@ class MCMCSamples(WeightedDataFrame):
         limit: tuple or float
             Tuple (iso-probability interval) or float (upper/lower limit)
         """
-        assert level<1, "Level >= 1!"
+        assert level < 1, "Level >= 1 is not allowed!"
         samples = self[key]
         weights = self.weights
         # Sort and normalize
@@ -386,15 +386,17 @@ class MCMCSamples(WeightedDataFrame):
         CDF = np.append(np.insert(np.cumsum(weights), 0, 0), 1)
         S = np.array([np.min(samples), *samples, np.max(samples)])
         invcdf = interp1d(CDF, S)
-        if method=="iso-probability":
+        if method == "iso-probability":
             # Find smallest interval
-            distance = lambda a, level=level: invcdf(a+level)-invcdf(a)
-            a = minimize_scalar(distance, bounds=(0,1-level), method="Bounded")
+            def distance(a, level=level):
+                return invcdf(a+level)-invcdf(a)
+            a = minimize_scalar(distance, bounds=(0, 1-level),
+                                method="Bounded")
             interval = (invcdf(a.x), invcdf(a.x+level))
-        elif method=="lower-limit":
+        elif method == "lower-limit":
             # Get value from which we reach the desired level
             interval = invcdf(1-level)
-        elif method=="upper-limit":
+        elif method == "upper-limit":
             # Get value to which we reach the desired level
             interval = invcdf(level)
         else:

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -348,8 +348,14 @@ class MCMCSamples(WeightedDataFrame):
         return fig, axes
 
     def credibility_interval(self, key, level=0.68, method="iso-probability"):
-        """Compute marginalised credibility interval, also referred to as
-        confidence interval or iso-probability contour.
+        """Compute the marginalised credibility interval, also referred to as
+        confidence interval or iso-probability contours. Also options to
+        compute upper or lower limits instead.
+
+        Note: This is based on the discrete set of points and weights without
+        interpolation. Discretization error is determined by the (normalized)
+        weights, i.e. is small for large sample sizes with small weights.
+
         Parameters
         ----------
         key: str

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -874,3 +874,12 @@ def test_plotting_with_integer_names():
     assert_array_equal(samples_1.loc[:, 0], samples_1.iloc[:, 0])
     with pytest.raises(KeyError):
         samples_1['0']
+
+
+def test_credibility_interval():
+    np.random.seed(3)
+    samples = NestedSamples(root='./tests/example_data/pc')
+    assert np.allclose([-0.1001, 0.0951], samples.credibility_interval("x0", level=0.68, method="iso-probability"), atol=0.001)
+    assert np.isclose(0.1633, samples.credibility_interval("x0", level=0.95, method="upper-limit"), atol=0.001)
+    assert np.isclose(-0.0009, samples.credibility_interval("x0", level=0.5, method="lower-limit"), atol=0.001)
+

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -885,6 +885,6 @@ def test_credibility_interval():
     assert np.isclose(samples.credibility_interval("x0", level=0.95,
                                                    method="upper-limit"),
                       0.1633, atol=0.001)
-    assert np.isclose(samples.credibility_interval("x0", level=0.95,
+    assert np.isclose(samples.credibility_interval("x0", level=0.5,
                                                    method="lower-limit"),
                       -0.0009, atol=0.001)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -879,7 +879,12 @@ def test_plotting_with_integer_names():
 def test_credibility_interval():
     np.random.seed(3)
     samples = NestedSamples(root='./tests/example_data/pc')
-    assert np.allclose([-0.1001, 0.0951], samples.credibility_interval("x0", level=0.68, method="iso-probability"), atol=0.001)
-    assert np.isclose(0.1633, samples.credibility_interval("x0", level=0.95, method="upper-limit"), atol=0.001)
-    assert np.isclose(-0.0009, samples.credibility_interval("x0", level=0.5, method="lower-limit"), atol=0.001)
-
+    assert np.allclose(samples.credibility_interval("x0", level=0.68,
+                                                    method="iso-probability"),
+                       [-0.1001, 0.0951], atol=0.001)
+    assert np.isclose(samples.credibility_interval("x0", level=0.95,
+                                                   method="upper-limit"),
+                      0.1633, atol=0.001)
+    assert np.isclose(samples.credibility_interval("x0", level=0.95,
+                                                   method="lower-limit"),
+                      -0.0009, atol=0.001)


### PR DESCRIPTION
Description
===========

Added a `credibility_interval` method to `MCMCSampels`/`NestedSamples`
which computes the credibility / confidence interval.

Fixes \#178 and replaces \#179

Notes:
======

-   Discretization error: Using `np.cumsum`, the value of the CDF at the
    first data point is `== its weight > 0`, but at the last data point
    is `== 1`. This should be negligible for `weights<<1` but for
    significant weights i.e. small sample sizes this can have an effect.
-   Should we add an alias function `confidence_interval`
-   I have also thrown in upper and lower limits which are not
    iso-probability intervals, but rely on the same code

Checklist:
==========

-   [x] I have performed a self-review of my own code
-   [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
-   [x] My code contains compliant docstrings
    (`pydocstyle --convention=numpy anesthetic`)
-   [x] New and existing unit tests pass locally with my changes
    (`python -m pytest`)
-   [x] I have added tests that prove my fix is effective or that my
    feature works
