### PR TITLE
Allow NestedSamples to take lists as well as numpy arrays as constructors

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -93,6 +93,7 @@ class MCMCSamples(WeightedDataFrame):
             logzero = kwargs.pop('logzero', -1e30)
             logL = kwargs.pop('logL', None)
             if logL is not None:
+                logL = np.array(logL)
                 logL = np.where(logL <= logzero, -np.inf, logL)
             self.tex = kwargs.pop('tex', {})
             self.limits = kwargs.pop('limits', {})
@@ -487,6 +488,7 @@ class NestedSamples(MCMCSamples):
             self._beta = kwargs.pop('beta', 1.)
             logL_birth = kwargs.pop('logL_birth', None)
             if not isinstance(logL_birth, int) and logL_birth is not None:
+                logL_birth = np.array(logL_birth)
                 logL_birth = np.where(logL_birth <= logzero, -np.inf,
                                       logL_birth)
 

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -874,3 +874,14 @@ def test_plotting_with_integer_names():
     assert_array_equal(samples_1.loc[:, 0], samples_1.iloc[:, 0])
     with pytest.raises(KeyError):
         samples_1['0']
+
+
+def test_logL_list():
+    np.random.seed(5)
+    default = NestedSamples(root='./tests/example_data/pc')
+    logL = default.logL.tolist()
+    logL_birth = default.logL_birth.tolist()
+    data = default.iloc[:, :5].to_numpy().tolist()
+
+    samples = NestedSamples(data=data, logL=logL, logL_birth=logL_birth)
+    assert_array_equal(default, samples)


### PR DESCRIPTION
# Description

Currently `NestedSamples(data=...,logL=...,logL_birth=...)` assumes that `logL` and `logL_birth` are numpy arrays. It shouldn't.

This adds a test which shows this behaviour, and then fixes with a quick conversion.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works
