### PR TITLE
Quick fix `c/=c[-1]` to `c=c/c[-1]`

### DIFF
--- a/anesthetic/utils.py
+++ b/anesthetic/utils.py
@@ -76,7 +76,7 @@ def quantile(a, q, w=None, interpolation='linear'):
     w = np.array(list(w))  # Necessary to convert pandas arrays
     i = np.argsort(a)
     c = np.cumsum(w[i[1:]]+w[i[:-1]])
-    c /= c[-1]
+    c = c / c[-1]
     c = np.concatenate(([0.], c))
     icdf = interp1d(c, a[i], kind=interpolation)
     quant = icdf(q)


### PR DESCRIPTION
Single line fix using `c=c/c[-1]` rather than `c/=c[-1]` which keeps creeping up in PRs and I want it fixed _now_...
Would be nice to push this through.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
