### PR TITLE
Updated for most recent PEP compliant assert statements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, '3.10']
         extras: [true, false]
 
     steps:
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -9,31 +9,31 @@ def test_gui():
 
     # Type buttons
     plotter.type.buttons.set_active(1)
-    assert(plotter.type() == 'posterior')
+    assert plotter.type() == 'posterior'
     plotter.type.buttons.set_active(0)
-    assert(plotter.type() == 'live')
+    assert plotter.type() == 'live'
 
     # Parameter choice buttons
     plotter.param_choice.buttons.set_active(1)
-    assert(len(plotter.triangle.ax) == 2)
+    assert len(plotter.triangle.ax) == 2
     plotter.param_choice.buttons.set_active(0)
-    assert(len(plotter.triangle.ax) == 1)
+    assert len(plotter.triangle.ax) == 1
     plotter.param_choice.buttons.set_active(0)
     plotter.param_choice.buttons.set_active(2)
     plotter.param_choice.buttons.set_active(3)
-    assert(len(plotter.triangle.ax) == 4)
+    assert len(plotter.triangle.ax) == 4
 
     # Sliders
     plotter.evolution.slider.set_val(100)
-    assert(plotter.evolution() == 100)
+    assert plotter.evolution() == 100
     plotter.type.buttons.set_active(1)
 
     plotter.temperature.slider.set_val(0)
-    assert(plotter.temperature() == 1)
+    assert plotter.temperature() == 1
     plotter.temperature.slider.set_val(1)
-    assert(plotter.temperature() == 10)
+    assert plotter.temperature() == 10
     plotter.temperature.slider.set_val(2)
-    assert(plotter.temperature() == 100)
+    assert plotter.temperature() == 100
     plotter.type.buttons.set_active(0)
 
     if version.parse(mpl_version) >= version.parse('3.4.0'):

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -29,36 +29,36 @@ def test_make_1d_axes():
 
     # Check no optional arguments
     fig, axes = make_1d_axes(paramnames)
-    assert(isinstance(fig, Figure))
-    assert(isinstance(axes, Series))
+    assert isinstance(fig, Figure)
+    assert isinstance(axes, Series)
     assert_array_equal(axes.index, paramnames)
     for p, ax in axes.iteritems():
-        assert(ax.get_xlabel() == p)
+        assert ax.get_xlabel() == p
 
     # Check tex argument
     fig, axes = make_1d_axes(paramnames, tex=tex)
     for t in tex:
-        assert(axes[t].get_xlabel() != t)
-        assert(axes[t].get_xlabel() == tex[t])
+        assert axes[t].get_xlabel() != t
+        assert axes[t].get_xlabel() == tex[t]
 
     # Check fig argument
     fig0 = plt.figure()
     fig0.suptitle('hi there')
     fig, axes = make_1d_axes(paramnames)
-    assert(fig is not fig0)
+    assert fig is not fig0
     fig, axes = make_1d_axes(paramnames, fig=fig0)
-    assert(fig is fig0)
+    assert fig is fig0
 
     # Check ncols argument
     fig, axes = make_1d_axes(paramnames, ncols=2)
     nrows, ncols = axes[0].get_subplotspec().get_gridspec().get_geometry()
-    assert(ncols == 2)
+    assert ncols == 2
 
     # Check gridspec argument
     grid = gs.GridSpec(2, 2, width_ratios=[3, 1], height_ratios=[3, 1])
     g00 = grid[0, 0]
     fig, axes = make_1d_axes(paramnames, subplot_spec=g00)
-    assert(g00 is axes[0].get_subplotspec().get_topmost_subplotspec())
+    assert g00 is axes[0].get_subplotspec().get_topmost_subplotspec()
 
     # Check unexpected kwargs
     with pytest.raises(TypeError):
@@ -72,35 +72,35 @@ def test_make_2d_axes_inputs_outputs():
 
     # 2D axes
     fig, axes = make_2d_axes([paramnames_x, paramnames_y])
-    assert(isinstance(fig, Figure))
-    assert(isinstance(axes, DataFrame))
+    assert isinstance(fig, Figure)
+    assert isinstance(axes, DataFrame)
     assert_array_equal(axes.index, paramnames_y)
     assert_array_equal(axes.columns, paramnames_x)
 
     # Axes labels
     for p, ax in axes.iloc[:, 0].iteritems():
-        assert(ax.get_ylabel() == p)
+        assert ax.get_ylabel() == p
 
     for p, ax in axes.iloc[-1].iteritems():
-        assert(ax.get_xlabel() == p)
+        assert ax.get_xlabel() == p
 
     for ax in axes.iloc[:-1, 1:].to_numpy().flatten():
-        assert(ax.get_xlabel() == '')
-        assert(ax.get_ylabel() == '')
+        assert ax.get_xlabel() == ''
+        assert ax.get_ylabel() == ''
 
     # Check fig argument
     fig0 = plt.figure()
     fig, axes = make_2d_axes(paramnames_x)
-    assert(fig is not fig0)
+    assert fig is not fig0
     fig, axes = make_2d_axes(paramnames_x, fig=fig0)
-    assert(fig is fig0)
+    assert fig is fig0
     plt.close("all")
 
     # Check gridspec argument
     grid = gs.GridSpec(2, 2, width_ratios=[3, 1], height_ratios=[3, 1])
     g00 = grid[0, 0]
     fig, axes = make_2d_axes(paramnames_x, subplot_spec=g00)
-    assert(g00 is axes.iloc[0, 0].get_subplotspec().get_topmost_subplotspec())
+    assert g00 is axes.iloc[0, 0].get_subplotspec().get_topmost_subplotspec()
 
     # Check unexpected kwargs
     with pytest.raises(TypeError):
@@ -130,9 +130,9 @@ def test_make_2d_axes_behaviour():
                                          lower=lower,
                                          diagonal=diagonal)
                 ns = calc_n(axes)
-                assert(ns['upper'] == upper * nx*(nx-1)//2)
-                assert(ns['lower'] == lower * nx*(nx-1)//2)
-                assert(ns['diagonal'] == diagonal * nx)
+                assert ns['upper'] == upper * nx*(nx-1)//2
+                assert ns['lower'] == lower * nx*(nx-1)//2
+                assert ns['diagonal'] == diagonal * nx
 
     plt.close("all")
 
@@ -166,9 +166,9 @@ def test_make_2d_axes_behaviour():
                                              lower=lower,
                                              diagonal=diagonal)
                     ns = calc_n(axes)
-                    assert(ns['upper'] == upper * nu)
-                    assert(ns['lower'] == lower * nl)
-                    assert(ns['diagonal'] == diagonal * nd)
+                    assert ns['upper'] == upper * nu
+                    assert ns['lower'] == lower * nl
+                    assert ns['diagonal'] == diagonal * nd
         plt.close("all")
 
 
@@ -208,13 +208,13 @@ def test_2d_axes_limits():
             a, b, c, d = np.random.rand(4)
             axes[x][y].set_xlim(a, b)
             for z in paramnames:
-                assert(axes[x][z].get_xlim() == (a, b))
-                assert(axes[z][x].get_ylim() == (a, b))
+                assert axes[x][z].get_xlim() == (a, b)
+                assert axes[z][x].get_ylim() == (a, b)
 
             axes[x][y].set_ylim(c, d)
             for z in paramnames:
-                assert(axes[y][z].get_xlim() == (c, d))
-                assert(axes[z][y].get_ylim() == (c, d))
+                assert axes[y][z].get_xlim() == (c, d)
+                assert axes[z][y].get_ylim() == (c, d)
 
 
 @pytest.mark.parametrize('axesparams', [['A', 'B', 'C', 'D'],
@@ -258,29 +258,29 @@ def test_kde_plot_1d(plot_1d):
     try:
         # Check height
         line, = plot_1d(ax, data)
-        assert(isinstance(line, Line2D))
-        assert(line.get_ydata().max() <= 1)
+        assert isinstance(line, Line2D)
+        assert line.get_ydata().max() <= 1
 
         # Check arguments are passed onward to underlying function
         line, = plot_1d(ax, data, color='r')
-        assert(line.get_color() == 'r')
+        assert line.get_color() == 'r'
         line, = plot_1d(ax, data, cmap=plt.cm.Blues)
-        assert(line.get_color() == plt.cm.Blues(0.68))
+        assert line.get_color() == plt.cm.Blues(0.68)
 
         # Check xmin
         xmin = -0.5
         line, = plot_1d(ax, data, xmin=xmin)
-        assert((line.get_xdata() >= xmin).all())
+        assert (line.get_xdata() >= xmin).all()
 
         # Check xmax
         xmax = 0.5
         line, = plot_1d(ax, data, xmax=xmax)
-        assert((line.get_xdata() <= xmax).all())
+        assert (line.get_xdata() <= xmax).all()
 
         # Check xmin and xmax
         line, = plot_1d(ax, data, xmin=xmin, xmax=xmax)
-        assert((line.get_xdata() <= xmax).all())
-        assert((line.get_xdata() >= xmin).all())
+        assert (line.get_xdata() <= xmax).all()
+        assert (line.get_xdata() >= xmin).all()
         plt.close("all")
 
         # Check q
@@ -295,10 +295,10 @@ def test_kde_plot_1d(plot_1d):
         line, fill = plot_1d(ax, data, facecolor=True)
         plot_1d(ax, data, facecolor=True, levels=[0.8, 0.6, 0.2])
         line, fill = plot_1d(ax, data, fc='blue', color='k', ec='r')
-        assert(np.all(fill[0].get_edgecolor()[0] == to_rgba('r')))
+        assert np.all(fill[0].get_edgecolor()[0] == to_rgba('r'))
         assert (to_rgba(line[0].get_color()) == to_rgba('r'))
         line, fill = plot_1d(ax, data, fc=True, color='k', ec=None)
-        assert(len(fill[0].get_edgecolor()) == 0)
+        assert len(fill[0].get_edgecolor()) == 0
         assert (to_rgba(line[0].get_color()) == to_rgba('k'))
         plt.close("all")
 
@@ -313,16 +313,16 @@ def test_kde_plot_1d(plot_1d):
         data = np.random.randn(1000) * 0.01 + 0.5
         plot_1d(ax, data, xmin=0, xmax=1)
         xmin, xmax = ax.get_xlim()
-        assert(xmin > 0.4)
-        assert(xmax < 0.6)
+        assert xmin > 0.4
+        assert xmax < 0.6
         plt.close("all")
         # Check xlim, Uniform (i.e. data and limits span entire prior boundary)
         fig, ax = plt.subplots()
         data = np.random.uniform(size=1000)
         plot_1d(ax, data, xmin=0, xmax=1)
         xmin, xmax = ax.get_xlim()
-        assert(xmin == 0)
-        assert(xmax == 1)
+        assert xmin == 0
+        assert xmax == 1
         plt.close("all")
 
     except ImportError:
@@ -338,68 +338,68 @@ def test_hist_plot_1d():
         try:
             # Check heights for histtype 'bar'
             bars = hist_plot_1d(ax, data, histtype='bar', plotter=p)
-            assert(np.all([isinstance(b, Patch) for b in bars]))
-            assert(max([b.get_height() for b in bars]) == 1.)
-            assert(np.all(np.array([b.get_height() for b in bars]) <= 1.))
+            assert np.all([isinstance(b, Patch) for b in bars])
+            assert max([b.get_height() for b in bars]) == 1.
+            assert np.all(np.array([b.get_height() for b in bars]) <= 1.)
 
             # Check heights for histtype 'step'
             polygon, = hist_plot_1d(ax, data, histtype='step', plotter=p)
-            assert(isinstance(polygon, Polygon))
+            assert isinstance(polygon, Polygon)
             trans = polygon.get_transform() - ax.transData
-            assert(np.isclose(trans.transform(polygon.xy)[:, -1].max(), 1.,
-                              rtol=1e-10, atol=1e-10))
-            assert(np.all(trans.transform(polygon.xy)[:, -1] <= 1.))
+            assert np.isclose(trans.transform(polygon.xy)[:, -1].max(), 1.,
+                              rtol=1e-10, atol=1e-10)
+            assert np.all(trans.transform(polygon.xy)[:, -1] <= 1.)
 
             # Check heights for histtype 'stepfilled'
             polygon, = hist_plot_1d(ax, data, histtype='stepfilled', plotter=p)
-            assert(isinstance(polygon, Polygon))
+            assert isinstance(polygon, Polygon)
             trans = polygon.get_transform() - ax.transData
-            assert(np.isclose(trans.transform(polygon.xy)[:, -1].max(), 1.,
-                              rtol=1e-10, atol=1e-10))
-            assert(np.all(trans.transform(polygon.xy)[:, -1] <= 1.))
+            assert np.isclose(trans.transform(polygon.xy)[:, -1].max(), 1.,
+                              rtol=1e-10, atol=1e-10)
+            assert np.all(trans.transform(polygon.xy)[:, -1] <= 1.)
 
             # Check arguments are passed onward to underlying function
             bars = hist_plot_1d(ax, data, histtype='bar',
                                 color='r', alpha=0.5, plotter=p)
             cc = ColorConverter.to_rgba('r', alpha=0.5)
-            assert(np.all([b.get_fc() == cc for b in bars]))
+            assert np.all([b.get_fc() == cc for b in bars])
             bars = hist_plot_1d(ax, data, histtype='bar',
                                 cmap=plt.cm.viridis, alpha=0.5, plotter=p)
             cc = ColorConverter.to_rgba(plt.cm.viridis(0.68), alpha=0.5)
-            assert(np.all([b.get_fc() == cc for b in bars]))
+            assert np.all([b.get_fc() == cc for b in bars])
             polygon, = hist_plot_1d(ax, data, histtype='step',
                                     color='r', alpha=0.5, plotter=p)
-            assert(polygon.get_ec() == ColorConverter.to_rgba('r', alpha=0.5))
+            assert polygon.get_ec() == ColorConverter.to_rgba('r', alpha=0.5)
             polygon, = hist_plot_1d(ax, data, histtype='step',
                                     cmap=plt.cm.viridis, color='r', plotter=p)
-            assert(polygon.get_ec() == ColorConverter.to_rgba('r'))
+            assert polygon.get_ec() == ColorConverter.to_rgba('r')
 
             # Check xmin
             for xmin in [-np.inf, -0.5]:
                 bars = hist_plot_1d(ax, data, histtype='bar',
                                     xmin=xmin, plotter=p)
-                assert((np.array([b.xy[0] for b in bars]) >= xmin).all())
+                assert (np.array([b.xy[0] for b in bars]) >= xmin).all()
                 polygon, = hist_plot_1d(ax, data, histtype='step', xmin=xmin)
-                assert((polygon.xy[:, 0] >= xmin).all())
+                assert (polygon.xy[:, 0] >= xmin).all()
 
             # Check xmax
             for xmax in [np.inf, 0.5]:
                 bars = hist_plot_1d(ax, data, histtype='bar',
                                     xmax=xmax, plotter=p)
-                assert((np.array([b.xy[-1] for b in bars]) <= xmax).all())
+                assert (np.array([b.xy[-1] for b in bars]) <= xmax).all()
                 polygon, = hist_plot_1d(ax, data, histtype='step',
                                         xmax=xmax, plotter=p)
-                assert((polygon.xy[:, 0] <= xmax).all())
+                assert (polygon.xy[:, 0] <= xmax).all()
 
             # Check xmin and xmax
             bars = hist_plot_1d(ax, data, histtype='bar',
                                 xmin=xmin, xmax=xmax, plotter=p)
-            assert((np.array([b.xy[0] for b in bars]) >= -0.5).all())
-            assert((np.array([b.xy[-1] for b in bars]) <= 0.5).all())
+            assert (np.array([b.xy[0] for b in bars]) >= -0.5).all()
+            assert (np.array([b.xy[-1] for b in bars]) <= 0.5).all()
             polygon, = hist_plot_1d(ax, data, histtype='step',
                                     xmin=xmin, xmax=xmax, plotter=p)
-            assert((polygon.xy[:, 0] >= -0.5).all())
-            assert((polygon.xy[:, 0] <= 0.5).all())
+            assert (polygon.xy[:, 0] >= -0.5).all()
+            assert (polygon.xy[:, 0] <= 0.5).all()
             plt.close("all")
         except ImportError:
             if p == 'astropyhist' and 'astropy' not in sys.modules:
@@ -440,25 +440,25 @@ def test_1d_density_kwarg(plot_1d, s):
         # hist density = False:
         h = hist_plot_1d(ax, x, density=False, bins=np.linspace(-5.5, 5.5, 12))
         bar_height = h.get_children()[len(h.get_children()) // 2].get_height()
-        assert(bar_height == pytest.approx(1, rel=0.1))
+        assert bar_height == pytest.approx(1, rel=0.1)
 
         # kde density = False:
         k = plot_1d(ax, x, density=False)[0]
         f = interp1d(k.get_xdata(), k.get_ydata(), 'cubic', assume_sorted=True)
         kde_height = f(0)
-        assert(kde_height == pytest.approx(1, rel=0.1))
+        assert kde_height == pytest.approx(1, rel=0.1)
 
         # hist density = True:
         h = hist_plot_1d(ax, x, density=True, bins=np.linspace(-5.5, 5.5, 12))
         bar_height = h.get_children()[len(h.get_children()) // 2].get_height()
-        assert(bar_height == pytest.approx(erf(0.5 / np.sqrt(2) / s), rel=0.1))
+        assert bar_height == pytest.approx(erf(0.5 / np.sqrt(2) / s), rel=0.1)
 
         # kde density = True:
         k = plot_1d(ax, x, density=True)[0]
         f = interp1d(k.get_xdata(), k.get_ydata(), 'cubic', assume_sorted=True)
         kde_height = f(0)
         gauss_norm = 1 / np.sqrt(2 * np.pi * s**2)
-        assert(kde_height == pytest.approx(gauss_norm, rel=0.1))
+        assert kde_height == pytest.approx(gauss_norm, rel=0.1)
 
         plt.close("all")
 
@@ -477,50 +477,50 @@ def test_contour_plot_2d(contour_plot_2d):
         data_y = np.random.randn(1000)
         cf, ct = contour_plot_2d(ax, data_x, data_y)
         if contour_plot_2d is fastkde_contour_plot_2d:
-            assert(isinstance(cf, QuadContourSet))
-            assert(isinstance(ct, QuadContourSet))
+            assert isinstance(cf, QuadContourSet)
+            assert isinstance(ct, QuadContourSet)
         elif contour_plot_2d is kde_contour_plot_2d:
-            assert(isinstance(cf, TriContourSet))
-            assert(isinstance(ct, TriContourSet))
+            assert isinstance(cf, TriContourSet)
+            assert isinstance(ct, TriContourSet)
 
         xmin, xmax, ymin, ymax = -0.5, 0.5, -0.5, 0.5
 
         # Check xmin
         ax = plt.gca()
         contour_plot_2d(ax, data_x, data_y, xmin=xmin)
-        assert(ax.get_xlim()[0] >= xmin)
+        assert ax.get_xlim()[0] >= xmin
         plt.close()
 
         # Check xmax
         ax = plt.gca()
         contour_plot_2d(ax, data_x, data_y, xmax=xmax)
-        assert(ax.get_xlim()[1] <= xmax)
+        assert ax.get_xlim()[1] <= xmax
         plt.close()
 
         # Check xmin and xmax
         ax = plt.gca()
         contour_plot_2d(ax, data_x, data_y, xmin=xmin, xmax=xmax)
-        assert(ax.get_xlim()[1] <= xmax)
-        assert(ax.get_xlim()[0] >= xmin)
+        assert ax.get_xlim()[1] <= xmax
+        assert ax.get_xlim()[0] >= xmin
         plt.close()
 
         # Check ymin
         ax = plt.gca()
         contour_plot_2d(ax, data_x, data_y, ymin=ymin)
-        assert(ax.get_ylim()[0] >= ymin)
+        assert ax.get_ylim()[0] >= ymin
         plt.close()
 
         # Check ymax
         ax = plt.gca()
         contour_plot_2d(ax, data_x, data_y, ymax=ymax)
-        assert(ax.get_ylim()[1] <= ymax)
+        assert ax.get_ylim()[1] <= ymax
         plt.close()
 
         # Check ymin and ymax
         ax = plt.gca()
         contour_plot_2d(ax, data_x, data_y, ymin=ymin, ymax=ymax)
-        assert(ax.get_ylim()[1] <= ymax)
-        assert(ax.get_ylim()[0] >= ymin)
+        assert ax.get_ylim()[1] <= ymax
+        assert ax.get_ylim()[0] >= ymin
         plt.close()
 
         # Check levels
@@ -572,10 +572,10 @@ def test_contour_plot_2d(contour_plot_2d):
         contour_plot_2d(ax, data_x, data_y, xmin=0, xmax=1, ymin=0, ymax=1)
         xmin, xmax = ax.get_xlim()
         ymin, ymax = ax.get_ylim()
-        assert(xmin > 0.4)
-        assert(xmax < 0.6)
-        assert(ymin > 0.4)
-        assert(ymax < 0.6)
+        assert xmin > 0.4
+        assert xmax < 0.6
+        assert ymin > 0.4
+        assert ymax < 0.6
         plt.close("all")
         # Check limits, Uniform (i.e. data & limits span entire prior boundary)
         fig, ax = plt.subplots()
@@ -584,10 +584,10 @@ def test_contour_plot_2d(contour_plot_2d):
         contour_plot_2d(ax, data_x, data_y, xmin=0, xmax=1, ymin=0, ymax=1)
         xmin, xmax = ax.get_xlim()
         ymin, ymax = ax.get_ylim()
-        assert(xmin == 0)
-        assert(xmax == 1)
-        assert(ymin == 0)
-        assert(ymax == 1)
+        assert xmin == 0
+        assert xmax == 1
+        assert ymin == 0
+        assert ymax == 1
         plt.close("all")
 
     except ImportError:
@@ -636,27 +636,27 @@ def test_scatter_plot_2d():
     data_x = np.random.randn(1000)
     data_y = np.random.randn(1000)
     lines, = scatter_plot_2d(ax, data_x, data_y)
-    assert(isinstance(lines, Line2D))
+    assert isinstance(lines, Line2D)
 
     xmin, xmax, ymin, ymax = -0.5, 0.5, -0.5, 0.5
     ax = plt.gca()
     scatter_plot_2d(ax, data_x, data_y, xmin=xmin)
-    assert(ax.get_xlim()[0] >= xmin)
+    assert ax.get_xlim()[0] >= xmin
     plt.close()
 
     ax = plt.gca()
     scatter_plot_2d(ax, data_x, data_y, xmax=xmax)
-    assert(ax.get_xlim()[1] <= xmax)
+    assert ax.get_xlim()[1] <= xmax
     plt.close()
 
     ax = plt.gca()
     scatter_plot_2d(ax, data_x, data_y, ymin=ymin)
-    assert(ax.get_ylim()[0] >= ymin)
+    assert ax.get_ylim()[0] >= ymin
     plt.close()
 
     ax = plt.gca()
     scatter_plot_2d(ax, data_x, data_y, ymax=ymax)
-    assert(ax.get_ylim()[1] <= ymax)
+    assert ax.get_ylim()[1] <= ymax
     plt.close()
 
     ax = plt.gca()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -32,59 +32,59 @@ def test_build_mcmc():
     limits = {'A': (-1, 1), 'B': (-2, 2), 'C': (-3, 3)}
 
     mcmc = MCMCSamples(data=data)
-    assert(len(mcmc) == nsamps)
+    assert len(mcmc) == nsamps
     assert_array_equal(mcmc.columns, np.array([0, 1, 2], dtype=object))
 
     mcmc = MCMCSamples(data=data, logL=logL)
-    assert(len(mcmc) == nsamps)
+    assert len(mcmc) == nsamps
     assert_array_equal(mcmc.columns, np.array([0, 1, 2, 'logL'], dtype=object))
 
     mcmc = MCMCSamples(data=data, weights=weights)
-    assert(len(mcmc) == nsamps)
+    assert len(mcmc) == nsamps
     assert_array_equal(mcmc.columns, np.array([0, 1, 2], dtype=object))
-    assert(mcmc.index.nlevels == 2)
+    assert mcmc.index.nlevels == 2
 
     mcmc = MCMCSamples(data=data, weights=weights, logL=logL)
-    assert(len(mcmc) == nsamps)
+    assert len(mcmc) == nsamps
     assert_array_equal(mcmc.columns, np.array([0, 1, 2, 'logL'], dtype=object))
-    assert(mcmc.index.nlevels == 2)
+    assert mcmc.index.nlevels == 2
 
     mcmc = MCMCSamples(data=data, columns=params)
-    assert(len(mcmc) == nsamps)
+    assert len(mcmc) == nsamps
     assert_array_equal(mcmc.columns, ['A', 'B', 'C'])
 
     mcmc = MCMCSamples(data=data, tex=tex)
     for p in params:
-        assert(mcmc.tex[p] == tex[p])
+        assert mcmc.tex[p] == tex[p]
 
     mcmc = MCMCSamples(data=data, limits=limits)
     for p in params:
-        assert(mcmc.limits[p] == limits[p])
+        assert mcmc.limits[p] == limits[p]
 
     ns = NestedSamples(data=data, logL=logL, weights=weights)
-    assert(len(ns) == nsamps)
-    assert(np.all(np.isfinite(ns.logL)))
+    assert len(ns) == nsamps
+    assert np.all(np.isfinite(ns.logL))
     logL[:10] = -1e300
     weights[:10] = 0.
     mcmc = MCMCSamples(data=data, logL=logL, weights=weights, logzero=-1e29)
     ns = NestedSamples(data=data, logL=logL, weights=weights, logzero=-1e29)
     assert_array_equal(mcmc.columns, np.array([0, 1, 2, 'logL'], dtype=object))
-    assert(mcmc.index.nlevels == 2)
+    assert mcmc.index.nlevels == 2
     assert_array_equal(ns.columns, np.array([0, 1, 2, 'logL'], dtype=object))
-    assert(ns.index.nlevels == 2)
-    assert(np.all(mcmc.logL[:10] == -np.inf))
-    assert(np.all(ns.logL[:10] == -np.inf))
-    assert(np.all(mcmc.logL[10:] == logL[10:]))
-    assert(np.all(ns.logL[10:] == logL[10:]))
+    assert ns.index.nlevels == 2
+    assert np.all(mcmc.logL[:10] == -np.inf)
+    assert np.all(ns.logL[:10] == -np.inf)
+    assert np.all(mcmc.logL[10:] == logL[10:])
+    assert np.all(ns.logL[10:] == logL[10:])
 
     mcmc = MCMCSamples(data=data, logL=logL, weights=weights, logzero=-1e301)
     ns = NestedSamples(data=data, logL=logL, weights=weights, logzero=-1e301)
-    assert(np.all(np.isfinite(mcmc.logL)))
-    assert(np.all(np.isfinite(ns.logL)))
-    assert(np.all(mcmc.logL == logL))
-    assert(np.all(ns.logL == logL))
+    assert np.all(np.isfinite(mcmc.logL))
+    assert np.all(np.isfinite(ns.logL))
+    assert np.all(mcmc.logL == logL)
+    assert np.all(ns.logL == logL)
 
-    assert(mcmc.root is None)
+    assert mcmc.root is None
 
 
 def test_NS_input_fails_in_MCMCSamples():
@@ -135,23 +135,23 @@ def test_plot_2d_types():
     params = [params_x, params_y]
 
     fig, axes = ns.plot_2d(params, types={'lower': 'kde'})
-    assert((~axes.isnull()).sum().sum() == 3)
+    assert (~axes.isnull()).sum().sum() == 3
 
     fig, axes = ns.plot_2d(params, types={'upper': 'scatter'})
-    assert((~axes.isnull()).sum().sum() == 6)
+    assert (~axes.isnull()).sum().sum() == 6
 
     fig, axes = ns.plot_2d(params, types={'upper': 'kde', 'diagonal': 'kde'})
-    assert((~axes.isnull()).sum().sum() == 9)
+    assert (~axes.isnull()).sum().sum() == 9
 
     fig, axes = ns.plot_2d(params, types={'lower': 'kde', 'diagonal': 'kde'})
-    assert((~axes.isnull()).sum().sum() == 6)
+    assert (~axes.isnull()).sum().sum() == 6
 
     fig, axes = ns.plot_2d(params, types={'lower': 'kde', 'diagonal': 'kde'})
-    assert((~axes.isnull()).sum().sum() == 6)
+    assert (~axes.isnull()).sum().sum() == 6
 
     fig, axes = ns.plot_2d(params, types={'lower': 'kde', 'diagonal': 'kde',
                                           'upper': 'scatter'})
-    assert((~axes.isnull()).sum().sum() == 12)
+    assert (~axes.isnull()).sum().sum() == 12
 
     with pytest.raises(NotImplementedError):
         fig, axes = ns.plot_2d(params, types={'lower': 'not a plot type'})
@@ -182,20 +182,20 @@ def test_plot_2d_types_multiple_calls():
 def test_root_and_label():
     np.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
-    assert(ns.root == './tests/example_data/pc')
-    assert(ns.label == 'pc')
+    assert ns.root == './tests/example_data/pc'
+    assert ns.label == 'pc'
 
     ns = NestedSamples()
-    assert(ns.root is None)
-    assert(ns.label is None)
+    assert ns.root is None
+    assert ns.label is None
 
     mc = MCMCSamples(root='./tests/example_data/gd')
     assert (mc.root == './tests/example_data/gd')
-    assert(mc.label == 'gd')
+    assert mc.label == 'gd'
 
     mc = MCMCSamples()
-    assert(mc.root is None)
-    assert(mc.label is None)
+    assert mc.root is None
+    assert mc.label is None
 
 
 def test_plot_2d_legend():
@@ -213,14 +213,14 @@ def test_plot_2d_legend():
         for x, ax in row.iteritems():
             if ax is not None:
                 leg = ax.legend()
-                assert(leg.get_texts()[0].get_text() == 'l1')
-                assert(leg.get_texts()[1].get_text() == 'l2')
+                assert leg.get_texts()[0].get_text() == 'l1'
+                assert leg.get_texts()[1].get_text() == 'l2'
                 handles, labels = ax.get_legend_handles_labels()
-                assert(labels == ['l1', 'l2'])
+                assert labels == ['l1', 'l2']
                 if x == y:
-                    assert(all([isinstance(h, Line2D) for h in handles]))
+                    assert all([isinstance(h, Line2D) for h in handles])
                 else:
-                    assert(all([isinstance(h, Rectangle) for h in handles]))
+                    assert all([isinstance(h, Rectangle) for h in handles])
     plt.close('all')
 
     # Test label kwarg for hist and scatter
@@ -232,15 +232,15 @@ def test_plot_2d_legend():
         for x, ax in row.iteritems():
             if ax is not None:
                 leg = ax.legend()
-                assert(leg.get_texts()[0].get_text() == 'l1')
-                assert(leg.get_texts()[1].get_text() == 'l2')
+                assert leg.get_texts()[0].get_text() == 'l1'
+                assert leg.get_texts()[1].get_text() == 'l2'
                 handles, labels = ax.get_legend_handles_labels()
-                assert(labels == ['l1', 'l2'])
+                assert labels == ['l1', 'l2']
                 if x == y:
-                    assert(all([isinstance(h, Rectangle) for h in handles]))
+                    assert all([isinstance(h, Rectangle) for h in handles])
                 else:
-                    assert(all([isinstance(h, Line2D)
-                                for h in handles]))
+                    assert all([isinstance(h, Line2D)
+                                for h in handles])
     plt.close('all')
 
     # test default labelling
@@ -252,7 +252,7 @@ def test_plot_2d_legend():
         for x, ax in row.iteritems():
             if ax is not None:
                 handles, labels = ax.get_legend_handles_labels()
-                assert(labels == ['pc', 'gd'])
+                assert labels == ['pc', 'gd']
     plt.close('all')
 
     # Test label kwarg to constructors
@@ -268,7 +268,7 @@ def test_plot_2d_legend():
         for x, ax in row.iteritems():
             if ax is not None:
                 handles, labels = ax.get_legend_handles_labels()
-                assert(labels == ['l1', 'l2'])
+                assert labels == ['l1', 'l2']
     plt.close('all')
 
 
@@ -311,9 +311,9 @@ def test_plot_2d_colours():
                     elif label == 'mn':
                         mn_colors.append(color)
 
-        assert(len(set(gd_colors)) == 1)
-        assert(len(set(mn_colors)) == 1)
-        assert(len(set(pc_colors)) == 1)
+        assert len(set(gd_colors)) == 1
+        assert len(set(mn_colors)) == 1
+        assert len(set(pc_colors)) == 1
         plt.close("all")
 
 
@@ -356,9 +356,9 @@ def test_plot_1d_colours():
                 elif label == 'mn':
                     mn_colors.append(color)
 
-        assert(len(set(gd_colors)) == 1)
-        assert(len(set(mn_colors)) == 1)
-        assert(len(set(pc_colors)) == 1)
+        assert len(set(gd_colors)) == 1
+        assert len(set(mn_colors)) == 1
+        assert len(set(pc_colors)) == 1
         plt.close("all")
 
 
@@ -391,14 +391,14 @@ def test_ns_output():
         assert abs(pc.logZ() - PC['logZ'].mean()) < PC['logZ'].std()
         assert PC['d'].mean() < 5
         assert PC.cov()['D']['logZ'] < 0
-        assert(abs(PC.logZ.mean() - pc.logZ()) < PC.logZ.std() * n**0.5 * 2)
-        assert(abs(PC.D.mean() - pc.D()) < PC.D.std() * n**0.5 * 2)
-        assert(abs(PC.d.mean() - pc.d()) < PC.d.std() * n**0.5 * 2)
+        assert abs(PC.logZ.mean() - pc.logZ()) < PC.logZ.std() * n**0.5 * 2
+        assert abs(PC.D.mean() - pc.D()) < PC.D.std() * n**0.5 * 2
+        assert abs(PC.d.mean() - pc.d()) < PC.d.std() * n**0.5 * 2
 
         n = 100
-        assert(ks_2samp(pc.logZ(n), PC.logZ).pvalue > 0.05)
-        assert(ks_2samp(pc.D(n), PC.D).pvalue > 0.05)
-        assert(ks_2samp(pc.d(n), PC.d).pvalue > 0.05)
+        assert ks_2samp(pc.logZ(n), PC.logZ).pvalue > 0.05
+        assert ks_2samp(pc.D(n), PC.D).pvalue > 0.05
+        assert ks_2samp(pc.d(n), PC.d).pvalue > 0.05
 
     assert abs(pc.set_beta(0.0).logZ()) < 1e-2
     assert pc.set_beta(0.9).logZ() < pc.set_beta(1.0).logZ()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,13 +13,13 @@ from anesthetic.utils import (nest_level, compute_nlive, unique, is_int,
 
 
 def test_nest_level():
-    assert(nest_level(0) == 0)
-    assert(nest_level([]) == 1)
-    assert(nest_level(['a']) == 1)
-    assert(nest_level(['a', 'b']) == 1)
-    assert(nest_level([['a'], 'b']) == 2)
-    assert(nest_level(['a', ['b']]) == 2)
-    assert(nest_level([['a'], ['b']]) == 2)
+    assert nest_level(0) == 0
+    assert nest_level([]) == 1
+    assert nest_level(['a']) == 1
+    assert nest_level(['a', 'b']) == 1
+    assert nest_level([['a'], 'b']) == 2
+    assert nest_level(['a', ['b']]) == 2
+    assert nest_level([['a'], ['b']]) == 2
 
 
 def test_compute_nlive():
@@ -41,14 +41,14 @@ def test_compute_nlive():
     assert_array_equal(nlives[:len(nlives)//2], nlive)
 
     # Check one point at the end
-    assert(nlives[-1] == 1)
+    assert nlives[-1] == 1
 
     # Check never more than nlive
-    assert(nlives.max() <= nlive)
+    assert nlives.max() <= nlive
 
 
 def test_unique():
-    assert(unique([3, 2, 1, 4, 1, 3]) == [3, 2, 1, 4])
+    assert unique([3, 2, 1, 4, 1, 3]) == [3, 2, 1, 4]
 
 
 @pytest.mark.parametrize('ipc', [iso_probability_contours,

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -243,7 +243,7 @@ def test_WeightedDataFrame_compress():
     for i in np.logspace(3, 5, 10):
         assert_allclose(i, len(df.compress(i)), rtol=1e-1)
     unit_weights = df.compress(0)
-    assert(len(np.unique(unit_weights.index)) == len(unit_weights))
+    assert len(np.unique(unit_weights.index)) == len(unit_weights)
     assert_array_equal(df.compress(), df.compress())
     assert_array_equal(df.compress(i), df.compress(i))
     assert_array_equal(df.compress(-1), df.compress(-1))
@@ -447,7 +447,7 @@ def test_WeightedSeries_compress():
     for i in np.logspace(3, 5, 10):
         assert_allclose(i, len(series.compress(i)), rtol=1e-1)
     unit_weights = series.compress(0)
-    assert(len(np.unique(unit_weights.index)) == len(unit_weights))
+    assert len(np.unique(unit_weights.index)) == len(unit_weights)
 
 
 def test_WeightedSeries_nan():


### PR DESCRIPTION
# Description

There has been a PEP update which means that our lint CI is now failing. This is a relatively straightforward change, which touches a lot of the tests, but otherwise does little, changing
`assert(...)` to `assert ...`


# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
