### PR TITLE
Fix #189, merge_samples_weighted breaking triangular_sample_compression_2d

### DIFF
--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -335,6 +335,11 @@ def triangular_sample_compression_2d(x, y, cov, w=None, n=1000):
     w: array-like
         Compressed samples and weights
     """
+    # Pre-process samples to not be affected by non-standard indexing
+    # Details: https://github.com/williamjameshandley/anesthetic/issues/189
+    x = np.array(x)
+    y = np.array(y)
+
     x = pandas.Series(x)
     if w is None:
         w = pandas.Series(index=x.index, data=np.ones_like(x))

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -484,6 +484,17 @@ def test_weighted_merging():
     mean = samples.mean()['xtest']
     assert np.isclose(mean, (mean1*weight1+mean2*weight2)/(weight1+weight2))
 
+    # Test plot still works (see issue #189)
+    prior_samples = []
+    for i in range(3):
+        d = {"x": np.random.uniform(size=1000),
+             "y": np.random.uniform(size=1000)}
+        tmp = MCMCSamples(d)
+        prior_samples.append(tmp)
+    merge_prior = merge_samples_weighted(prior_samples, weights=np.ones(3))
+    merge_prior.plot_2d(["x", "y"])
+    plt.close('all')
+
     # Test if correct exceptions are raised:
     # MCMCSamples are passed without weights
     with pytest.raises(ValueError):


### PR DESCRIPTION
# Description

Add
```
x = np.array(x)
y = np.array(y)
```
to `triangular_sample_compression_2d` (already present in `sample_compression_1d`) as suggested by @williamjameshandley.

Fixes #189

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
` 153 passed, 3 xfailed, 1 xpassed, 16 warnings`
- [x] I have added tests that prove my fix is effective or that my feature works
