### PR TITLE
WeightedPandas index improvements

### DIFF
--- a/anesthetic/convert.py
+++ b/anesthetic/convert.py
@@ -16,7 +16,7 @@ def to_getdist(nested_samples):
     """
     import getdist
     samples = nested_samples.to_numpy()
-    weights = nested_samples.weights
+    weights = nested_samples.get_weights()
     loglikes = -nested_samples.logL.to_numpy()
     names = nested_samples.columns
     ranges = {name: nested_samples._limits(name) for name in names}

--- a/anesthetic/plotting/_matplotlib/core.py
+++ b/anesthetic/plotting/_matplotlib/core.py
@@ -17,7 +17,7 @@ import numpy as np
 
 def _get_weights(kwargs, data):
     if isinstance(data, _WeightedObject):
-        kwargs['weights'] = data.weights
+        kwargs['weights'] = data.get_weights()
 
 
 class _WeightedMPLPlot(MPLPlot):
@@ -79,7 +79,7 @@ class HexBinPlot(_HexBinPlot):
     def __init__(self, data, x, y, C=None, **kwargs) -> None:
         if isinstance(data, _WeightedObject):
             C = '__weights'
-            data[C] = data.weights
+            data[C] = data.get_weights()
             kwargs['reduce_C_function'] = np.sum
         super().__init__(data, x, y, C=C, **kwargs)
 

--- a/anesthetic/plotting/_matplotlib/core.py
+++ b/anesthetic/plotting/_matplotlib/core.py
@@ -93,7 +93,7 @@ class PiePlot(_PiePlot):
     # noqa: disable=D101
     def __init__(self, data, kind=None, **kwargs) -> None:
         if isinstance(data, _WeightedObject):
-            labels = data.index.get_level_values('#')._mpl_repr()
+            labels = data.index.droplevel('weights')._mpl_repr()
             kwargs['labels'] = kwargs.get('labels', labels)
         super().__init__(data, kind=kind, **kwargs)
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -314,7 +314,11 @@ class Samples(WeightedDataFrame):
         samples: Samples/MCMCSamples/NestedSamples
             Importance re-weighted samples.
         """
-        samples = self.copy()
+        if inplace:
+            samples = self
+        else:
+            samples = self.copy()
+
         if action == 'add':
             new_weights = samples.get_weights()
             new_weights *= np.exp(logL_new - logL_new.max())
@@ -336,7 +340,7 @@ class Samples(WeightedDataFrame):
         if inplace:
             self._update_inplace(samples)
         else:
-            return samples
+            return samples.__finalize__(self, "importance_sample")
 
 
 class MCMCSamples(Samples):
@@ -729,7 +733,7 @@ class NestedSamples(Samples):
         if inplace:
             self._update_inplace(samples)
         else:
-            return samples
+            return samples.__finalize__(self, "importance_sample")
 
     def recompute(self, logL_birth=None, inplace=False):
         """Re-calculate the nested sampling contours and live points.
@@ -746,7 +750,10 @@ class NestedSamples(Samples):
             frame with contours resorted and nlive recomputed
             default: False
         """
-        samples = self.copy()
+        if inplace:
+            samples = self
+        else:
+            samples = self.copy()
 
         if is_int(logL_birth):
             nlive = logL_birth
@@ -758,7 +765,7 @@ class NestedSamples(Samples):
         else:
             if logL_birth is not None:
                 samples['logL_birth'] = logL_birth
-                samples.tex['logL_birth'] = r'$\log\mathcal{L}_{\rm birth}$'
+                samples.tex['logL_birth'] = r'$\log\mathcal{L}_\mathrm{birth}$'
 
             if 'logL_birth' not in samples:
                 raise RuntimeError("Cannot recompute run without "
@@ -783,7 +790,7 @@ class NestedSamples(Samples):
             samples.reset_index(drop=True, inplace=True)
             samples['nlive'] = compute_nlive(samples.logL, samples.logL_birth)
 
-        samples.tex['nlive'] = r'$n_{\rm live}$'
+        samples.tex['nlive'] = r'$n_\mathrm{live}$'
         samples.beta = samples._beta
 
         if np.any(pandas.isna(samples.logL)):
@@ -796,7 +803,7 @@ class NestedSamples(Samples):
         if inplace:
             self._update_inplace(samples)
         else:
-            return samples
+            return samples.__finalize__(self, "recompute")
 
 
 def merge_nested_samples(runs):

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -857,7 +857,6 @@ def merge_samples_weighted(samples, weights=None, label=None):
         new_weights = s.weights / s.weights.sum() * w/np.sum(weights)
         s = Samples(s, weights=new_weights)
         new_samples.append(s)
-        new_samples[0]
 
     new_samples = pandas.concat(new_samples)
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -805,6 +805,7 @@ def merge_samples_weighted(samples, weights=None, label=None):
         new_weights = s.weights / s.weights.sum() * w/np.sum(weights)
         s = MCMCSamples(s, weights=new_weights)
         new_samples.append(s)
+        new_samples[0]
 
     new_samples = pandas.concat(new_samples)
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -499,7 +499,7 @@ class NestedSamples(MCMCSamples):
 
         """
         dlogX = self.dlogX(nsamples)
-        samples = pandas.DataFrame(index=dlogX.columns)
+        samples = MCMCSamples(index=dlogX.columns)
         samples['logZ'] = self.logZ(dlogX)
 
         logw = dlogX.add(self.beta * self.logL, axis=0)
@@ -508,7 +508,6 @@ class NestedSamples(MCMCSamples):
 
         samples['D'] = np.exp(logsumexp(logw, b=S, axis=0))
         samples['d'] = np.exp(logsumexp(logw, b=(S-samples.D)**2, axis=0))*2
-        samples = MCMCSamples(samples)
 
         samples.tex = {'logZ': r'$\log\mathcal{Z}$',
                        'D': r'$\mathcal{D}$',
@@ -538,8 +537,8 @@ class NestedSamples(MCMCSamples):
         """
         dlogX = self.dlogX(nsamples)
         logZ = self.logZ(dlogX)
-        logw = dlogX.add(self.beta * self.logL, axis=0).values - logZ
-        S = (dlogX*0).add(self.beta * self.logL, axis=0).values - logZ
+        logw = dlogX.add(self.beta * self.logL, axis=0) - logZ
+        S = (dlogX*0).add(self.beta * self.logL, axis=0) - logZ
         return np.exp(logsumexp(logw, b=S, axis=0))
 
     def d(self, nsamples=None):
@@ -553,8 +552,8 @@ class NestedSamples(MCMCSamples):
         dlogX = self.dlogX(nsamples)
         logZ = self.logZ(dlogX)
         D = self.D(dlogX)
-        logw = dlogX.add(self.beta * self.logL, axis=0).values - logZ
-        S = (dlogX*0).add(self.beta * self.logL, axis=0).values - logZ
+        logw = dlogX.add(self.beta * self.logL, axis=0) - logZ
+        S = (dlogX*0).add(self.beta * self.logL, axis=0) - logZ
         return np.exp(logsumexp(logw, b=(S-D)**2, axis=0))*2
 
     def live_points(self, logL=None):

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -87,13 +87,6 @@ class Samples(WeightedDataFrame):
         self.__init__(root=self.root)
         return self
 
-    def copy(self, deep=True):
-        """Copy which also includes mutable metadata."""
-        new = super().copy(deep)
-        if deep:
-            new.tex = copy.deepcopy(self.tex)
-        return new
-
     def plot_1d(self, axes, *args, **kwargs):
         """Create an array of 1D plots.
 

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -616,7 +616,7 @@ class NestedSamples(Samples):
             except KeyError:
                 pass
         i = (self.logL >= logL) & (self.logL_birth < logL)
-        return Samples(self[i], weights=np.ones(i.sum()))
+        return Samples(self[i]).set_weights(None)
 
     def posterior_points(self, beta=1):
         """Get equally weighted posterior points at temperature beta."""

--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -6,7 +6,6 @@ from scipy.interpolate import interp1d
 from scipy.stats import kstwobign
 from matplotlib.tri import Triangulation
 import contextlib
-import copy
 
 
 def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
@@ -510,11 +509,3 @@ def temporary_seed(seed):
         yield
     finally:
         np.random.set_state(state)
-
-
-def modify_inplace(orig, new, inplace):
-    """Conditionally modify object inplace or return."""
-    if inplace:
-        orig.__dict__ = copy.deepcopy(new.__dict__)
-    else:
-        return new

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -292,7 +292,9 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
         if not numeric_only:
             raise NotImplementedError("numeric_only kwarg not implemented")
         if axis == 0:
-            data = np.array([c.quantile(q) for _, c in self.iteritems()])
+            data = np.array([c.quantile(q, interpolation=interpolation,
+                                        numeric_only=numeric_only)
+                             for _, c in self.iteritems()])
             if np.isscalar(q):
                 return Series(data, index=self.columns)
             else:
@@ -319,12 +321,12 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
         df.index = df.index.droplevel('weights')
         return df
 
-    def _reduce(self, op, name, **kwargs):
-        answer = super()._reduce(op, name, **kwargs)
-        if kwargs['axis'] == 0:
-            answer = Series(answer).droplevel('weights')
-            answer.name = None
-        return answer
+    #def _reduce(self, op, name, **kwargs):
+    #    answer = super()._reduce(op, name, **kwargs)
+    #    print(kwargs['axis'])
+    #    if self._get_axis_number(kwargs['axis']) == 0 and 'weights' in self.index.names:
+    #        answer = Series(answer).droplevel('weights', 0)
+    #    return answer
 
     @property
     def _constructor_sliced(self):
@@ -334,14 +336,12 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
     def _constructor(self):
         return WeightedDataFrame
 
-    def _ixs(self, i, axis=0): 
-        answer = super()._ixs(i, axis=axis)
-        #print("columns", self.columns)
-        #print("index", self.index)
-        
-        #if self._get_axis_number(axis) == 0:
-        #    answer = Series(answer.droplevel('weights'))
-        return answer
+    #def _ixs(self, i, axis=0): 
+    #    answer = super()._ixs(i, axis=axis)
+    #    
+    #    if self._get_axis_number(axis) == 0:
+    #        answer = Series(answer.droplevel('weights'))
+    #    return answer
 
 
 

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -6,6 +6,7 @@ from pandas.util import hash_pandas_object
 from numpy.ma import masked_array
 from anesthetic.utils import (compress_weights, channel_capacity, quantile,
                               temporary_seed)
+from inspect import signature
 
 
 class _WeightedObject(object):
@@ -14,17 +15,16 @@ class _WeightedObject(object):
     def __init__(self, *args, **kwargs):
         weights = kwargs.pop('weights', None)
         super().__init__(*args, **kwargs)
-        if weights is None:
-            if 'weights' in self.index.names:
-                weights = self.weights
-            else:
-                weights = np.ones_like(self.index, int)
-        self._set_weights(weights)
+        if weights is not None and 'weights' not in self.index.names:
+            self._set_weights(weights)
 
     @property
     def weights(self):
         """Sample weights."""
-        return self.index.get_level_values('weights').to_numpy()
+        if 'weights' in self.index.names:
+            return self.index.get_level_values('weights').to_numpy()
+        else:
+            return np.ones_like(self.index)
 
     @weights.setter
     def weights(self, weights):
@@ -47,13 +47,6 @@ class _WeightedObject(object):
             answer._set_weights(weights)
             return answer
 
-    @property
-    def _rand(self):
-        """Random number for consistent compression."""
-        seed = hash_pandas_object(self.index).sum() % 2**32
-        with temporary_seed(seed):
-            return np.random.rand(len(self))
-
     def std(self, *args, **kwargs):
         """Weighted standard deviation of the sampled distribution."""
         return np.sqrt(self.var(*args, **kwargs))
@@ -66,22 +59,34 @@ class _WeightedObject(object):
         """Weighted median of the sampled distribution."""
         return self.quantile(*args, **kwargs)
 
-    def sample(self, *args, **kwargs):
-        """Weighted sample."""
-        return super().sample(weights=self.weights, *args, **kwargs)
-
-    def neff(self):
-        """Effective number of samples."""
-        return channel_capacity(self.weights)
 
 
 class WeightedSeries(_WeightedObject, Series):
     """Weighted version of pandas.Series."""
 
+    @property
+    def _rand(self):
+        """Random number for consistent compression."""
+        seed = hash_pandas_object(self.index).sum() % 2**32
+        with temporary_seed(seed):
+            return np.random.rand(len(self))
+
+    @property
+    def weighted(self):
+        return 'weights' in self.index.names
+
+    def sample(self, *args, **kwargs):
+        """Weighted sample."""
+        return super().sample(weights=self.weights, *args, **kwargs)
+
     def mean(self, skipna=True):
         """Weighted mean of the sampled distribution."""
         null = self.isnull() & skipna
         return np.average(masked_array(self, null), weights=self.weights)
+
+    def neff(self):
+        """Effective number of samples."""
+        return channel_capacity(self.weights)
 
     def var(self, skipna=True):
         """Weighted variance of the sampled distribution."""
@@ -172,114 +177,149 @@ class WeightedSeries(_WeightedObject, Series):
 class WeightedDataFrame(_WeightedObject, DataFrame):
     """Weighted version of pandas.DataFrame."""
 
-    def mean(self, axis=0, skipna=True):
+    def _rand(self, axis):
+        """Random number for consistent compression."""
+        seed = hash_pandas_object(self._get_axis(axis)).sum() % 2**32
+        with temporary_seed(seed):
+            return np.random.rand(self.shape[axis])
+
+    def _weights(self, axis):
+        return self._get_axis(axis).get_level_values('weights').to_numpy()
+
+    def weighted(self, axis):
+        return 'weights' in self._get_axis(axis).names
+
+    def neff(self, axis=0):
+        """Effective number of samples."""
+        if self.weighted(axis):
+            return channel_capacity(self._weights(axis))
+        else:
+            return self.shape[axis]
+
+    def sample(self, *args, **kwargs):
+        """Weighted sample."""
+        sig = signature(DataFrame.sample)
+        axis = sig.bind(self, *args, **kwargs).arguments.get('axis', 0)
+        if self.weighted(axis):
+            return super().sample(weights=self._weights(axis), *args, **kwargs)
+        else:
+            return super().sample(*args, **kwargs)
+
+    def mean(self, axis=0, skipna=True, *args, **kwargs):
         """Weighted mean of the sampled distribution."""
-        if axis == 0:
+        if self.weighted(axis):
             null = self.isnull() & skipna
             mean = np.average(masked_array(self, null),
-                              weights=self.weights, axis=0)
-            return Series(mean, index=self.columns)
+                              weights=self._weights(axis), axis=axis)
+            return WeightedSeries(mean, index=self._get_axis(1-axis))
         else:
-            return super().mean(axis=axis, skipna=skipna)
+            return super().mean(axis=axis, skipna=skipna, *args, **kwargs)
 
-    def var(self, axis=0, skipna=True):
+    def var(self, axis=0, skipna=True, *args, **kwargs):
         """Weighted variance of the sampled distribution."""
-        if axis == 0:
+        if self.weighted(axis):
             null = self.isnull() & skipna
-            mean = self.mean(skipna=skipna)
+            mean = self.mean(axis=axis, skipna=skipna)
             var = np.average(masked_array((self-mean)**2, null),
-                             weights=self.weights, axis=0)
-            return Series(var, index=self.columns)
+                             weights=self._weights(axis), axis=axis)
+            return WeightedSeries(var, index=self._get_axis(1-axis))
         else:
-            return super().var(axis=axis, skipna=skipna)
+            return super().var(axis=axis, skipna=skipna, *args, **kwargs)
 
-    def cov(self, skipna=True):
+    def cov(self, skipna=True, *args, **kwargs):
         """Weighted covariance of the sampled distribution."""
-        null = self.isnull() & skipna
-        mean = self.mean(skipna=skipna)
-        x = masked_array(self - mean, null)
-        cov = np.ma.dot(self.weights * x.T, x) / self.weights.sum().T
-        return DataFrame(cov, index=self.columns, columns=self.columns)
+        if self.weighted(0):
+            null = self.isnull() & skipna
+            mean = self.mean(skipna=skipna)
+            x = masked_array(self - mean, null)
+            cov = np.ma.dot(self._weights(0)*x.T, x) / self._weights(0).sum().T
+            return WeightedDataFrame(cov, index=self.columns,
+                                     columns=self.columns)
+        else:
+            return super().cov(*args, **kwargs)
 
-    def corr(self, skipna=True):
+    def corr(self, skipna=True, *args, **kwargs):
         """Weighted pearson correlation matrix of the sampled distribution."""
-        cov = self.cov()
-        diag = np.sqrt(np.diag(cov))
-        return cov.divide(diag, axis=1).divide(diag, axis=0)
+        if self.weighted(0):
+            cov = self.cov()
+            diag = np.sqrt(np.diag(cov))
+            return cov.divide(diag, axis=1).divide(diag, axis=0)
+        else:
+            return super().corr(*args, **kwargs)
 
-    def corrwith(self, other, drop=False):
+    def corrwith(self, other, drop=False, *args, **kwargs):
         """Pairwise weighted pearson correlation."""
-        this = self._get_numeric_data()
+        if self.weighted(0):
+            if isinstance(other, Series):
+                answer = self.apply(lambda x: other.corr(x), axis=0)
+                return WeightedSeries(answer)
 
-        if isinstance(other, Series):
-            answer = this.apply(lambda x: other.corr(x), axis=0)
-            return Series(answer)
+            left, right = self.align(other, join="inner", copy=False)
 
-        other = other._get_numeric_data()
-        left, right = this.align(other, join="inner", copy=False)
+            # mask missing values
+            left = left + right * 0
+            right = right + left * 0
 
-        # mask missing values
-        left = left + right * 0
-        right = right + left * 0
+            # demeaned data
+            ldem = left - left.mean()
+            rdem = right - right.mean()
 
-        # demeaned data
-        ldem = left - left.mean()
-        rdem = right - right.mean()
+            num = (ldem * rdem * self._weights(0)[:, None]).sum()
+            dom = self._weights(0).sum() * left.std() * right.std()
 
-        num = (ldem * rdem * self.weights[:, None]).sum()
-        dom = self.weights.sum() * left.std() * right.std()
+            correl = num / dom
 
-        correl = num / dom
+            if not drop:
+                # Find non-matching labels along the given axis
+                result_index = self._get_axis(1).union(other._get_axis(1))
+                idx_diff = result_index.difference(correl.index)
 
-        if not drop:
-            # Find non-matching labels along the given axis
-            result_index = this._get_axis(1).union(other._get_axis(1))
-            idx_diff = result_index.difference(correl.index)
+                if len(idx_diff) > 0:
+                    correl = concat([correl, Series([np.nan] * len(idx_diff),
+                                                    index=idx_diff)])
 
-            if len(idx_diff) > 0:
-                correl = concat([correl, Series([np.nan] * len(idx_diff),
-                                                index=idx_diff)])
+            return WeightedSeries(correl)
+        else:
+            return super().corrwith(other, drop=drop, *args, **kwargs)
 
-        return Series(correl)
-
-    def kurt(self, axis=0, skipna=True):
+    def kurt(self, axis=0, skipna=True, *args, **kwargs):
         """Weighted kurtosis of the sampled distribution."""
-        if axis == 0:
+        if self.weighted(axis):
             null = self.isnull() & skipna
-            mean = self.mean(skipna=skipna)
-            std = self.std(skipna=skipna)
+            mean = self.mean(axis=axis, skipna=skipna)
+            std = self.std(axis=axis, skipna=skipna)
             kurt = np.average(masked_array(((self-mean)/std)**4, null),
-                              weights=self.weights, axis=0)
-            return Series(kurt, index=self.columns)
+                              weights=self._weights(axis), axis=axis)
+            return WeightedSeries(kurt, index=self._get_axis(1-axis))
         else:
-            return super().kurt(axis=axis, skipna=skipna)
+            return super().kurt(axis=axis, skipna=skipna, *args, **kwargs)
 
-    def skew(self, axis=0, skipna=True):
+    def skew(self, axis=0, skipna=True, *args, **kwargs):
         """Weighted skewness of the sampled distribution."""
-        if axis == 0:
+        if self.weighted(axis):
             null = self.isnull() & skipna
-            mean = self.mean(skipna=skipna)
-            std = self.std(skipna=skipna)
+            mean = self.mean(axis=axis, skipna=skipna)
+            std = self.std(axis=axis, skipna=skipna)
             skew = np.average(masked_array(((self-mean)/std)**3, null),
-                              weights=self.weights, axis=0)
-            return Series(skew, index=self.columns)
+                              weights=self._weights(axis), axis=axis)
+            return WeightedSeries(skew, index=self._get_axis(1-axis))
         else:
-            return super().skew(axis=axis, skipna=skipna)
+            return super().skew(axis=axis, skipna=skipna, *args, **kwargs)
 
-    def mad(self, axis=0, skipna=True):
+    def mad(self, axis=0, skipna=True, *args, **kwargs):
         """Weighted mean absolute deviation of the sampled distribution."""
-        if axis == 0:
+        if self.weighted(axis):
             null = self.isnull() & skipna
-            mean = self.mean(skipna=skipna)
+            mean = self.mean(axis=axis, skipna=skipna)
             mad = np.average(masked_array(abs(self-mean), null),
-                             weights=self.weights, axis=0)
-            return Series(mad, index=self.columns)
+                             weights=self._weights(axis), axis=axis)
+            return WeightedSeries(mad, index=self._get_axis(1-axis))
         else:
-            return super().var(axis=axis, skipna=skipna)
+            return super().var(axis=axis, skipna=skipna, *args, **kwargs)
 
     def sem(self, axis=0, skipna=True):
         """Weighted standard error of the mean."""
-        n = self.neff() if axis == 0 else self.shape[1]
+        n = self.neff(axis)
         return np.sqrt(self.var(axis=axis, skipna=skipna)/n)
 
     def quantile(self, q=0.5, axis=0, numeric_only=True,
@@ -287,19 +327,20 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
         """Weighted quantile of the sampled distribution."""
         if not numeric_only:
             raise NotImplementedError("numeric_only kwarg not implemented")
-        if axis == 0:
+        if self.weighted(axis):
             data = np.array([c.quantile(q, interpolation=interpolation,
                                         numeric_only=numeric_only)
                              for _, c in self.iteritems()])
             if np.isscalar(q):
-                return Series(data, index=self.columns)
+                return WeightedSeries(data, index=self._get_axis(1-axis))
             else:
-                return DataFrame(data.T, columns=self.columns, index=q)
+                return WeightedDataFrame(data.T, index=q,
+                                         columns=self._get_axis(1-axis))
         else:
             return super().quantile(q=q, axis=axis, numeric_only=numeric_only,
                                     interpolation=interpolation)
 
-    def compress(self, nsamples=None):
+    def compress(self, nsamples=None, axis=0):
         """Reduce the number of samples by discarding low-weights.
 
         Parameters
@@ -310,19 +351,17 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
             compression). If <=0, then compress so that all weights are unity.
 
         """
-        i = compress_weights(self.weights, self._rand, nsamples)
-        data = np.repeat(self.to_numpy(), i, axis=0)
-        index = self.index.repeat(i)
-        df = DataFrame(data=data, index=index, columns=self.columns)
-        df.index = df.index.droplevel('weights')
-        return df
-
-    #def _reduce(self, op, name, **kwargs):
-    #    answer = super()._reduce(op, name, **kwargs)
-    #    print(kwargs['axis'])
-    #    if self._get_axis_number(kwargs['axis']) == 0 and 'weights' in self.index.names:
-    #        answer = Series(answer).droplevel('weights', 0)
-    #    return answer
+        if self.weighted(axis):
+            i = compress_weights(self._weights(axis), self._rand(axis),
+                                 nsamples)
+            data = np.repeat(self.to_numpy(), i, axis=axis)
+            i = self._get_axis(axis).repeat(i).droplevel('weights')
+            df = WeightedDataFrame(data=data)
+            df.set_axis(i, axis=axis, inplace=True)
+            df.set_axis(self._get_axis(1-axis), axis=1-axis, inplace=True)
+            return df
+        else:
+            return self
 
     @property
     def _constructor_sliced(self):
@@ -331,13 +370,3 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
     @property
     def _constructor(self):
         return WeightedDataFrame
-
-    #def _ixs(self, i, axis=0): 
-    #    answer = super()._ixs(i, axis=axis)
-    #    
-    #    if self._get_axis_number(axis) == 0:
-    #        answer = Series(answer.droplevel('weights'))
-    #    return answer
-
-
-

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -243,6 +243,7 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
                 return WeightedSeries(answer)
 
             left, right = self.align(other, join="inner", copy=False)
+            weights = self.get_weights(axis)
 
             if axis == 1:
                 left = left.T
@@ -256,14 +257,15 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
             ldem = left - left.mean()
             rdem = right - right.mean()
 
-            num = (ldem * rdem * self.get_weights(axis)[:, None]).sum()
-            dom = self.get_weights(axis).sum() * left.std() * right.std()
+            num = (ldem * rdem * weights[:, None]).sum()
+            dom = weights.sum() * left.std() * right.std()
 
             correl = num / dom
 
             if not drop:
                 # Find non-matching labels along the given axis
-                result_index = self._get_axis(1).union(other._get_axis(1))
+                result_index = self._get_axis(1-axis).union(
+                    other._get_axis(1-axis))
                 idx_diff = result_index.difference(correl.index)
 
                 if len(idx_diff) > 0:

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -29,8 +29,27 @@ class _WeightedObject(object):
         else:
             return np.ones_like(self._get_axis(axis))
 
-    def set_weights(self, weights, axis=0, inplace=False):
-        """Set sample weights along an axis."""
+    def set_weights(self, weights, axis=0, inplace=False, level=None):
+        """Set sample weights along an axis.
+
+        Parameters
+        ----------
+        weights: 1d array-like
+            The sample weights to put in an index.
+
+        axis: int (0,1), optional
+            Whether to put weights in an index or column.
+            Default 0.
+
+        inplace: bool, optional
+            Whether to operate inplace, or return a new array.
+            Default False.
+
+        level: int
+            Which level in the index to insert before.
+            Defaults to inserting at back
+
+        """
         if inplace:
             result = self
         else:
@@ -40,13 +59,15 @@ class _WeightedObject(object):
             if result.isweighted(axis=axis):
                 result = result.droplevel('weights', axis=axis)
         else:
-            names = result._get_axis(axis).names
+            names = list(result._get_axis(axis).names)
             index = [result._get_axis(axis).get_level_values(name)
                      if name != 'weights' else weights
                      for name in result._get_axis(axis).names]
             if not result.isweighted(axis):
-                index += [weights]
-                names += ['weights']
+                if level is None:
+                    level = len(index)
+                index.insert(level, weights)
+                names.insert(level, 'weights')
 
             index = MultiIndex.from_arrays(index, names=names)
             result.set_axis(index, axis=axis, inplace=True)

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -1,7 +1,7 @@
 """Pandas DataFrame and Series with weighted samples."""
 
 import numpy as np
-from pandas import Series, DataFrame
+from pandas import Series, DataFrame, concat
 from pandas.util import hash_pandas_object
 from numpy.ma import masked_array
 from anesthetic.utils import (compress_weights, channel_capacity, quantile,
@@ -240,8 +240,8 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
             idx_diff = result_index.difference(correl.index)
 
             if len(idx_diff) > 0:
-                correl = correl._append(Series([np.nan] * len(idx_diff),
-                                               index=idx_diff))
+                correl = concat([correl, Series([np.nan] * len(idx_diff),
+                                                index=idx_diff)])
 
         return correl
 

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -216,7 +216,8 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
         this = self._get_numeric_data()
 
         if isinstance(other, Series):
-            return this.apply(lambda x: other.corr(x), axis=0)
+            answer = this.apply(lambda x: other.corr(x), axis=0)
+            return Series(answer)
 
         other = other._get_numeric_data()
         left, right = this.align(other, join="inner", copy=False)
@@ -243,7 +244,7 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
                 correl = concat([correl, Series([np.nan] * len(idx_diff),
                                                 index=idx_diff)])
 
-        return correl
+        return Series(correl)
 
     def kurt(self, axis=0, skipna=True):
         """Weighted kurtosis of the sampled distribution."""
@@ -332,3 +333,15 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
     @property
     def _constructor(self):
         return WeightedDataFrame
+
+    def _ixs(self, i, axis=0): 
+        answer = super()._ixs(i, axis=axis)
+        #print("columns", self.columns)
+        #print("index", self.index)
+        
+        #if self._get_axis_number(axis) == 0:
+        #    answer = Series(answer.droplevel('weights'))
+        return answer
+
+
+

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -236,7 +236,7 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
     def corrwith(self, other, axis=0, drop=False, method="pearson",
                  *args, **kwargs):
         """Pairwise weighted pearson correlation."""
-        if self.isweighted():
+        if self.isweighted(axis):
             if isinstance(other, Series):
                 answer = self.apply(lambda x: other.corr(x, method=method),
                                     axis=axis)
@@ -256,8 +256,8 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
             ldem = left - left.mean()
             rdem = right - right.mean()
 
-            num = (ldem * rdem * self.get_weights()[:, None]).sum()
-            dom = self.get_weights().sum() * left.std() * right.std()
+            num = (ldem * rdem * self.get_weights(axis)[:, None]).sum()
+            dom = self.get_weights(axis).sum() * left.std() * right.std()
 
             correl = num / dom
 
@@ -272,7 +272,7 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
 
             return WeightedSeries(correl)
         else:
-            return super().corrwith(other, drop=drop, *args, **kwargs)
+            return super().corrwith(other, drop=drop, axis=axis, *args, **kwargs)
 
     def kurt(self, axis=0, skipna=True, *args, **kwargs):
         """Weighted kurtosis of the sampled distribution."""

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -39,18 +39,19 @@ class _WeightedObject(object):
         if inplace:
             self._update_inplace(result)
         else:
-            return result
+            return result.__finalize__(self, "set_weights")
 
-    def reset_index(self, level=None, drop=False, inplace=False, *args):
+    def reset_index(self, level=None, drop=False, inplace=False,
+                    *args, **kwargs):
         """Reset the index, retaining weights."""
         weights = self.get_weights()
         answer = super().reset_index(level=level, drop=drop,
-                                     inplace=False, *args)
-        answer.set_weights(weights)
+                                     inplace=False, *args, **kwargs)
+        answer.set_weights(weights, inplace=True)
         if inplace:
             self._update_inplace(answer)
         else:
-            return answer
+            return answer.__finalize__(self, "reset_index")
 
     def std(self, *args, **kwargs):
         """Weighted standard deviation of the sampled distribution."""

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -59,15 +59,15 @@ class _WeightedObject(object):
             if result.isweighted(axis=axis):
                 result = result.droplevel('weights', axis=axis)
         else:
-            names = list(result._get_axis(axis).names)
-            index = [result._get_axis(axis).get_level_values(name)
-                     if name != 'weights' else weights
-                     for name in result._get_axis(axis).names]
-            if not result.isweighted(axis):
-                if level is None:
+            names = [n for n in result._get_axis(axis).names if n != 'weights']
+            index = [result._get_axis(axis).get_level_values(n) for n in names]
+            if level is None:
+                if result.isweighted(axis):
+                    level = result._get_axis(axis).names.index('weights')
+                else:
                     level = len(index)
-                index.insert(level, weights)
-                names.insert(level, 'weights')
+            index.insert(level, weights)
+            names.insert(level, 'weights')
 
             index = MultiIndex.from_arrays(index, names=names)
             result.set_axis(index, axis=axis, inplace=True)

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -15,7 +15,7 @@ class _WeightedObject(object):
     def __init__(self, *args, **kwargs):
         weights = kwargs.pop('weights', None)
         super().__init__(*args, **kwargs)
-        if weights is not None and 'weights' not in self.index.names:
+        if weights is not None:
             self._set_weights(weights)
 
     @property
@@ -58,7 +58,6 @@ class _WeightedObject(object):
     def median(self, *args, **kwargs):
         """Weighted median of the sampled distribution."""
         return self.quantile(*args, **kwargs)
-
 
 
 class WeightedSeries(_WeightedObject, Series):

--- a/anesthetic/weighted_pandas.py
+++ b/anesthetic/weighted_pandas.py
@@ -272,7 +272,8 @@ class WeightedDataFrame(_WeightedObject, DataFrame):
 
             return WeightedSeries(correl)
         else:
-            return super().corrwith(other, drop=drop, axis=axis, *args, **kwargs)
+            return super().corrwith(other, drop=drop, axis=axis, method=method,
+                                    *args, **kwargs)
 
     def kurt(self, axis=0, skipna=True, *args, **kwargs):
         """Weighted kurtosis of the sampled distribution."""

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -9,7 +9,7 @@ def test_to_getdist():
         getdist_samples = to_getdist(anesthetic_samples)
 
         assert_array_equal(getdist_samples.samples, anesthetic_samples)
-        assert_array_equal(getdist_samples.get_weights(),
+        assert_array_equal(getdist_samples.weights,
                            anesthetic_samples.get_weights())
 
         for param, p in zip(getdist_samples.getParamNames().names,

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -9,7 +9,8 @@ def test_to_getdist():
         getdist_samples = to_getdist(anesthetic_samples)
 
         assert_array_equal(getdist_samples.samples, anesthetic_samples)
-        assert_array_equal(getdist_samples.weights, anesthetic_samples.weights)
+        assert_array_equal(getdist_samples.get_weights(),
+                           anesthetic_samples.get_weights())
 
         for param, p in zip(getdist_samples.getParamNames().names,
                             anesthetic_samples.columns):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -77,9 +77,9 @@ def test_read_polychord():
     np.random.seed(3)
     ns = NestedSamples(root='./tests/example_data/pc')
     for key1 in ns.columns:
-        assert_array_equal(ns.weights, ns[key1].weights)
+        assert_array_equal(ns.get_weights(), ns[key1].get_weights())
         for key2 in ns.columns:
-            assert_array_equal(ns[key1].weights, ns[key2].weights)
+            assert_array_equal(ns[key1].get_weights(), ns[key2].get_weights())
     ns.plot_2d(['x0', 'x1', 'x2', 'x3'])
     ns.plot_1d(['x0', 'x1', 'x2', 'x3'])
     plt.close("all")

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -606,14 +606,14 @@ def test_live_points():
         live_points_from_index = pc.live_points(i)
         assert_array_equal(live_points_from_index, live_points)
 
-    assert pc.live_points(0).index[0][0] == 0
+    assert pc.live_points(0).index[0] == 0
 
     last_live_points = pc.live_points()
     logL = pc.logL_birth.max()
     assert (last_live_points.logL >= logL).all()
     assert len(last_live_points) == pc.nlive.mode().to_numpy()[0]
 
-    len(last_live_points)
+    assert not live_points.isweighted()
 
 
 def test_hist_range_1d():

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -765,8 +765,6 @@ def test_NestedSamples_importance_sample():
     ns0.importance_sample(logL_new, inplace=True)
     assert type(ns0) is NestedSamples
     assert_array_equal(ns0, ns1)
-    ns0.tex
-    ns1.tex
     assert ns0.tex == ns1.tex
     assert ns0.limits == ns1.limits
     assert ns0.root == ns1.root

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -727,7 +727,6 @@ def test_NestedSamples_importance_sample():
     assert ns0.label == ns1.label
     assert ns0.beta == ns1.beta
     assert ns0 is not ns1
-    assert ns0.tex is not ns1.tex
 
 
 def test_MCMCSamples_importance_sample():
@@ -772,7 +771,6 @@ def test_MCMCSamples_importance_sample():
         assert mc.label == mc0.label
         assert mc._metadata == mc0._metadata
         assert mc is not mc0
-        assert mc.tex is not mc0.tex
 
     mc0.importance_sample(mask, action='mask', inplace=True)
     assert type(mc0) is MCMCSamples
@@ -782,7 +780,6 @@ def test_MCMCSamples_importance_sample():
     assert mc3.label == mc0.label
     assert mc3._metadata == mc0._metadata
     assert mc3 is not mc0
-    assert mc3.tex is not mc0.tex
 
 
 def test_wedding_cake():
@@ -876,7 +873,6 @@ def test_copy():
     pc = NestedSamples(root='./tests/example_data/pc')
     new = pc.copy()
     assert new is not pc
-    assert new.tex is not pc.tex
 
 
 def test_plotting_with_integer_names():

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -441,9 +441,12 @@ def test_ns_output():
     assert abs(pc.set_beta(0.0).logZ()) < 1e-2
     assert pc.set_beta(0.9).logZ() < pc.set_beta(1.0).logZ()
 
-    assert_array_almost_equal(pc.set_beta(1).weights, pc.set_beta(1).weights)
-    assert_array_almost_equal(pc.set_beta(.5).weights, pc.set_beta(.5).weights)
-    assert_array_equal(pc.set_beta(0).weights, pc.set_beta(0).weights)
+    assert_array_almost_equal(pc.set_beta(1).get_weights(),
+                              pc.set_beta(1).get_weights())
+    assert_array_almost_equal(pc.set_beta(.5).get_weights(),
+                              pc.set_beta(.5).get_weights())
+    assert_array_equal(pc.set_beta(0).get_weights(),
+                       pc.set_beta(0).get_weights())
 
 
 def test_masking():
@@ -546,30 +549,33 @@ def test_weighted_merging():
 
 def test_beta():
     pc = NestedSamples(root="./tests/example_data/pc")
-    weights = pc.weights
-    assert_array_equal(weights, pc.weights)
-    assert_array_equal(pc.index.get_level_values('weights'), pc.weights)
+    weights = pc.get_weights()
+    assert_array_equal(weights, pc.get_weights())
+    assert_array_equal(pc.index.get_level_values('weights'), pc.get_weights())
     assert pc.beta == 1
 
     prior = pc.set_beta(0)
     assert prior.beta == 0
-    assert_array_equal(prior.index.get_level_values('weights'), prior.weights)
+    assert_array_equal(prior.index.get_level_values('weights'),
+                       prior.get_weights())
     assert pc.beta == 1
-    assert_array_equal(pc.index.get_level_values('weights'), pc.weights)
-    assert_array_almost_equal(sorted(prior.weights, reverse=True),
-                              prior.weights)
+    assert_array_equal(pc.index.get_level_values('weights'), pc.get_weights())
+    assert_array_almost_equal(sorted(prior.get_weights(), reverse=True),
+                              prior.get_weights())
 
     for beta in np.linspace(0, 2, 10):
         pc.set_beta(beta, inplace=True)
         assert pc.beta == beta
-        assert_array_equal(pc.index.get_level_values('weights'), pc.weights)
+        assert_array_equal(pc.index.get_level_values('weights'),
+                           pc.get_weights())
         assert not np.array_equal(pc.index.get_level_values('weights'),
                                   weights)
 
     for beta in np.linspace(0, 2, 10):
         pc.beta = beta
         assert pc.beta == beta
-        assert_array_equal(pc.index.get_level_values('weights'), pc.weights)
+        assert_array_equal(pc.index.get_level_values('weights'),
+                           pc.get_weights())
         assert not np.array_equal(pc.index.get_level_values('weights'),
                                   weights)
 
@@ -580,7 +586,7 @@ def test_beta_with_logL_infinities():
         ns.loc[i, 'logL'] = -np.inf
     prior = ns.set_beta(0)
     assert np.all(prior.logL[:10] == -np.inf)
-    assert np.all(prior.weights[:10] == 0)
+    assert np.all(prior.get_weights()[:10] == 0)
     ns.plot_1d(['x0', 'x1'])
 
 
@@ -677,9 +683,9 @@ def test_contour_plot_2d_nan():
         ns.plot_2d(['x0', 'x1'])
 
     # Check this error is removed in the case of zero weights
-    weights = ns.weights
+    weights = ns.get_weights()
     weights[:10] = 0
-    ns.weights = weights
+    ns.set_weights(weights, inplace=True)
     ns.plot_2d(['x0', 'x1'])
 
 
@@ -726,22 +732,22 @@ def test_NestedSamples_importance_sample():
     ns_masked = ns0.importance_sample(ns0.logL, action='replace')
     assert_array_equal(ns0.logL, ns_masked.logL)
     assert_array_equal(ns0.logL_birth, ns_masked.logL_birth)
-    assert_array_equal(ns0.weights, ns_masked.weights)
+    assert_array_equal(ns0.get_weights(), ns_masked.get_weights())
 
     ns_masked = ns0.importance_sample(np.zeros_like(ns0.logL), action='add')
     assert_array_equal(ns0.logL, ns_masked.logL)
     assert_array_equal(ns0.logL_birth, ns_masked.logL_birth)
-    assert_array_equal(ns0.weights, ns_masked.weights)
+    assert_array_equal(ns0.get_weights(), ns_masked.get_weights())
 
     mask = ((ns0.x0 > -0.3) & (ns0.x2 > 0.2) & (ns0.x4 < 3.5)).to_numpy()
     ns_masked = merge_nested_samples((ns0[mask], ))
-    V_prior = pi0[mask].weights.sum() / pi0.weights.sum()
-    V_posterior = ns0[mask].weights.sum() / ns0.weights.sum()
+    V_prior = pi0[mask].get_weights().sum() / pi0.get_weights().sum()
+    V_posterior = ns0[mask].get_weights().sum() / ns0.get_weights().sum()
 
     ns1 = ns0.importance_sample(mask, action='mask')
     assert_array_equal(ns_masked.logL, ns1.logL)
     assert_array_equal(ns_masked.logL_birth, ns1.logL_birth)
-    assert_array_equal(ns_masked.weights, ns1.weights)
+    assert_array_equal(ns_masked.get_weights(), ns1.get_weights())
 
     logL_new = np.where(mask, 0, -np.inf)
     ns1 = ns0.importance_sample(logL_new)
@@ -759,6 +765,8 @@ def test_NestedSamples_importance_sample():
     ns0.importance_sample(logL_new, inplace=True)
     assert type(ns0) is NestedSamples
     assert_array_equal(ns0, ns1)
+    ns0.tex
+    ns1.tex
     assert ns0.tex == ns1.tex
     assert ns0.limits == ns1.limits
     assert ns0.root == ns1.root
@@ -782,18 +790,18 @@ def test_MCMCSamples_importance_sample():
     # add logL
     mc1 = mc0.importance_sample(np.zeros_like(mc0.logL), action='add')
     assert_array_equal(mc0.logL, mc1.logL)
-    assert_array_equal(mc0.weights, mc1.weights)
+    assert_array_equal(mc0.get_weights(), mc1.get_weights())
     mc1 = mc0.importance_sample(logL_new=logL_i)
     assert np.all(mc1.logL.to_numpy() != mc0.logL.to_numpy())
-    assert not np.all(mc1.weights == mc0.weights)
+    assert not np.all(mc1.get_weights() == mc0.get_weights())
 
     # replace logL
     mc2 = mc0.importance_sample(mc0.logL, action='replace')
     assert_array_equal(mc0.logL, mc2.logL)
-    assert_array_equal(mc0.weights, mc2.weights)
+    assert_array_equal(mc0.get_weights(), mc2.get_weights())
     mc2 = mc0.importance_sample(mc0.logL.to_numpy()+logL_i, action='replace')
     assert np.all(mc2.logL.to_numpy() != mc0.logL.to_numpy())
-    assert not np.all(mc2.weights == mc0.weights)
+    assert not np.all(mc2.get_weights() == mc0.get_weights())
     assert_array_equal(mc1.logL.to_numpy(), mc2.logL.to_numpy())
     assert_array_almost_equal(mc1.logL.to_numpy(), mc2.logL.to_numpy())
 
@@ -802,7 +810,7 @@ def test_MCMCSamples_importance_sample():
     mc_masked = mc0[mask]
     mc3 = mc0.importance_sample(mask, action='mask')
     assert_array_equal(mc_masked.logL, mc3.logL)
-    assert_array_equal(mc_masked.weights, mc3.weights)
+    assert_array_equal(mc_masked.get_weights(), mc3.get_weights())
     assert np.all(mc3.x0 > -0.3)
 
     for mc in [mc1, mc2, mc3]:
@@ -847,8 +855,8 @@ def test_logzero_mask_prior_level():
     NS0 = ns0.ns_output(nsamples=2000)
     mask = ((ns0.x0 > -0.3) & (ns0.x2 > 0.2) & (ns0.x4 < 3.5)).to_numpy()
 
-    V_prior = pi0[mask].weights.sum() / pi0.weights.sum()
-    V_posterior = ns0[mask].weights.sum() / ns0.weights.sum()
+    V_prior = pi0[mask].get_weights().sum() / pi0.get_weights().sum()
+    V_posterior = ns0[mask].get_weights().sum() / ns0.get_weights().sum()
     logZ_V = NS0.logZ.mean() + np.log(V_posterior) - np.log(V_prior)
 
     ns1 = merge_nested_samples((ns0[mask],))
@@ -863,7 +871,7 @@ def test_logzero_mask_likelihood_level():
     NS0 = ns0.ns_output(nsamples=2000)
     mask = ((ns0.x0 > -0.3) & (ns0.x2 > 0.2) & (ns0.x4 < 3.5)).to_numpy()
 
-    V_posterior = ns0[mask].weights.sum() / ns0.weights.sum()
+    V_posterior = ns0[mask].get_weights().sum() / ns0.get_weights().sum()
     logZ_V = NS0.logZ.mean() + np.log(V_posterior)
 
     ns1 = NestedSamples(root='./tests/example_data/pc')

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -431,9 +431,9 @@ def test_merging():
     samples_1 = NestedSamples(root='./tests/example_data/pc')
     samples_2 = NestedSamples(root='./tests/example_data/pc_250')
     samples = merge_nested_samples([samples_1, samples_2])
-    nlive_1 = samples_1.nlive.mode()[0]
-    nlive_2 = samples_2.nlive.mode()[0]
-    nlive = samples.nlive.mode()[0]
+    nlive_1 = samples_1.nlive.mode().to_numpy()[0]
+    nlive_2 = samples_2.nlive.mode().to_numpy()[0]
+    nlive = samples.nlive.mode().to_numpy()[0]
     assert nlive_1 == 125
     assert nlive_2 == 250
     assert nlive == nlive_1 + nlive_2
@@ -452,15 +452,15 @@ def test_weighted_merging():
     samples_2['xtest'] = samples_2['x3']
     samples_1.tex['xtest'] = "$x_{t,1}$"
     samples_2.tex['xtest'] = "$x_{t,2}$"
-    mean1 = samples_1.mean()['xtest']
-    mean2 = samples_2.mean()['xtest']
+    mean1 = samples_1.xtest.mean()
+    mean2 = samples_2.xtest.mean()
 
     # Test with evidence weights
     weight1 = np.exp(samples_1.logZ())
     weight2 = np.exp(samples_2.logZ())
     samples = merge_samples_weighted([samples_1, samples_2],
                                      label='Merged label')
-    mean = samples.mean()['xtest']
+    mean = samples.xtest.mean()
     assert np.isclose(mean, (mean1*weight1+mean2*weight2)/(weight1+weight2))
 
     # Test tex and label
@@ -482,7 +482,7 @@ def test_weighted_merging():
     weight2 = 13
     samples = merge_samples_weighted(
         [samples_1, samples_2], weights=[weight1, weight2])
-    mean = samples.mean()['xtest']
+    mean = samples.xtest.mean()
     assert np.isclose(mean, (mean1*weight1+mean2*weight2)/(weight1+weight2))
 
     # Test plot still works (see issue #189)
@@ -574,7 +574,9 @@ def test_live_points():
     last_live_points = pc.live_points()
     logL = pc.logL_birth.max()
     assert (last_live_points.logL >= logL).all()
-    assert len(last_live_points) == pc.nlive.mode()[0]
+    assert len(last_live_points) == pc.nlive.mode().to_numpy()[0]
+
+    len(last_live_points)
 
 
 def test_limit_assignment():
@@ -652,7 +654,7 @@ def test_compute_insertion():
     ns._compute_insertion_indexes()
     assert 'insertion' in ns
 
-    nlive = ns.nlive.mode()[0]
+    nlive = ns.nlive.mode().to_numpy()[0]
     assert_array_less(ns.insertion, nlive)
 
     u = ns.insertion.to_numpy()/nlive

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -1,5 +1,5 @@
 from anesthetic.weighted_pandas import WeightedDataFrame, WeightedSeries
-from pandas import Series, DataFrame
+from pandas import Series, DataFrame, MultiIndex
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
@@ -13,6 +13,7 @@ def test_WeightedSeries_constructor():
 
     series = WeightedSeries(data)
     assert_array_equal(series.weights, 1)
+    assert_array_equal(series.index.get_level_values('weights'), 1)
     assert_array_equal(series, data)
 
     series = WeightedSeries(data, weights=None)
@@ -465,3 +466,18 @@ def test_WeightedSeries_nan():
     assert_allclose(series.mean(), 0.5, atol=1e-2)
     assert_allclose(series.var(), 1./12, atol=1e-2)
     assert_allclose(series.std(), (1./12)**0.5, atol=1e-2)
+
+
+def test_multiindex():
+    np.random.rand(0)
+    N = 1000
+    index_1 = np.arange(N)
+    index_2 = np.random.randint(0, 1000, N)
+    index = MultiIndex.from_arrays([index_1, index_2], names=['A', 'B'])
+    data = np.random.rand(N, 5)
+    weights = np.random.rand(N)
+    wdf = WeightedDataFrame(data, weights=weights, index=index)
+
+    assert wdf.index.names == ['A', 'B', 'weights']
+    assert_allclose(np.array([*wdf.index]).T, [index_1, index_2, weights])
+    assert wdf.reset_index().index.names == [None, 'weights']

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -197,6 +197,10 @@ def test_WeightedDataFrame_corrwith(frame):
     assert_array_equal(correl_2, correl_3)
     assert_array_equal(correl_2.index, correl_3.index)
 
+    correl_4 = frame.T.corrwith(frame.T, axis=1)
+    correl_5 = unweighted.T.corrwith(unweighted.T, axis=1)
+    assert_allclose(correl_4, correl_5)
+
     frame.set_weights(None, inplace=True)
     assert_array_equal(frame.corrwith(frame), unweighted.corrwith(unweighted))
 

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -188,6 +188,13 @@ def test_WeightedDataFrame_corrwith(frame):
     with pytest.raises(ValueError):
         unweighted.corrwith(frame[['A', 'B']])
 
+    correl_1 = frame[:5].corrwith(frame.iloc[0], axis=1)
+    correl_2 = frame[:5].T.corrwith(unweighted.T[0])
+    assert_allclose(correl_1, correl_2)
+
+    frame.set_weights(None, inplace=True)
+    assert_array_equal(frame.corrwith(frame), unweighted.corrwith(unweighted))
+
 
 def test_WeightedDataFrame_median(frame):
     median = frame.median()
@@ -872,3 +879,18 @@ def test_weight_passing(mcmc_wdf):
 
     new_wdf = WeightedDataFrame(mcmc_wdf.copy(), weights=weights)
     assert_array_equal(new_wdf.get_weights(), weights)
+
+
+def test_set_weights(mcmc_wdf):
+    weights_1 = mcmc_wdf.get_weights()
+    weights_2 = np.random.rand(len(mcmc_wdf.index))
+
+    assert_array_equal(mcmc_wdf.set_weights(weights_2).get_weights(),
+                       weights_2)
+    assert_array_equal(mcmc_wdf.get_weights(), weights_1)
+    mcmc_wdf.set_weights(weights_2, inplace=True)
+    assert_array_equal(mcmc_wdf.get_weights(), weights_2)
+
+    assert mcmc_wdf.isweighted()
+    assert not mcmc_wdf.set_weights(None).isweighted()
+    assert_array_equal(mcmc_wdf.set_weights(None).get_weights(), 1)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -19,17 +19,17 @@ def series():
 
     series = WeightedSeries(data)
     assert_array_equal(series.weights, 1)
-    assert not series.weighted
+    assert not series._weighted
     assert_array_equal(series, data)
 
     series = WeightedSeries(data, weights=None)
     assert_array_equal(series.weights, 1)
-    assert not series.weighted
+    assert not series._weighted
     assert_array_equal(series, data)
 
     weights = np.random.rand(N)
     series = WeightedSeries(data, weights=weights)
-    assert series.weighted
+    assert series._weighted
     assert_array_equal(series, data)
 
     assert series.weights.shape == (N,)
@@ -54,17 +54,17 @@ def frame():
 
     frame = WeightedDataFrame(data, columns=cols)
     assert_array_equal(frame.weights, 1)
-    assert not frame.weighted(0) and not frame.weighted(1)
+    assert not frame._weighted(0) and not frame._weighted(1)
     assert_array_equal(frame, data)
 
     frame = WeightedDataFrame(data, weights=None, columns=cols)
     assert_array_equal(frame.weights, 1)
-    assert not frame.weighted(0) and not frame.weighted(1)
+    assert not frame._weighted(0) and not frame._weighted(1)
     assert_array_equal(frame, data)
 
     weights = np.random.rand(N)
     frame = WeightedDataFrame(data, weights=weights, columns=cols)
-    assert frame.weighted(0) and not frame.weighted(1)
+    assert frame._weighted(0) and not frame._weighted(1)
     assert frame.weights.shape == (N,)
     assert frame.shape == (N, m)
     assert isinstance(frame.weights, np.ndarray)
@@ -85,9 +85,9 @@ def test_WeightedDataFrame_key(frame):
 def test_WeightedDataFrame_slice(frame):
     assert isinstance(frame['A'], WeightedSeries)
     assert isinstance(frame.iloc[0], WeightedSeries)
-    assert not frame.iloc[0].weighted
+    assert not frame.iloc[0]._weighted
     assert isinstance(frame[:10], WeightedDataFrame)
-    assert frame[:10].weighted
+    assert frame[:10]._weighted
     assert frame[:10].shape == (10, 6)
     assert frame[:10].weights.shape == (10,)
     assert frame[:10]._rand(0).shape == (10,)
@@ -97,7 +97,7 @@ def test_WeightedDataFrame_slice(frame):
 def test_WeightedDataFrame_mean(frame):
     mean = frame.mean()
     assert isinstance(mean, WeightedSeries)
-    assert not mean.weighted
+    assert not mean._weighted
     assert_array_equal(mean.index, frame.columns)
     assert_allclose(mean, 0.5, atol=1e-2)
 
@@ -105,8 +105,8 @@ def test_WeightedDataFrame_mean(frame):
     assert isinstance(mean, WeightedSeries)
     assert_array_equal(mean, frame.T.mean())
     assert isinstance(frame.T.mean(), WeightedSeries)
-    assert mean.weighted
-    assert frame.T.mean().weighted
+    assert mean._weighted
+    assert frame.T.mean()._weighted
     assert_array_equal(mean.index, frame.index)
     assert_allclose(mean.mean(), 0.5, atol=1e-2)
 
@@ -114,7 +114,7 @@ def test_WeightedDataFrame_mean(frame):
 def test_WeightedDataFrame_std(frame):
     std = frame.std()
     assert isinstance(std, WeightedSeries)
-    assert not std.weighted
+    assert not std._weighted
     assert_array_equal(std.index, frame.columns)
     assert_allclose(std, (1./12)**0.5, atol=1e-2)
 
@@ -122,8 +122,8 @@ def test_WeightedDataFrame_std(frame):
     assert isinstance(std, WeightedSeries)
     assert_array_equal(std, frame.T.std())
     assert isinstance(frame.T.std(), WeightedSeries)
-    assert std.weighted
-    assert frame.T.std().weighted
+    assert std._weighted
+    assert frame.T.std()._weighted
     assert_array_equal(std.index, frame.index)
     assert_allclose(std.mean(), (1./12)**0.5, atol=1e-1)
 
@@ -131,14 +131,14 @@ def test_WeightedDataFrame_std(frame):
 def test_WeightedDataFrame_cov(frame):
     cov = frame.cov()
     assert isinstance(cov, WeightedDataFrame)
-    assert not cov.weighted(0) and not cov.weighted(1)
+    assert not cov._weighted(0) and not cov._weighted(1)
     assert_array_equal(cov.index, frame.columns)
     assert_array_equal(cov.columns, frame.columns)
     assert_allclose(cov, (1./12)*np.identity(6), atol=1e-2)
 
     cov = frame[:5].T.cov()
     assert isinstance(cov, WeightedDataFrame)
-    assert cov.weighted(0) and cov.weighted(1)
+    assert cov._weighted(0) and cov._weighted(1)
     assert_array_equal(cov.index, frame[:5].index)
     assert_array_equal(cov.columns, frame[:5].index)
 
@@ -146,14 +146,14 @@ def test_WeightedDataFrame_cov(frame):
 def test_WeightedDataFrame_corr(frame):
     corr = frame.corr()
     assert isinstance(corr, WeightedDataFrame)
-    assert not corr.weighted(0) and not corr.weighted(1)
+    assert not corr._weighted(0) and not corr._weighted(1)
     assert_array_equal(corr.index, frame.columns)
     assert_array_equal(corr.columns, frame.columns)
     assert_allclose(corr, np.identity(6), atol=1.1e-2)
 
     corr = frame[:5].T.corr()
     assert isinstance(corr, WeightedDataFrame)
-    assert corr.weighted(0) and corr.weighted(1)
+    assert corr._weighted(0) and corr._weighted(1)
     assert_array_equal(corr.index, frame[:5].index)
     assert_array_equal(corr.columns, frame[:5].index)
 
@@ -161,13 +161,13 @@ def test_WeightedDataFrame_corr(frame):
 def test_WeightedDataFrame_corrwith(frame):
     correl = frame.corrwith(frame.A)
     assert isinstance(correl, WeightedSeries)
-    assert not correl.weighted
+    assert not correl._weighted
     assert_array_equal(correl.index, frame.columns)
     assert_allclose(correl, frame.corr()['A'])
 
     correl = frame.corrwith(frame[['A', 'B']])
     assert isinstance(correl, WeightedSeries)
-    assert not correl.weighted
+    assert not correl._weighted
     assert_array_equal(correl.index, frame.columns)
     assert_allclose(correl['A'], 1, atol=1e-2)
     assert_allclose(correl['B'], 1, atol=1e-2)
@@ -177,7 +177,7 @@ def test_WeightedDataFrame_corrwith(frame):
 def test_WeightedDataFrame_median(frame):
     median = frame.median()
     assert isinstance(median, WeightedSeries)
-    assert not median.weighted
+    assert not median._weighted
     assert_array_equal(median.index, frame.columns)
     assert_allclose(median, 0.5, atol=1e-2)
 
@@ -185,8 +185,8 @@ def test_WeightedDataFrame_median(frame):
     assert isinstance(median, WeightedSeries)
     assert_array_equal(median, frame.T.median())
     assert isinstance(frame.T.median(), WeightedSeries)
-    assert median.weighted
-    assert frame.T.median().weighted
+    assert median._weighted
+    assert frame.T.median()._weighted
     assert_array_equal(median.index, frame.index)
     assert_allclose(median.mean(), 0.5, atol=1e-2)
 
@@ -194,7 +194,7 @@ def test_WeightedDataFrame_median(frame):
 def test_WeightedDataFrame_sem(frame):
     sem = frame.sem()
     assert isinstance(sem, WeightedSeries)
-    assert not sem.weighted
+    assert not sem._weighted
     assert_array_equal(sem.index, frame.columns)
     assert_allclose(sem, (1./12)**0.5/np.sqrt(frame.neff()), atol=1e-2)
 
@@ -202,15 +202,15 @@ def test_WeightedDataFrame_sem(frame):
     assert isinstance(sem, WeightedSeries)
     assert_array_equal(sem, frame.T.sem())
     assert isinstance(frame.T.sem(), WeightedSeries)
-    assert sem.weighted
-    assert frame.T.sem().weighted
+    assert sem._weighted
+    assert frame.T.sem()._weighted
     assert_array_equal(sem.index, frame.index)
 
 
 def test_WeightedDataFrame_kurtosis(frame):
     kurtosis = frame.kurtosis()
     assert isinstance(kurtosis, WeightedSeries)
-    assert not kurtosis.weighted
+    assert not kurtosis._weighted
     assert_array_equal(kurtosis.index, frame.columns)
     assert_allclose(kurtosis, 9./5, atol=1e-2)
     assert_array_equal(frame.kurtosis(), frame.kurt())
@@ -219,8 +219,8 @@ def test_WeightedDataFrame_kurtosis(frame):
     assert isinstance(kurtosis, WeightedSeries)
     assert_array_equal(kurtosis, frame.T.kurtosis())
     assert isinstance(frame.T.kurtosis(), WeightedSeries)
-    assert kurtosis.weighted
-    assert frame.T.kurtosis().weighted
+    assert kurtosis._weighted
+    assert frame.T.kurtosis()._weighted
     assert_array_equal(kurtosis.index, frame.index)
     assert_array_equal(frame.kurtosis(axis=1), frame.kurt(axis=1))
 
@@ -228,7 +228,7 @@ def test_WeightedDataFrame_kurtosis(frame):
 def test_WeightedDataFrame_skew(frame):
     skew = frame.skew()
     assert isinstance(skew, WeightedSeries)
-    assert not skew.weighted
+    assert not skew._weighted
     assert_array_equal(skew.index, frame.columns)
     assert_allclose(skew, 0., atol=2e-2)
 
@@ -236,15 +236,15 @@ def test_WeightedDataFrame_skew(frame):
     assert isinstance(skew, WeightedSeries)
     assert_array_equal(skew, frame.T.skew())
     assert isinstance(frame.T.skew(), WeightedSeries)
-    assert skew.weighted
-    assert frame.T.skew().weighted
+    assert skew._weighted
+    assert frame.T.skew()._weighted
     assert_array_equal(skew.index, frame.index)
 
 
 def test_WeightedDataFrame_mad(frame):
     mad = frame.mad()
     assert isinstance(mad, WeightedSeries)
-    assert not mad.weighted
+    assert not mad._weighted
     assert_array_equal(mad.index, frame.columns)
     assert_allclose(mad, 0.25, atol=1e-2)
 
@@ -252,23 +252,23 @@ def test_WeightedDataFrame_mad(frame):
     assert isinstance(mad, WeightedSeries)
     assert_array_equal(mad, frame.T.mad())
     assert isinstance(frame.T.mad(), WeightedSeries)
-    assert mad.weighted
-    assert frame.T.mad().weighted
+    assert mad._weighted
+    assert frame.T.mad()._weighted
     assert_array_equal(mad.index, frame.index)
 
 
 def test_WeightedDataFrame_quantile(frame):
     quantile = frame.quantile()
     assert isinstance(quantile, WeightedSeries)
-    assert not quantile.weighted
+    assert not quantile._weighted
     assert_array_equal(quantile.index, frame.columns)
     assert_allclose(quantile, 0.5, atol=1e-2)
 
     quantile = frame.quantile(axis=1)
     assert isinstance(quantile, WeightedSeries)
     assert_array_equal(quantile, frame.T.quantile())
-    assert quantile.weighted
-    assert frame.T.quantile().weighted
+    assert quantile._weighted
+    assert frame.T.quantile()._weighted
     assert_array_equal(quantile.index, frame.index)
     assert_allclose(quantile.mean(), 0.5, atol=1e-2)
 
@@ -276,7 +276,7 @@ def test_WeightedDataFrame_quantile(frame):
     for q in qs:
         quantile = frame.quantile(q)
         assert isinstance(quantile, WeightedSeries)
-        assert not quantile.weighted
+        assert not quantile._weighted
         assert_array_equal(quantile.index, frame.columns)
         assert_allclose(quantile, q, atol=1e-2)
 
@@ -286,8 +286,8 @@ def test_WeightedDataFrame_quantile(frame):
         quantile = frame.quantile(q, axis=1)
         assert isinstance(quantile, WeightedSeries)
         assert_array_equal(quantile, frame.T.quantile(q))
-        assert quantile.weighted
-        assert frame.T.quantile(q).weighted
+        assert quantile._weighted
+        assert frame.T.quantile(q)._weighted
         assert_array_equal(quantile.index, frame.index)
 
     quantile = frame.quantile(qs)
@@ -421,9 +421,9 @@ def test_WeightedDataFrame_nan(frame):
     assert_allclose(frame.cov(), (1./12)*np.identity(6), atol=1e-2)
 
     assert isinstance(frame.mean(), WeightedSeries)
-    assert not frame.mean().weighted
+    assert not frame.mean()._weighted
     assert isinstance(frame.mean(axis=1), WeightedSeries)
-    assert frame.mean(axis=1).weighted
+    assert frame.mean(axis=1)._weighted
 
 
 def test_WeightedSeries_mean(series):

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -174,6 +174,20 @@ def test_WeightedDataFrame_corrwith(frame):
     assert_allclose(correl['B'], 1, atol=1e-2)
     assert np.isnan(correl['C'])
 
+    unweighted = DataFrame(frame).droplevel('weights')
+
+    with pytest.raises(ValueError):
+        frame.corrwith(unweighted.A)
+
+    with pytest.raises(ValueError):
+        frame.corrwith(unweighted[['A', 'B']])
+
+    with pytest.raises(ValueError):
+        unweighted.corrwith(frame.A)
+
+    with pytest.raises(ValueError):
+        unweighted.corrwith(frame[['A', 'B']])
+
 
 def test_WeightedDataFrame_median(frame):
     median = frame.median()
@@ -461,6 +475,14 @@ def test_WeightedSeries_corr(frame):
     assert_allclose(frame.A.corr(frame.B), 0, atol=1e-2)
     D = frame.A + frame.B
     assert_allclose(frame.A.corr(D), 1/np.sqrt(2), atol=1e-2)
+
+    unweighted = DataFrame(frame).droplevel('weights')
+
+    with pytest.raises(ValueError):
+        frame.A.corr(unweighted.B)
+
+    with pytest.raises(ValueError):
+        unweighted.A.corr(frame.B)
 
 
 def test_WeightedSeries_median(series):

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -894,3 +894,12 @@ def test_set_weights(mcmc_wdf):
     assert mcmc_wdf.isweighted()
     assert not mcmc_wdf.set_weights(None).isweighted()
     assert_array_equal(mcmc_wdf.set_weights(None).get_weights(), 1)
+
+    mcmc_wdf.set_weights(None, inplace=True)
+    assert not mcmc_wdf.isweighted()
+    assert mcmc_wdf.set_weights(None) is not mcmc_wdf
+
+    mcmc_id = id(mcmc_wdf)
+    mcmc_wdf.set_weights(None, inplace=True)
+    assert id(mcmc_wdf) == mcmc_id
+    assert not mcmc_wdf.isweighted()

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -877,6 +877,12 @@ def test_multiindex(mcmc_wdf):
     wdf_ = wdf.reset_index(level=['A', 'C'])
     assert wdf_.index.names == ['B', 'weights']
 
+    assert_array_equal(wdf.get_weights(), weights)
+    wdf_ = wdf.reorder_levels(['B', 'C', 'weights', 'A'])
+    assert_array_equal(wdf_.get_weights(), weights)
+    weights_ = np.random.rand(len(weights))
+    assert_array_equal(wdf_.set_weights(weights_).get_weights(), weights_)
+
 
 def test_weight_passing(mcmc_wdf):
     weights = mcmc_wdf.get_weights()

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -883,6 +883,14 @@ def test_multiindex(mcmc_wdf):
     weights_ = np.random.rand(len(weights))
     assert_array_equal(wdf_.set_weights(weights_).get_weights(), weights_)
 
+    wdf_ = wdf.droplevel('weights').set_weights(weights, level=2)
+    assert wdf_.index.names == ['A', 'B', 'weights', 'C']
+    assert_array_equal(wdf_.get_weights(), weights)
+
+    wdf_ = wdf.set_weights(weights, level=2)
+    assert wdf_.index.names == ['A', 'B', 'weights', 'C']
+    assert_array_equal(wdf_.get_weights(), weights)
+
 
 def test_weight_passing(mcmc_wdf):
     weights = mcmc_wdf.get_weights()

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -72,6 +72,9 @@ def test_WeightedDataFrame_key():
 def test_WeightedDataFrame_slice():
     df = test_WeightedDataFrame_constructor()
     assert isinstance(df['A'], WeightedSeries)
+    assert isinstance(df.iloc[0], Series)
+    assert not isinstance(df.iloc[0], WeightedSeries)
+    assert isinstance(df[:10], WeightedDataFrame)
     assert df[:10].shape == (10, 3)
     assert df[:10].weights.shape == (10,)
     assert df[:10]._rand.shape == (10,)
@@ -81,6 +84,7 @@ def test_WeightedDataFrame_mean():
     df = test_WeightedDataFrame_constructor()
     mean = df.mean()
     assert isinstance(mean, Series)
+    assert not isinstance(mean, WeightedSeries)
     assert_allclose(mean, 0.5, atol=1e-2)
 
     mean = df.mean(axis=1)
@@ -92,6 +96,7 @@ def test_WeightedDataFrame_std():
     df = test_WeightedDataFrame_constructor()
     std = df.std()
     assert isinstance(std, Series)
+    assert not isinstance(std, WeightedSeries)
     assert_allclose(std, (1./12)**0.5, atol=1e-2)
 
     std = df.std(axis=1)
@@ -103,6 +108,7 @@ def test_WeightedDataFrame_cov():
     df = test_WeightedDataFrame_constructor()
     cov = df.cov()
     assert isinstance(cov, DataFrame)
+    assert not isinstance(cov, WeightedDataFrame)
     assert_allclose(cov, (1./12)*np.identity(3), atol=1e-2)
 
 
@@ -110,6 +116,7 @@ def test_WeightedDataFrame_corr():
     df = test_WeightedDataFrame_constructor()
     corr = df.corr()
     assert isinstance(corr, DataFrame)
+    assert not isinstance(corr, WeightedDataFrame)
     assert_allclose(corr, np.identity(3), atol=1e-2)
 
 
@@ -118,10 +125,12 @@ def test_WeightedDataFrame_corrwith():
 
     correl = df.corrwith(df.A)
     assert isinstance(correl, Series)
-    assert_allclose(df.corrwith(df.A), df.corr()['A'])
+    assert not isinstance(correl, WeightedSeries)
+    assert_allclose(correl, df.corr()['A'])
 
     correl = df.corrwith(df[['A', 'B']])
     assert isinstance(correl, Series)
+    assert not isinstance(correl, WeightedSeries)
     assert_allclose(correl['A'], 1, atol=1e-2)
     assert_allclose(correl['B'], 1, atol=1e-2)
     assert np.isnan(correl['C'])
@@ -131,10 +140,12 @@ def test_WeightedDataFrame_median():
     df = test_WeightedDataFrame_constructor()
     median = df.median()
     assert isinstance(median, Series)
+    assert not isinstance(median, WeightedSeries)
     assert_allclose(median, 0.5, atol=1e-2)
 
     median = df.median(axis=1)
     assert isinstance(median, WeightedSeries)
+    type(median)
     assert_allclose(median.mean(), 0.5, atol=1e-2)
 
 
@@ -142,6 +153,7 @@ def test_WeightedDataFrame_sem():
     df = test_WeightedDataFrame_constructor()
     sem = df.sem()
     assert isinstance(sem, Series)
+    assert not isinstance(sem, WeightedSeries)
     assert_allclose(sem, (1./12)**0.5/np.sqrt(df.neff()), atol=1e-2)
 
     sem = df.sem(axis=1)
@@ -152,6 +164,7 @@ def test_WeightedDataFrame_kurtosis():
     df = test_WeightedDataFrame_constructor()
     kurtosis = df.kurtosis()
     assert isinstance(kurtosis, Series)
+    assert not isinstance(kurtosis, WeightedSeries)
     assert_allclose(kurtosis, 9./5, atol=1e-2)
     assert_array_equal(df.kurtosis(), df.kurt())
 
@@ -164,20 +177,22 @@ def test_WeightedDataFrame_skew():
     df = test_WeightedDataFrame_constructor()
     skew = df.skew()
     assert isinstance(skew, Series)
+    assert not isinstance(skew, WeightedSeries)
     assert_allclose(skew, 0., atol=2e-2)
 
     skew = df.skew(axis=1)
-    assert isinstance(skew, Series)
+    assert isinstance(skew, WeightedSeries)
 
 
 def test_WeightedDataFrame_mad():
     df = test_WeightedDataFrame_constructor()
     mad = df.mad()
     assert isinstance(mad, Series)
+    assert not isinstance(mad, WeightedSeries)
     assert_allclose(mad, 0.25, atol=1e-2)
 
     mad = df.mad(axis=1)
-    assert isinstance(mad, Series)
+    assert isinstance(mad, WeightedSeries)
 
 
 def test_WeightedDataFrame_quantile():
@@ -185,6 +200,7 @@ def test_WeightedDataFrame_quantile():
 
     quantile = df.quantile()
     assert isinstance(quantile, Series)
+    assert not isinstance(quantile, WeightedSeries)
     assert_allclose(quantile, 0.5, atol=1e-2)
 
     quantile = df.quantile(axis=1)
@@ -195,6 +211,7 @@ def test_WeightedDataFrame_quantile():
     for q in qs:
         quantile = df.quantile(q)
         assert isinstance(quantile, Series)
+        assert not isinstance(quantile, WeightedSeries)
         assert_allclose(quantile, q, atol=1e-2)
 
         quantile = df.quantile(q, axis=1)
@@ -304,6 +321,10 @@ def test_WeightedDataFrame_nan():
     assert_allclose(df.mean(), 0.5, atol=1e-2)
     assert_allclose(df.std(), (1./12)**0.5, atol=1e-2)
     assert_allclose(df.cov(), (1./12)*np.identity(3), atol=1e-2)
+
+    assert isinstance(df.mean(), Series)
+    assert not isinstance(df.mean(), WeightedSeries)
+    assert isinstance(df.mean(axis=1), WeightedSeries)
 
 
 def test_WeightedSeries_mean():

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -1,3 +1,5 @@
+%load_ext autoreload
+%autoreload 2
 from anesthetic.weighted_pandas import WeightedDataFrame, WeightedSeries
 from pandas import Series, DataFrame, MultiIndex
 import pytest
@@ -74,6 +76,7 @@ def test_WeightedDataFrame_slice():
     assert isinstance(df['A'], WeightedSeries)
     assert isinstance(df.iloc[0], Series)
     assert not isinstance(df.iloc[0], WeightedSeries)
+    assert 'weights' not in df.iloc[0].index.names
     assert isinstance(df[:10], WeightedDataFrame)
     assert df[:10].shape == (10, 3)
     assert df[:10].weights.shape == (10,)
@@ -85,6 +88,7 @@ def test_WeightedDataFrame_mean():
     mean = df.mean()
     assert isinstance(mean, Series)
     assert not isinstance(mean, WeightedSeries)
+    assert 'weights' not in mean.index.names
     assert_allclose(mean, 0.5, atol=1e-2)
 
     mean = df.mean(axis=1)
@@ -97,6 +101,7 @@ def test_WeightedDataFrame_std():
     std = df.std()
     assert isinstance(std, Series)
     assert not isinstance(std, WeightedSeries)
+    assert 'weights' not in std.index.names
     assert_allclose(std, (1./12)**0.5, atol=1e-2)
 
     std = df.std(axis=1)
@@ -109,6 +114,7 @@ def test_WeightedDataFrame_cov():
     cov = df.cov()
     assert isinstance(cov, DataFrame)
     assert not isinstance(cov, WeightedDataFrame)
+    assert 'weights' not in cov.index.names
     assert_allclose(cov, (1./12)*np.identity(3), atol=1e-2)
 
 
@@ -117,6 +123,7 @@ def test_WeightedDataFrame_corr():
     corr = df.corr()
     assert isinstance(corr, DataFrame)
     assert not isinstance(corr, WeightedDataFrame)
+    assert 'weights' not in corr.index.names
     assert_allclose(corr, np.identity(3), atol=1e-2)
 
 
@@ -126,11 +133,13 @@ def test_WeightedDataFrame_corrwith():
     correl = df.corrwith(df.A)
     assert isinstance(correl, Series)
     assert not isinstance(correl, WeightedSeries)
+    assert 'weights' not in correl.index.names
     assert_allclose(correl, df.corr()['A'])
 
     correl = df.corrwith(df[['A', 'B']])
     assert isinstance(correl, Series)
     assert not isinstance(correl, WeightedSeries)
+    assert 'weights' not in correl.index.names
     assert_allclose(correl['A'], 1, atol=1e-2)
     assert_allclose(correl['B'], 1, atol=1e-2)
     assert np.isnan(correl['C'])
@@ -141,6 +150,7 @@ def test_WeightedDataFrame_median():
     median = df.median()
     assert isinstance(median, Series)
     assert not isinstance(median, WeightedSeries)
+    assert 'weights' not in median.index.names
     assert_allclose(median, 0.5, atol=1e-2)
 
     median = df.median(axis=1)
@@ -154,6 +164,7 @@ def test_WeightedDataFrame_sem():
     sem = df.sem()
     assert isinstance(sem, Series)
     assert not isinstance(sem, WeightedSeries)
+    assert 'weights' not in sem.index.names
     assert_allclose(sem, (1./12)**0.5/np.sqrt(df.neff()), atol=1e-2)
 
     sem = df.sem(axis=1)
@@ -165,6 +176,7 @@ def test_WeightedDataFrame_kurtosis():
     kurtosis = df.kurtosis()
     assert isinstance(kurtosis, Series)
     assert not isinstance(kurtosis, WeightedSeries)
+    assert 'weights' not in kurtosis.index.names
     assert_allclose(kurtosis, 9./5, atol=1e-2)
     assert_array_equal(df.kurtosis(), df.kurt())
 
@@ -178,6 +190,7 @@ def test_WeightedDataFrame_skew():
     skew = df.skew()
     assert isinstance(skew, Series)
     assert not isinstance(skew, WeightedSeries)
+    assert 'weights' not in skew.index.names
     assert_allclose(skew, 0., atol=2e-2)
 
     skew = df.skew(axis=1)
@@ -189,6 +202,7 @@ def test_WeightedDataFrame_mad():
     mad = df.mad()
     assert isinstance(mad, Series)
     assert not isinstance(mad, WeightedSeries)
+    assert 'weights' not in mad.index.names
     assert_allclose(mad, 0.25, atol=1e-2)
 
     mad = df.mad(axis=1)
@@ -198,12 +212,36 @@ def test_WeightedDataFrame_mad():
 def test_WeightedDataFrame_quantile():
     df = test_WeightedDataFrame_constructor()
 
+
+    df.T
+
+    DataFrame(df.T).droplevel('weights',axis=1)
+    df
+    df.mean()
+    df.T.mean(axis=1)
+    df.sum()
+    a = df.T.sum()
+    a = df.sum()
+    df.T.sum(axis=1)
+    df.mean()
+    df.mean(axis=1)
+    df.T.mean()
+    df.T.mean(axis=1)
+    df.sum()
+    df._get_axis_number(0)
+    df.T._get_axis_number(1)
+    df.mean(axis=1)
+    df.T
+    df
+
     quantile = df.quantile()
     assert isinstance(quantile, Series)
     assert not isinstance(quantile, WeightedSeries)
+    assert 'weights' not in quantile.index.names
     assert_allclose(quantile, 0.5, atol=1e-2)
 
     quantile = df.quantile(axis=1)
+    quantile
     assert isinstance(quantile, WeightedSeries)
     assert_allclose(quantile.mean(), 0.5, atol=1e-2)
 
@@ -212,6 +250,7 @@ def test_WeightedDataFrame_quantile():
         quantile = df.quantile(q)
         assert isinstance(quantile, Series)
         assert not isinstance(quantile, WeightedSeries)
+        assert 'weights' not in quantile.index.names
         assert_allclose(quantile, q, atol=1e-2)
 
         quantile = df.quantile(q, axis=1)
@@ -324,6 +363,7 @@ def test_WeightedDataFrame_nan():
 
     assert isinstance(df.mean(), Series)
     assert not isinstance(df.mean(), WeightedSeries)
+    assert 'weights' not in df.mean().index.names
     assert isinstance(df.mean(axis=1), WeightedSeries)
 
 

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -188,9 +188,14 @@ def test_WeightedDataFrame_corrwith(frame):
     with pytest.raises(ValueError):
         unweighted.corrwith(frame[['A', 'B']])
 
-    correl_1 = frame[:5].corrwith(frame.iloc[0], axis=1)
-    correl_2 = frame[:5].T.corrwith(unweighted.T[0])
-    assert_allclose(correl_1, correl_2)
+    correl_1 = unweighted[:5].corrwith(unweighted[:4], axis=1)
+    correl_2 = frame[:5].corrwith(frame[:4], axis=1)
+    assert_array_equal(correl_1.values, correl_2.values)
+    assert correl_2.isweighted()
+
+    correl_3 = frame[:5].T.corrwith(frame[:4].T)
+    assert_array_equal(correl_2, correl_3)
+    assert_array_equal(correl_2.index, correl_3.index)
 
     frame.set_weights(None, inplace=True)
     assert_array_equal(frame.corrwith(frame), unweighted.corrwith(unweighted))

--- a/tests/wedding_cake.py
+++ b/tests/wedding_cake.py
@@ -77,7 +77,9 @@ class WeddingCake():
             samps = NestedSamples(points, logL=death_likes,
                                   logL_birth=birth_likes)
 
-            if samps.iloc[-nlive:].weights.sum()/samps.weights.sum() < 0.001:
+            live_weights = samps.iloc[-nlive:].get_weights().sum()
+            dead_weights = samps.get_weights().sum()
+            if live_weights < 0.001 * dead_weights:
                 break
 
         death_likes = np.concatenate([death_likes, live_likes])


### PR DESCRIPTION
# Description

This provides a few simultaneous upgrades to WeightedPandas, which were sparked by some of the indexing considerations in #194. These are

1. `WeightedDataFrame` and `WeightedSeries` always have a weights column in their `MultiIndex`. If no weights are passed, the column is filled with 1's (integers).
2. More complicated `MultiIndex`es are now possible (previously it was assumed there would be only one other 'iteration' column).
3. The 'other' column is now no longer called `'#'`, but will retain the name of the previous index/indices (if present at all).

The above changes make the code more robust and extensible, particularly when it comes to extracting/dropping weights (we can assume that `df.index.get_level_values('weights')` and `df.index.droplevel('weights')` will always work), but also making sure that code like `(a*b).mean()` is only possible between weighted objects if they have the same weights.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
