### PR TITLE
remove `limits` attribute and `xmin` and `xmax` kwargs

### DIFF
--- a/anesthetic/boundary.py
+++ b/anesthetic/boundary.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.special import erf
 
 
-def cut_and_normalise_gaussian(x, p, sigma, xmin=None, xmax=None):
+def cut_and_normalise_gaussian(x, p, bw, xmin=None, xmax=None):
     """Cut and normalise boundary correction for a Gaussian kernel.
 
     Parameters
@@ -15,7 +15,7 @@ def cut_and_normalise_gaussian(x, p, sigma, xmin=None, xmax=None):
     p: np.array
         probability densities for normalisation correction
 
-    sigma: float
+    bw: float
         bandwidth of KDE
 
     xmin, xmax: float
@@ -31,9 +31,9 @@ def cut_and_normalise_gaussian(x, p, sigma, xmin=None, xmax=None):
     correction = np.ones_like(x)
 
     if xmin is not None:
-        correction *= 0.5*(1 + erf((x - xmin)/sigma/np.sqrt(2)))
+        correction *= 0.5 * (1 + erf((x-xmin)/bw/np.sqrt(2)))
         correction[x < xmin] = np.inf
     if xmax is not None:
-        correction *= 0.5*(1 + erf((xmax - x)/sigma/np.sqrt(2)))
+        correction *= 0.5 * (1 + erf((xmax-x)/bw/np.sqrt(2)))
         correction[x > xmax] = np.inf
     return p/correction

--- a/anesthetic/convert.py
+++ b/anesthetic/convert.py
@@ -19,7 +19,8 @@ def to_getdist(nested_samples):
     weights = nested_samples.weights
     loglikes = -nested_samples.logL.to_numpy()
     names = nested_samples.columns
-    ranges = {name: nested_samples._limits(name) for name in names}
+    ranges = {name: (nested_samples[name].min(), nested_samples[name].max())
+              for name in names}
     return getdist.mcsamples.MCSamples(samples=samples,
                                        weights=weights,
                                        loglikes=loglikes,

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -390,6 +390,13 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
         values at which to draw iso-probability lines.
         optional, default [0.95, 0.68]
 
+    q: int or float or tuple
+        Quantile to determine the data range to be plotted.
+        - 0: full data range, i.e. q=0 --> quantile range (0, 1)
+        - int: `q`-sigma data range, e.g. q=1 --> quantile range (0.16, 0.84)
+        - float: percentile, e.g. q=0.68 --> quantile range  (0.16, 0.84)
+        - tuple: quantile range, e.g. (0.16, 0.84)
+
     facecolor: bool or string
         If set to True then the 1d plot will be shaded with the value of the
         ``color`` kwarg. Set to a string such as 'blue', 'k', 'r', 'C1' ect.
@@ -435,7 +442,7 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
     except NameError:
         raise ImportError("You need to install fastkde to use fastkde")
     p /= p.max()
-    i = ((x > quantile(x, q[0], p)) & (x < quantile(x, q[1], p)))
+    i = ((x > quantile(x, q[0], p)) & (x < quantile(x, q[-1], p)))
 
     area = np.trapz(x=x[i], y=p[i]) if density else 1
     ans = ax.plot(x[i], p[i]/area, color=color, *args, **kwargs)
@@ -479,6 +486,13 @@ def kde_plot_1d(ax, data, *args, **kwargs):
     levels: list
         values at which to draw iso-probability lines.
         optional, default [0.95, 0.68]
+
+    q: int or float or tuple
+        Quantile to determine the data range to be plotted.
+        - 0: full data range, i.e. q=0 --> quantile range (0, 1)
+        - int: `q`-sigma data range, e.g. q=1 --> quantile range (0.16, 0.84)
+        - float: percentile, e.g. q=0.68 --> quantile range  (0.16, 0.84)
+        - tuple: quantile range, e.g. (0.16, 0.84)
 
     facecolor: bool or string
         If set to True then the 1d plot will be shaded with the value of the
@@ -529,7 +543,7 @@ def kde_plot_1d(ax, data, *args, **kwargs):
     kde = gaussian_kde(x, weights=w, bw_method=bw_method)
     p = kde(x)
     p /= p.max()
-    i = ((x > quantile(x, q[0], w)) & (x < quantile(x, q[1], w)))
+    i = ((x > quantile(x, q[0], w)) & (x < quantile(x, q[-1], w)))
     bw = np.sqrt(kde.covariance[0, 0])
     pp = cut_and_normalise_gaussian(x[i], p[i], bw=bw,
                                     xmin=data.min(), xmax=data.max())
@@ -570,6 +584,13 @@ def hist_plot_1d(ax, data, *args, **kwargs):
     weights: np.array, optional
         Sample weights.
 
+    q: int or float or tuple
+        Quantile to determine the data range to be plotted.
+        - 0: full data range, i.e. q=0 --> quantile range (0, 1)
+        - int: `q`-sigma data range, e.g. q=1 --> quantile range (0.16, 0.84)
+        - float: percentile, e.g. q=0.68 --> quantile range  (0.16, 0.84)
+        - tuple: quantile range, e.g. (0.16, 0.84)
+
     Returns
     -------
     patches : list or list of lists
@@ -596,7 +617,7 @@ def hist_plot_1d(ax, data, *args, **kwargs):
     q = kwargs.pop('q', 5)
     q = quantile_plot_interval(q=q)
     xmin = quantile(data, q[0], weights)
-    xmax = quantile(data, q[1], weights)
+    xmax = quantile(data, q[-1], weights)
 
     if bins in ['knuth', 'freedman', 'blocks']:
         try:
@@ -850,6 +871,13 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
         mass. If None defaults to usual matplotlib.axes.Axes.hist2d colouring.
         optional, default None
 
+    q: int or float or tuple
+        Quantile to determine the data range to be plotted.
+        - 0: full data range, i.e. q=0 --> quantile range (0, 1)
+        - int: `q`-sigma data range, e.g. q=1 --> quantile range (0.16, 0.84)
+        - float: percentile, e.g. q=0.68 --> quantile range  (0.16, 0.84)
+        - tuple: quantile range, e.g. (0.16, 0.84)
+
     Returns
     -------
     c: matplotlib.collections.QuadMesh
@@ -868,9 +896,9 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
     q = kwargs.pop('q', 5)
     q = quantile_plot_interval(q=q)
     xmin = quantile(data_x, q[0], weights)
-    xmax = quantile(data_x, q[1], weights)
+    xmax = quantile(data_x, q[-1], weights)
     ymin = quantile(data_y, q[0], weights)
-    ymax = quantile(data_y, q[1], weights)
+    ymax = quantile(data_y, q[-1], weights)
     rge = kwargs.pop('range', ((xmin, xmax), (ymin, ymax)))
 
     if levels is None:
@@ -986,7 +1014,7 @@ def quantile_plot_interval(q):
         if q > 0.5:
             q = 1 - q
         q = (q, 1-q)
-    return q
+    return tuple(np.sort(q))
 
 
 def normalize_kwargs(kwargs, alias_mapping=None, drop=None):

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -408,9 +408,6 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
         dict(linewidth=['lw'], linestyle=['ls'], color=['c'],
              facecolor=['fc'], edgecolor=['ec']))
 
-    if len(data) == 0:
-        return np.zeros(0), np.zeros(0)
-
     if data.max()-data.min() <= 0:
         return
 
@@ -500,9 +497,6 @@ def kde_plot_1d(ax, data, *args, **kwargs):
         kwargs,
         dict(linewidth=['lw'], linestyle=['ls'], color=['c'],
              facecolor=['fc'], edgecolor=['ec']))
-
-    if len(data) == 0:
-        return np.zeros(0), np.zeros(0)
 
     if data.max()-data.min() <= 0:
         return
@@ -666,9 +660,6 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
                                            facecolor=['fc'],
                                            edgecolor=['ec']))
 
-    if len(data_x) == 0 or len(data_y) == 0:
-        return np.zeros(0), np.zeros(0), np.zeros((0, 0))
-
     xmin = kwargs.pop('xmin', None)
     xmax = kwargs.pop('xmax', None)
     ymin = kwargs.pop('ymin', None)
@@ -768,9 +759,6 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
                                            color=['c'],
                                            facecolor=['fc'],
                                            edgecolor=['ec']))
-
-    if len(data_x) == 0 or len(data_y) == 0:
-        return np.zeros(0), np.zeros(0), np.zeros((0, 0))
 
     weights = kwargs.pop('weights', None)
     if weights is not None:
@@ -875,6 +863,7 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
     levels = kwargs.pop('levels', None)
 
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
+    cmap = kwargs.pop('cmap', basic_cmap(color))
 
     q = kwargs.pop('q', 5)
     q = quantile_plot_interval(q=q)
@@ -883,11 +872,6 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ymin = quantile(data_y, q[0], weights)
     ymax = quantile(data_y, q[1], weights)
     rge = kwargs.pop('range', ((xmin, xmax), (ymin, ymax)))
-
-    if len(data_x) == 0 or len(data_y) == 0:
-        return np.zeros(0), np.zeros(0), np.zeros((0, 0))
-
-    cmap = kwargs.pop('cmap', basic_cmap(color))
 
     if levels is None:
         pdf, x, y, image = ax.hist2d(data_x, data_y, weights=weights,

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas
 import matplotlib.pyplot as plt
 from scipy.stats import gaussian_kde
+from scipy.special import erf
 from matplotlib.gridspec import GridSpec as GS, GridSpecFromSubplotSpec as SGS
 try:
     from astropy.visualization import hist
@@ -417,16 +418,15 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
     if data.max()-data.min() <= 0:
         return
 
-    levels = kwargs.pop('levels', [0.95, 0.68])
-
     xmin = kwargs.pop('xmin', None)
     xmax = kwargs.pop('xmax', None)
+    levels = kwargs.pop('levels', [0.95, 0.68])
     density = kwargs.pop('density', False)
+
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
                                  if cmap is None else cmap(0.68)))
     facecolor = kwargs.pop('facecolor', False)
-
     if 'edgecolor' in kwargs:
         edgecolor = kwargs.pop('edgecolor')
         if edgecolor:
@@ -434,7 +434,7 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
     else:
         edgecolor = color
 
-    q = kwargs.pop('q', '5sigma')
+    q = kwargs.pop('q', 5)
     q = quantile_plot_interval(q=q)
 
     try:
@@ -446,7 +446,6 @@ def fastkde_plot_1d(ax, data, *args, **kwargs):
 
     area = np.trapz(x=x[i], y=p[i]) if density else 1
     ans = ax.plot(x[i], p[i]/area, color=color, *args, **kwargs)
-    ax.set_xlim(xmin, xmax, auto=True)
 
     if facecolor and facecolor not in [None, 'None', 'none']:
         if facecolor is True:
@@ -484,10 +483,6 @@ def kde_plot_1d(ax, data, *args, **kwargs):
     ncompress: int, optional
         Degree of compression. Default 1000
 
-    xmin, xmax: float
-        lower/upper prior bound.
-        optional, default None
-
     levels: list
         values at which to draw iso-probability lines.
         optional, default [0.95, 0.68]
@@ -505,30 +500,31 @@ def kde_plot_1d(ax, data, *args, **kwargs):
         matplotlib matplotlib.axes.Axes.plot command)
 
     """
+    kwargs = normalize_kwargs(
+        kwargs,
+        dict(linewidth=['lw'], linestyle=['ls'], color=['c'],
+             facecolor=['fc'], edgecolor=['ec']))
+
     if len(data) == 0:
         return np.zeros(0), np.zeros(0)
 
     if data.max()-data.min() <= 0:
         return
 
-    kwargs = normalize_kwargs(
-        kwargs,
-        dict(linewidth=['lw'], linestyle=['ls'], color=['c'],
-             facecolor=['fc'], edgecolor=['ec']))
+    weights = kwargs.pop('weights', None)
+    if weights is not None:
+        data = data[weights != 0]
+        weights = weights[weights != 0]
 
+    ncompress = kwargs.pop('ncompress', 1000)
     bw_method = kwargs.pop('bw_method', None)
     levels = kwargs.pop('levels', [0.95, 0.68])
-
-    xmin = kwargs.pop('xmin', None)
-    xmax = kwargs.pop('xmax', None)
-    weights = kwargs.pop('weights', None)
-    ncompress = kwargs.pop('ncompress', 1000)
     density = kwargs.pop('density', False)
+
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
                                  if cmap is None else cmap(0.68)))
     facecolor = kwargs.pop('facecolor', False)
-
     if 'edgecolor' in kwargs:
         edgecolor = kwargs.pop('edgecolor')
         if edgecolor:
@@ -536,28 +532,20 @@ def kde_plot_1d(ax, data, *args, **kwargs):
     else:
         edgecolor = color
 
-    q = kwargs.pop('q', '5sigma')
+    q = kwargs.pop('q', 5)
     q = quantile_plot_interval(q=q)
-
-    if weights is not None:
-        data = data[weights != 0]
-        weights = weights[weights != 0]
 
     x, w = sample_compression_1d(data, weights, ncompress)
     kde = gaussian_kde(x, weights=w, bw_method=bw_method)
     p = kde(x)
     p /= p.max()
     i = ((x > quantile(x, q[0], w)) & (x < quantile(x, q[1], w)))
-    if xmin is not None:
-        i = i & (x > xmin)
-    if xmax is not None:
-        i = i & (x < xmax)
-    sigma = np.sqrt(kde.covariance[0, 0])
-    pp = cut_and_normalise_gaussian(x[i], p[i], sigma, xmin, xmax)
+    bw = np.sqrt(kde.covariance[0, 0])
+    pp = cut_and_normalise_gaussian(x[i], p[i], bw=bw,
+                                    xmin=data.min(), xmax=data.max())
     pp /= pp.max()
     area = np.trapz(x=x[i], y=pp) if density else 1
     ans = ax.plot(x[i], pp/area, color=color, *args, **kwargs)
-    ax.set_xlim(*check_bounds(x[i], xmin, xmax), auto=True)
 
     if facecolor and facecolor not in [None, 'None', 'none']:
         if facecolor is True:
@@ -592,11 +580,6 @@ def hist_plot_1d(ax, data, *args, **kwargs):
     weights: np.array, optional
         Sample weights.
 
-    xmin, xmax: float
-        lower/upper prior bound.
-        optional, default data.min() and data.max()
-        cannot be None (reverts to default in that case)
-
     Returns
     -------
     patches : list or list of lists
@@ -611,30 +594,31 @@ def hist_plot_1d(ax, data, *args, **kwargs):
     if data.max()-data.min() <= 0:
         return
 
-    xmin = kwargs.pop('xmin', None)
-    xmax = kwargs.pop('xmax', None)
-    plotter = kwargs.pop('plotter', '')
     weights = kwargs.pop('weights', None)
-    if xmin is None or not np.isfinite(xmin):
-        xmin = quantile(data, 0.01, weights)
-    if xmax is None or not np.isfinite(xmax):
-        xmax = quantile(data, 0.99, weights)
+    bins = kwargs.pop('bins', 10)
     histtype = kwargs.pop('histtype', 'bar')
     density = kwargs.get('density', False)
+
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
                                  if cmap is None else cmap(0.68)))
 
-    if plotter == 'astropyhist':
+    q = kwargs.pop('q', 5)
+    q = quantile_plot_interval(q=q)
+    xmin = quantile(data, q[0], weights)
+    xmax = quantile(data, q[1], weights)
+
+    if bins in ['knuth', 'freedman', 'blocks']:
         try:
-            h, edges, bars = hist(data, ax=ax, color=color, range=(xmin, xmax),
-                                  histtype=histtype, *args, **kwargs)
+            h, edges, bars = hist(data, ax=ax, bins=bins,
+                                  range=(xmin, xmax), histtype=histtype,
+                                  color=color, *args, **kwargs)
         except NameError:
             raise ImportError("You need to install astropy to use astropyhist")
     else:
-        h, edges, bars = ax.hist(data, color=color, range=(xmin, xmax),
-                                 histtype=histtype, weights=weights,
-                                 *args, **kwargs)
+        h, edges, bars = ax.hist(data, weights=weights, bins=bins,
+                                 range=(xmin, xmax), histtype=histtype,
+                                 color=color, *args, **kwargs)
 
     if histtype == 'bar' and not density:
         for b in bars:
@@ -643,7 +627,6 @@ def hist_plot_1d(ax, data, *args, **kwargs):
         trans = Affine2D().scale(sx=1, sy=1./h.max()) + ax.transData
         bars[0].set_transform(trans)
 
-    ax.set_xlim(*check_bounds(edges, xmin, xmax), auto=True)
     if not density:
         ax.set_ylim(0, 1.1)
     return bars
@@ -686,6 +669,10 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
                                            color=['c'],
                                            facecolor=['fc'],
                                            edgecolor=['ec']))
+
+    if len(data_x) == 0 or len(data_y) == 0:
+        return np.zeros(0), np.zeros(0), np.zeros((0, 0))
+
     xmin = kwargs.pop('xmin', None)
     xmax = kwargs.pop('xmax', None)
     ymin = kwargs.pop('ymin', None)
@@ -693,16 +680,15 @@ def fastkde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
     label = kwargs.pop('label', None)
     zorder = kwargs.pop('zorder', 1)
     levels = kwargs.pop('levels', [0.95, 0.68])
+
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
     facecolor = kwargs.pop('facecolor', True)
     edgecolor = kwargs.pop('edgecolor', None)
     cmap = kwargs.pop('cmap', None)
     facecolor, edgecolor, cmap = set_colors(c=color, fc=facecolor,
                                             ec=edgecolor, cmap=cmap)
-    kwargs.pop('q', None)
 
-    if len(data_x) == 0 or len(data_y) == 0:
-        return np.zeros(0), np.zeros(0), np.zeros((0, 0))
+    kwargs.pop('q', None)
 
     try:
         x, y, pdf, xmin, xmax, ymin, ymax = fastkde_2d(data_x, data_y,
@@ -775,10 +761,6 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
         Degree of compression.
         optional, Default 1000
 
-    xmin, xmax, ymin, ymax: float
-        lower/upper prior bounds in x/y coordinates.
-        optional, default None
-
     Returns
     -------
     c: matplotlib.contour.QuadContourSet
@@ -790,31 +772,30 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
                                            color=['c'],
                                            facecolor=['fc'],
                                            edgecolor=['ec']))
-    bw_method = kwargs.pop('bw_method', None)
-    xmin = kwargs.pop('xmin', None)
-    xmax = kwargs.pop('xmax', None)
-    ymin = kwargs.pop('ymin', None)
-    ymax = kwargs.pop('ymax', None)
+
+    if len(data_x) == 0 or len(data_y) == 0:
+        return np.zeros(0), np.zeros(0), np.zeros((0, 0))
+
     weights = kwargs.pop('weights', None)
+    if weights is not None:
+        data_x = data_x[weights != 0]
+        data_y = data_y[weights != 0]
+        weights = weights[weights != 0]
+
     ncompress = kwargs.pop('ncompress', 1000)
+    bw_method = kwargs.pop('bw_method', None)
     label = kwargs.pop('label', None)
     zorder = kwargs.pop('zorder', 1)
     levels = kwargs.pop('levels', [0.95, 0.68])
+
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
     facecolor = kwargs.pop('facecolor', True)
     edgecolor = kwargs.pop('edgecolor', None)
     cmap = kwargs.pop('cmap', None)
     facecolor, edgecolor, cmap = set_colors(c=color, fc=facecolor,
                                             ec=edgecolor, cmap=cmap)
+
     kwargs.pop('q', None)
-
-    if len(data_x) == 0 or len(data_y) == 0:
-        return np.zeros(0), np.zeros(0), np.zeros((0, 0))
-
-    if weights is not None:
-        data_x = data_x[weights != 0]
-        data_y = data_y[weights != 0]
-        weights = weights[weights != 0]
 
     cov = np.cov(data_x, data_y, aweights=weights)
     tri, w = triangular_sample_compression_2d(data_x, data_y, cov,
@@ -829,10 +810,12 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
 
     p = kde([tri.x, tri.y])
 
-    sigmax = np.sqrt(kde.covariance[0, 0])
-    p = cut_and_normalise_gaussian(tri.x, p, sigmax, xmin, xmax)
-    sigmay = np.sqrt(kde.covariance[1, 1])
-    p = cut_and_normalise_gaussian(tri.y, p, sigmay, ymin, ymax)
+    bw_x = np.sqrt(kde.covariance[0, 0])
+    p = cut_and_normalise_gaussian(tri.x, p, bw=bw_x,
+                                   xmin=data_x.min(), xmax=data_x.max())
+    bw_y = np.sqrt(kde.covariance[1, 1])
+    p = cut_and_normalise_gaussian(tri.y, p, bw=bw_y,
+                                   xmin=data_y.min(), xmax=data_y.max())
 
     levels = iso_probability_contours_from_samples(p, contours=levels,
                                                    weights=w)
@@ -861,8 +844,6 @@ def kde_contour_plot_2d(ax, data_x, data_y, *args, **kwargs):
                          vmin=vmin, vmax=vmax, linewidths=linewidths,
                          colors=edgecolor, cmap=cmap, *args, **kwargs)
 
-    ax.set_xlim(*check_bounds(tri.x, xmin, xmax), auto=True)
-    ax.set_ylim(*check_bounds(tri.y, ymin, ymax), auto=True)
     return contf, cont
 
 
@@ -880,10 +861,6 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
         x and y coordinates of uniformly weighted samples to generate kernel
         density estimator.
 
-    xmin, xmax, ymin, ymax: float
-        lower/upper prior bounds in x/y coordinates
-        optional, default None
-
     levels: list
         Shade iso-probability contours containing these levels of probability
         mass. If None defaults to usual matplotlib.axes.Axes.hist2d colouring.
@@ -895,25 +872,20 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
         A set of colors
 
     """
-    xmin = kwargs.pop('xmin', None)
-    xmax = kwargs.pop('xmax', None)
-    ymin = kwargs.pop('ymin', None)
-    ymax = kwargs.pop('ymax', None)
+    weights = kwargs.pop('weights', None)
+
     vmin = kwargs.pop('vmin', 0)
     label = kwargs.pop('label', None)
     levels = kwargs.pop('levels', None)
+
     color = kwargs.pop('color', next(ax._get_lines.prop_cycler)['color'])
-    weights = kwargs.pop('weights', None)
 
-    if xmin is None or not np.isfinite(xmin):
-        xmin = quantile(data_x, 0.01, weights)
-    if xmax is None or not np.isfinite(xmax):
-        xmax = quantile(data_x, 0.99, weights)
-    if ymin is None or not np.isfinite(ymin):
-        ymin = quantile(data_y, 0.01, weights)
-    if ymax is None or not np.isfinite(ymax):
-        ymax = quantile(data_y, 0.99, weights)
-
+    q = kwargs.pop('q', 5)
+    q = quantile_plot_interval(q=q)
+    xmin = quantile(data_x, q[0], weights)
+    xmax = quantile(data_x, q[1], weights)
+    ymin = quantile(data_y, q[0], weights)
+    ymax = quantile(data_y, q[1], weights)
     rge = kwargs.pop('range', ((xmin, xmax), (ymin, ymax)))
 
     if len(data_x) == 0 or len(data_y) == 0:
@@ -946,8 +918,6 @@ def hist_plot_2d(ax, data_x, data_y, *args, **kwargs):
     ax.add_patch(plt.Rectangle((0, 0), 0, 0, fc=cmap(0.999), ec=cmap(0.32),
                                lw=2, label=label))
 
-    ax.set_xlim(*check_bounds(x, xmin, xmax), auto=True)
-    ax.set_ylim(*check_bounds(y, ymin, ymax), auto=True)
     return image
 
 
@@ -965,15 +935,11 @@ def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
     data_x, data_y: np.array
         x and y coordinates of uniformly weighted samples to plot.
 
-    xmin, xmax, ymin, ymax: float
-        lower/upper prior bounds in x/y coordinates
-        optional, default None
-
     Returns
     -------
     lines: matplotlib.lines.Line2D
         A list of line objects representing the plotted data (same as
-        matplotlib matplotlib.axes.Axes.plot command)
+        matplotlib.axes.Axes.plot command)
 
     """
     kwargs = normalize_kwargs(
@@ -981,20 +947,16 @@ def scatter_plot_2d(ax, data_x, data_y, *args, **kwargs):
         dict(color=['c'], mfc=['facecolor', 'fc'], mec=['edgecolor', 'ec']),
         drop=['ls', 'lw'])
     kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
-    xmin = kwargs.pop('xmin', None)
-    xmax = kwargs.pop('xmax', None)
-    ymin = kwargs.pop('ymin', None)
-    ymax = kwargs.pop('ymax', None)
-    kwargs.pop('q', None)
+
     markersize = kwargs.pop('markersize', 1)
     cmap = kwargs.pop('cmap', None)
     color = kwargs.pop('color', (next(ax._get_lines.prop_cycler)['color']
                                  if cmap is None else cmap(0.68)))
 
+    kwargs.pop('q', None)
+
     points = ax.plot(data_x, data_y, 'o', color=color, markersize=markersize,
                      *args, **kwargs)
-    ax.set_xlim(*check_bounds(data_x, xmin, xmax), auto=True)
-    ax.set_ylim(*check_bounds(data_y, ymin, ymax), auto=True)
     return points
 
 
@@ -1038,6 +1000,8 @@ def quantile_plot_interval(q):
                   '4sigma': 0.999936657516334,
                   '5sigma': 0.999999426696856}
         q = (1 - sigmas[q]) / 2
+    elif isinstance(q, int) and q >= 1:
+        q = (1 - erf(q / np.sqrt(2))) / 2
     if isinstance(q, float) or isinstance(q, int):
         if q > 0.5:
             q = 1 - q

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -28,7 +28,7 @@ import matplotlib.lines as mlines
 from matplotlib.ticker import MaxNLocator
 from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.transforms import Affine2D
-from anesthetic.utils import check_bounds, nest_level
+from anesthetic.utils import nest_level
 from anesthetic.utils import (sample_compression_1d, quantile,
                               triangular_sample_compression_2d,
                               iso_probability_contours,

--- a/anesthetic/plot.py
+++ b/anesthetic/plot.py
@@ -363,10 +363,6 @@ def make_2d_axes(params, **kwargs):
                 for a in ax_:
                     a.tick_params('x', bottom=False, top=False,
                                   labelbottom=False, labeltop=False)
-            else:
-                raise ValueError(
-                    "ticks=%s was requested, but ticks can only be one of "
-                    "['outer', 'inner', None]." % ticks)
 
     return fig, axes
 

--- a/anesthetic/read/chainreader.py
+++ b/anesthetic/read/chainreader.py
@@ -11,10 +11,6 @@ class ChainReader(object):
         """Parameter names mapping."""
         return None, {}
 
-    def limits(self):
-        """Parameter limits mapping."""
-        return {}
-
     def samples(self):
         """Read samples from file."""
         raise NotImplementedError

--- a/anesthetic/read/cobayamcmcreader.py
+++ b/anesthetic/read/cobayamcmcreader.py
@@ -38,16 +38,9 @@ class CobayaMCMCReader(ChainReader):
         for chains_file in self.chains_files:
             data_i = np.loadtxt(chains_file)
             if burn_in:
-                if isinstance(burn_in, float) and 0 < burn_in < 1:
-                    index = int(len(data_i) * burn_in)
-                elif isinstance(burn_in, int) and 1 < burn_in < len(data_i):
-                    index = burn_in
-                else:
-                    raise ValueError(f"You requested `burn_in={burn_in}`, but "
-                                     f"it should be either an integer with "
-                                     f"`1<burn_in<len(data)` or a float with "
-                                     f"`0<burn_in<1`.")
-                data_i = data_i[index:]
+                if 0 < burn_in < 1:
+                    burn_in *= len(data_i)
+                data_i = data_i[np.ceil(burn_in).astype(int):]
             data = np.concatenate((data, data_i)) if data.size else data_i
         weights, logP, samples = np.split(data, [1, 2], axis=1)
         return weights.flatten(), logP.flatten(), samples

--- a/anesthetic/read/cobayamcmcreader.py
+++ b/anesthetic/read/cobayamcmcreader.py
@@ -32,14 +32,6 @@ class CobayaMCMCReader(ChainReader):
         except IOError:
             return super().paramnames()
 
-    def limits(self):
-        """Infer param limits from <root>.yaml in cobaya format."""
-        s = loadMCSamples(file_root=self.root)
-        return {p.name: (s.ranges.getLower(p.name), s.ranges.getUpper(p.name))
-                for p in s.paramNames.names
-                if s.ranges.getLower(p.name) is not None
-                or s.ranges.getUpper(p.name) is not None}
-
     def samples(self, burn_in=False):
         """Read <root>_1.txt in getdist format."""
         data = np.array([])

--- a/anesthetic/read/cobayamcmcreader.py
+++ b/anesthetic/read/cobayamcmcreader.py
@@ -38,14 +38,15 @@ class CobayaMCMCReader(ChainReader):
         for chains_file in self.chains_files:
             data_i = np.loadtxt(chains_file)
             if burn_in:
-                if 0 < burn_in < 1:
+                if isinstance(burn_in, float) and 0 < burn_in < 1:
                     index = int(len(data_i) * burn_in)
-                elif type(burn_in) is int and 1 < burn_in < len(data_i):
+                elif isinstance(burn_in, int) and 1 < burn_in < len(data_i):
                     index = burn_in
                 else:
-                    raise ValueError("`burn_in` is %s, but should be an "
-                                     "integer greater 1 and smaller len(data) "
-                                     "or a float between 0 and 1." % burn_in)
+                    raise ValueError(f"You requested `burn_in={burn_in}`, but "
+                                     f"it should be either an integer with "
+                                     f"`1<burn_in<len(data)` or a float with "
+                                     f"`0<burn_in<1`.")
                 data_i = data_i[index:]
             data = np.concatenate((data, data_i)) if data.size else data_i
         weights, logP, samples = np.split(data, [1, 2], axis=1)

--- a/anesthetic/read/getdistreader.py
+++ b/anesthetic/read/getdistreader.py
@@ -42,14 +42,15 @@ class GetDistReader(ChainReader):
         for chains_file in self.chains_files:
             data_i = np.loadtxt(chains_file)
             if burn_in:
-                if 0 < burn_in < 1:
+                if isinstance(burn_in, float) and 0 < burn_in < 1:
                     index = int(len(data_i) * burn_in)
-                elif type(burn_in) is int and 1 < burn_in < len(data_i):
+                elif isinstance(burn_in, int) and 1 < burn_in < len(data_i):
                     index = burn_in
                 else:
-                    raise ValueError("`burn_in` is %s, but should be an "
-                                     "integer greater 1 and smaller len(data) "
-                                     "or a float between 0 and 1." % burn_in)
+                    raise ValueError(f"You requested `burn_in={burn_in}`, but "
+                                     f"it should be either an integer with "
+                                     f"`1<burn_in<len(data)` or a float with "
+                                     f"`0<burn_in<1`.")
                 data_i = data_i[index:]
             data = np.concatenate((data, data_i)) if data.size else data_i
         weights, minuslogL, samples = np.split(data, [1, 2], axis=1)

--- a/anesthetic/read/getdistreader.py
+++ b/anesthetic/read/getdistreader.py
@@ -36,27 +36,6 @@ class GetDistReader(ChainReader):
         except IOError:
             return super().paramnames()
 
-    def limits(self):
-        """Read <root>.ranges in getdist format."""
-        try:
-            with open(self.ranges_file, 'r') as f:
-                limits = {}
-                for line in f:
-                    line = line.strip().split()
-                    paramname = line[0]
-                    try:
-                        xmin = float(line[1])
-                    except ValueError:
-                        xmin = None
-                    try:
-                        xmax = float(line[2])
-                    except ValueError:
-                        xmax = None
-                    limits[paramname] = (xmin, xmax)
-                return limits
-        except IOError:
-            return super().limits()
-
     def samples(self, burn_in=False):
         """Read <root>_1.txt in getdist format."""
         data = np.array([])
@@ -80,11 +59,6 @@ class GetDistReader(ChainReader):
     def paramnames_file(self):
         """File containing parameter names."""
         return self.root + '.paramnames'
-
-    @property
-    def ranges_file(self):
-        """File containing parameter names."""
-        return self.root + '.ranges'
 
     @property
     def chains_files(self):

--- a/anesthetic/read/getdistreader.py
+++ b/anesthetic/read/getdistreader.py
@@ -42,16 +42,9 @@ class GetDistReader(ChainReader):
         for chains_file in self.chains_files:
             data_i = np.loadtxt(chains_file)
             if burn_in:
-                if isinstance(burn_in, float) and 0 < burn_in < 1:
-                    index = int(len(data_i) * burn_in)
-                elif isinstance(burn_in, int) and 1 < burn_in < len(data_i):
-                    index = burn_in
-                else:
-                    raise ValueError(f"You requested `burn_in={burn_in}`, but "
-                                     f"it should be either an integer with "
-                                     f"`1<burn_in<len(data)` or a float with "
-                                     f"`0<burn_in<1`.")
-                data_i = data_i[index:]
+                if 0 < burn_in < 1:
+                    burn_in *= len(data_i)
+                data_i = data_i[np.ceil(burn_in).astype(int):]
             data = np.concatenate((data, data_i)) if data.size else data_i
         weights, minuslogL, samples = np.split(data, [1, 2], axis=1)
         return weights.flatten(), -minuslogL.flatten(), samples

--- a/anesthetic/read/montepythonreader.py
+++ b/anesthetic/read/montepythonreader.py
@@ -57,7 +57,6 @@ class MontePythonReader(ChainReader):
             * Extracts parameter names from MontePython's log.param file.
             * Removes burn-in and non-markovian points from the data.
             * Extract tex names.
-            * Extracts parameter limits from MontePython's log.param file.
 
         """
         if 'montepython' not in sys.modules:
@@ -67,8 +66,7 @@ class MontePythonReader(ChainReader):
                 "to read the data folder. Alternatively you can pass the root "
                 "to the actual chain _files_ into `MCMCSamples` (omitting "
                 "_1.txt, _2.txt, etc.) in which case the files will be read "
-                "by the `GetDistReader` (with less functionality, though, "
-                "e.g. won't automatically detect limits).")
+                "by the `GetDistReader` (with less functionality, though).")
         # The variable and function names used here correspond to the ones
         # used in MontePython's analyze.py module.
         command_line = Namespace(files=[self.root])
@@ -119,11 +117,6 @@ class MontePythonReader(ChainReader):
         logL = -self.data[:, 1]
         samples = self.data[:, 2:]
         return weights, logL, samples
-
-    def limits(self):
-        """Return param limits as specified in MontePython's log.param file."""
-        limits = dict(zip(self.info.ref_names, self.info.boundaries))
-        return limits
 
 
 class Namespace(object):

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -344,13 +344,13 @@ class MCMCSamples(Samples):
         Anything equal or below this value is set to `-np.inf`.
         default: -1e30
 
-    burn_in: int or float
-        if not False:
-            if 0 < burn_in < 1:
-                discard the first burn_in fraction of samples
-            else:
-                only keep samples [burn_in:]
-        Only works if `root` provided and if chains are GetDist compatible.
+    burn_in: float
+        if 0 < burn_in < 1:
+            discard the first burn_in fraction of samples
+        elif 1 < burn_in:
+            only keep samples [burn_in:]
+        Only works if `root` provided and if chains are GetDist or Cobaya
+        compatible.
         default: False
 
     """
@@ -367,7 +367,7 @@ class MCMCSamples(Samples):
                                  "instead which has the same features as "
                                  "Samples and more. MCMCSamples should be "
                                  "used for MCMC chains only." % root)
-            burn_in = kwargs.pop('burn_in', False)
+            burn_in = kwargs.pop('burn_in', None)
             weights, logL, samples = reader.samples(burn_in=burn_in)
             params, tex = reader.paramnames()
             columns = kwargs.pop('columns', params)

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -345,8 +345,11 @@ class MCMCSamples(Samples):
         default: -1e30
 
     burn_in: int or float
-        Discards the first integer number of nsamples if int
-        or the first fraction of nsamples if float.
+        if not False:
+            if 0 < burn_in < 1:
+                discard the first burn_in fraction of samples
+            else:
+                only keep samples [burn_in:]
         Only works if `root` provided and if chains are GetDist compatible.
         default: False
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -199,6 +199,11 @@ def test_make_2d_axes_ticks(upper, ticks):
         make_2d_axes(paramnames, upper=upper, ticks='spam')
 
 
+def test_make_2d_axes_ticks_error():
+    with pytest.raises(ValueError):
+        make_2d_axes(['a', 'b'], ticks='spam')
+
+
 def test_2d_axes_limits():
     np.random.seed(0)
     paramnames = ['A', 'B', 'C', 'D']

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -316,6 +316,33 @@ def test_kde_plot_1d(plot_1d):
             pass
 
 
+def test_fastkde_min_max():
+    np.random.seed(0)
+    data_x = np.random.randn(100)
+    data_y = np.random.randn(100)
+    xmin, xmax = -1, +1
+    ymin, ymax = -1, +1
+    try:
+        _, ax = plt.subplots()
+        line, = fastkde_plot_1d(ax, data_x, xmin=xmin, xmax=xmax)
+        assert (line.get_xdata() >= xmin).all()
+        assert (line.get_xdata() <= xmax).all()
+        plt.close("all")
+
+        _, ax = plt.subplots()
+        fastkde_contour_plot_2d(ax, data_x, data_y,
+                                xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
+        assert ax.get_xlim()[0] >= xmin
+        assert ax.get_xlim()[1] <= xmax
+        assert ax.get_ylim()[0] >= ymin
+        assert ax.get_ylim()[1] <= ymax
+        plt.close()
+
+    except ImportError:
+        if 'fastkde' not in sys.modules:
+            pass
+
+
 def test_hist_plot_1d():
     fig, ax = plt.subplots()
     np.random.seed(0)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -324,10 +324,32 @@ def test_fastkde_min_max():
     ymin, ymax = -1, +1
     try:
         _, ax = plt.subplots()
+        line, = fastkde_plot_1d(ax, data_x, xmin=xmin)
+        assert (line.get_xdata() >= xmin).all()
+        plt.close("all")
+
+        _, ax = plt.subplots()
+        line, = fastkde_plot_1d(ax, data_x, xmax=xmax)
+        assert (line.get_xdata() <= xmax).all()
+        plt.close("all")
+
+        _, ax = plt.subplots()
         line, = fastkde_plot_1d(ax, data_x, xmin=xmin, xmax=xmax)
         assert (line.get_xdata() >= xmin).all()
         assert (line.get_xdata() <= xmax).all()
         plt.close("all")
+
+        _, ax = plt.subplots()
+        fastkde_contour_plot_2d(ax, data_x, data_y, xmin=xmin, ymin=ymin)
+        assert ax.get_xlim()[0] >= xmin
+        assert ax.get_ylim()[0] >= ymin
+        plt.close()
+
+        _, ax = plt.subplots()
+        fastkde_contour_plot_2d(ax, data_x, data_y, xmax=xmax, ymax=ymax)
+        assert ax.get_xlim()[1] <= xmax
+        assert ax.get_ylim()[1] <= ymax
+        plt.close()
 
         _, ax = plt.subplots()
         fastkde_contour_plot_2d(ax, data_x, data_y,

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -267,26 +267,12 @@ def test_kde_plot_1d(plot_1d):
         line, = plot_1d(ax, data, cmap=plt.cm.Blues)
         assert line.get_color() == plt.cm.Blues(0.68)
 
-        # Check xmin
-        xmin = -0.5
-        line, = plot_1d(ax, data, xmin=xmin)
-        assert (line.get_xdata() >= xmin).all()
-
-        # Check xmax
-        xmax = 0.5
-        line, = plot_1d(ax, data, xmax=xmax)
-        assert (line.get_xdata() <= xmax).all()
-
-        # Check xmin and xmax
-        line, = plot_1d(ax, data, xmin=xmin, xmax=xmax)
-        assert (line.get_xdata() <= xmax).all()
-        assert (line.get_xdata() >= xmin).all()
-        plt.close("all")
-
         # Check q
         plot_1d(ax, data, q='1sigma')
         plot_1d(ax, data, q=0)
         plot_1d(ax, data, q=1)
+        plot_1d(ax, data, q=5)
+        plot_1d(ax, data, q=10)
         plot_1d(ax, data, q=0.1)
         plot_1d(ax, data, q=0.9)
         plot_1d(ax, data, q=(0.1, 0.9))
@@ -311,7 +297,7 @@ def test_kde_plot_1d(plot_1d):
         # Check xlim, Gaussian (i.e. limits reduced to relevant data range)
         fig, ax = plt.subplots()
         data = np.random.randn(1000) * 0.01 + 0.5
-        plot_1d(ax, data, xmin=0, xmax=1)
+        plot_1d(ax, data)
         xmin, xmax = ax.get_xlim()
         assert xmin > 0.4
         assert xmax < 0.6
@@ -319,10 +305,10 @@ def test_kde_plot_1d(plot_1d):
         # Check xlim, Uniform (i.e. data and limits span entire prior boundary)
         fig, ax = plt.subplots()
         data = np.random.uniform(size=1000)
-        plot_1d(ax, data, xmin=0, xmax=1)
+        plot_1d(ax, data)
         xmin, xmax = ax.get_xlim()
-        assert xmin == 0
-        assert xmax == 1
+        assert xmin <= 0
+        assert xmax >= 1
         plt.close("all")
 
     except ImportError:
@@ -334,99 +320,82 @@ def test_hist_plot_1d():
     fig, ax = plt.subplots()
     np.random.seed(0)
     data = np.random.randn(1000)
-    for p in ['', 'astropyhist']:
-        try:
-            # Check heights for histtype 'bar'
-            bars = hist_plot_1d(ax, data, histtype='bar', plotter=p)
-            assert np.all([isinstance(b, Patch) for b in bars])
-            assert max([b.get_height() for b in bars]) == 1.
-            assert np.all(np.array([b.get_height() for b in bars]) <= 1.)
 
-            # Check heights for histtype 'step'
-            polygon, = hist_plot_1d(ax, data, histtype='step', plotter=p)
-            assert isinstance(polygon, Polygon)
-            trans = polygon.get_transform() - ax.transData
-            assert np.isclose(trans.transform(polygon.xy)[:, -1].max(), 1.,
-                              rtol=1e-10, atol=1e-10)
-            assert np.all(trans.transform(polygon.xy)[:, -1] <= 1.)
+    # Check heights for histtype 'bar'
+    bars = hist_plot_1d(ax, data, histtype='bar')
+    assert np.all([isinstance(b, Patch) for b in bars])
+    assert max([b.get_height() for b in bars]) == 1.
+    assert np.all(np.array([b.get_height() for b in bars]) <= 1.)
 
-            # Check heights for histtype 'stepfilled'
-            polygon, = hist_plot_1d(ax, data, histtype='stepfilled', plotter=p)
-            assert isinstance(polygon, Polygon)
-            trans = polygon.get_transform() - ax.transData
-            assert np.isclose(trans.transform(polygon.xy)[:, -1].max(), 1.,
-                              rtol=1e-10, atol=1e-10)
-            assert np.all(trans.transform(polygon.xy)[:, -1] <= 1.)
+    # Check heights for histtype 'step'
+    polygon, = hist_plot_1d(ax, data, histtype='step')
+    assert isinstance(polygon, Polygon)
+    trans = polygon.get_transform() - ax.transData
+    assert np.isclose(trans.transform(polygon.xy)[:, -1].max(), 1.,
+                      rtol=1e-10, atol=1e-10)
+    assert np.all(trans.transform(polygon.xy)[:, -1] <= 1.)
 
-            # Check arguments are passed onward to underlying function
-            bars = hist_plot_1d(ax, data, histtype='bar',
-                                color='r', alpha=0.5, plotter=p)
-            cc = ColorConverter.to_rgba('r', alpha=0.5)
-            assert np.all([b.get_fc() == cc for b in bars])
-            bars = hist_plot_1d(ax, data, histtype='bar',
-                                cmap=plt.cm.viridis, alpha=0.5, plotter=p)
-            cc = ColorConverter.to_rgba(plt.cm.viridis(0.68), alpha=0.5)
-            assert np.all([b.get_fc() == cc for b in bars])
-            polygon, = hist_plot_1d(ax, data, histtype='step',
-                                    color='r', alpha=0.5, plotter=p)
-            assert polygon.get_ec() == ColorConverter.to_rgba('r', alpha=0.5)
-            polygon, = hist_plot_1d(ax, data, histtype='step',
-                                    cmap=plt.cm.viridis, color='r', plotter=p)
-            assert polygon.get_ec() == ColorConverter.to_rgba('r')
+    # Check heights for histtype 'stepfilled'
+    polygon, = hist_plot_1d(ax, data, histtype='stepfilled')
+    assert isinstance(polygon, Polygon)
+    trans = polygon.get_transform() - ax.transData
+    assert np.isclose(trans.transform(polygon.xy)[:, -1].max(), 1.,
+                      rtol=1e-10, atol=1e-10)
+    assert np.all(trans.transform(polygon.xy)[:, -1] <= 1.)
 
-            # Check xmin
-            for xmin in [-np.inf, -0.5]:
-                bars = hist_plot_1d(ax, data, histtype='bar',
-                                    xmin=xmin, plotter=p)
-                assert (np.array([b.xy[0] for b in bars]) >= xmin).all()
-                polygon, = hist_plot_1d(ax, data, histtype='step', xmin=xmin)
-                assert (polygon.xy[:, 0] >= xmin).all()
+    # Check arguments are passed onward to underlying function
+    bars = hist_plot_1d(ax, data, histtype='bar', color='r', alpha=0.5)
+    cc = ColorConverter.to_rgba('r', alpha=0.5)
+    assert np.all([b.get_fc() == cc for b in bars])
+    bars = hist_plot_1d(ax, data, histtype='bar', cmap=plt.cm.viridis,
+                        alpha=0.5)
+    cc = ColorConverter.to_rgba(plt.cm.viridis(0.68), alpha=0.5)
+    assert np.all([b.get_fc() == cc for b in bars])
+    polygon, = hist_plot_1d(ax, data, histtype='step', color='r', alpha=0.5)
+    assert polygon.get_ec() == ColorConverter.to_rgba('r', alpha=0.5)
+    polygon, = hist_plot_1d(ax, data, histtype='step', cmap=plt.cm.viridis,
+                            color='r')
+    assert polygon.get_ec() == ColorConverter.to_rgba('r')
+    plt.close("all")
 
-            # Check xmax
-            for xmax in [np.inf, 0.5]:
-                bars = hist_plot_1d(ax, data, histtype='bar',
-                                    xmax=xmax, plotter=p)
-                assert (np.array([b.xy[-1] for b in bars]) <= xmax).all()
-                polygon, = hist_plot_1d(ax, data, histtype='step',
-                                        xmax=xmax, plotter=p)
-                assert (polygon.xy[:, 0] <= xmax).all()
 
-            # Check xmin and xmax
-            bars = hist_plot_1d(ax, data, histtype='bar',
-                                xmin=xmin, xmax=xmax, plotter=p)
-            assert (np.array([b.xy[0] for b in bars]) >= -0.5).all()
-            assert (np.array([b.xy[-1] for b in bars]) <= 0.5).all()
-            polygon, = hist_plot_1d(ax, data, histtype='step',
-                                    xmin=xmin, xmax=xmax, plotter=p)
-            assert (polygon.xy[:, 0] >= -0.5).all()
-            assert (polygon.xy[:, 0] <= 0.5).all()
-            plt.close("all")
-        except ImportError:
-            if p == 'astropyhist' and 'astropy' not in sys.modules:
-                pass
+@pytest.mark.parametrize('bins', ['knuth', 'freedman', 'blocks'])
+def test_astropyhist_plot_1d(bins):
+    try:
+        fig, ax = plt.subplots()
+        np.random.seed(0)
+        data = np.random.randn(100)
+        bars = hist_plot_1d(ax, data, histtype='bar', bins=bins)
+        assert np.all([isinstance(b, Patch) for b in bars])
+        assert max([b.get_height() for b in bars]) == 1.
+        assert np.all(np.array([b.get_height() for b in bars]) <= 1.)
+        plt.close("all")
+    except ImportError:
+        if 'astropy' not in sys.modules:
+            pass
 
 
 def test_hist_plot_2d():
     fig, ax = plt.subplots()
     np.random.seed(0)
-    data_x, data_y = np.random.randn(2, 10000)
+    data_x, data_y = np.random.randn(2, 1000)
     hist_plot_2d(ax, data_x, data_y)
     xmin, xmax = ax.get_xlim()
     ymin, ymax = ax.get_ylim()
-    assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
+    assert xmin > -5 and xmax < 5 and ymin > -5 and ymax < 5
 
-    hist_plot_2d(ax, data_x, data_y, xmin=-np.inf)
-    hist_plot_2d(ax, data_x, data_y, xmax=np.inf)
-    hist_plot_2d(ax, data_x, data_y, ymin=-np.inf)
-    hist_plot_2d(ax, data_x, data_y, ymax=np.inf)
-    assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
+    data_x, data_y = np.random.uniform(-10, 10, (2, 1000))
+    hist_plot_2d(ax, data_x, data_y)
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+    assert xmin > -10 and xmax < 10 and ymin > -10 and ymax < 10
 
-    data_x, data_y = np.random.uniform(-10, 10, (2, 1000000))
+    data_x, data_y = np.random.uniform(-10, 10, (2, 1000))
     weights = np.exp(-(data_x**2 + data_y**2)/2)
     hist_plot_2d(ax, data_x, data_y, weights=weights, bins=30)
     xmin, xmax = ax.get_xlim()
     ymin, ymax = ax.get_ylim()
-    assert xmin > -3 and xmax < 3 and ymin > -3 and ymax < 3
+    assert xmin > -6 and xmax < 6 and ymin > -6 and ymax < 6
 
 
 @pytest.mark.parametrize('plot_1d', [kde_plot_1d, fastkde_plot_1d])
@@ -483,46 +452,6 @@ def test_contour_plot_2d(contour_plot_2d):
             assert isinstance(cf, TriContourSet)
             assert isinstance(ct, TriContourSet)
 
-        xmin, xmax, ymin, ymax = -0.5, 0.5, -0.5, 0.5
-
-        # Check xmin
-        ax = plt.gca()
-        contour_plot_2d(ax, data_x, data_y, xmin=xmin)
-        assert ax.get_xlim()[0] >= xmin
-        plt.close()
-
-        # Check xmax
-        ax = plt.gca()
-        contour_plot_2d(ax, data_x, data_y, xmax=xmax)
-        assert ax.get_xlim()[1] <= xmax
-        plt.close()
-
-        # Check xmin and xmax
-        ax = plt.gca()
-        contour_plot_2d(ax, data_x, data_y, xmin=xmin, xmax=xmax)
-        assert ax.get_xlim()[1] <= xmax
-        assert ax.get_xlim()[0] >= xmin
-        plt.close()
-
-        # Check ymin
-        ax = plt.gca()
-        contour_plot_2d(ax, data_x, data_y, ymin=ymin)
-        assert ax.get_ylim()[0] >= ymin
-        plt.close()
-
-        # Check ymax
-        ax = plt.gca()
-        contour_plot_2d(ax, data_x, data_y, ymax=ymax)
-        assert ax.get_ylim()[1] <= ymax
-        plt.close()
-
-        # Check ymin and ymax
-        ax = plt.gca()
-        contour_plot_2d(ax, data_x, data_y, ymin=ymin, ymax=ymax)
-        assert ax.get_ylim()[1] <= ymax
-        assert ax.get_ylim()[0] >= ymin
-        plt.close()
-
         # Check levels
         with pytest.raises(ValueError):
             ax = plt.gca()
@@ -569,7 +498,7 @@ def test_contour_plot_2d(contour_plot_2d):
         fig, ax = plt.subplots()
         data_x = np.random.randn(1000) * 0.01 + 0.5
         data_y = np.random.randn(1000) * 0.01 + 0.5
-        contour_plot_2d(ax, data_x, data_y, xmin=0, xmax=1, ymin=0, ymax=1)
+        contour_plot_2d(ax, data_x, data_y)
         xmin, xmax = ax.get_xlim()
         ymin, ymax = ax.get_ylim()
         assert xmin > 0.4
@@ -581,13 +510,13 @@ def test_contour_plot_2d(contour_plot_2d):
         fig, ax = plt.subplots()
         data_x = np.random.uniform(size=1000)
         data_y = np.random.uniform(size=1000)
-        contour_plot_2d(ax, data_x, data_y, xmin=0, xmax=1, ymin=0, ymax=1)
+        contour_plot_2d(ax, data_x, data_y)
         xmin, xmax = ax.get_xlim()
         ymin, ymax = ax.get_ylim()
-        assert xmin == 0
-        assert xmax == 1
-        assert ymin == 0
-        assert ymax == 1
+        assert xmin <= 0
+        assert xmax >= 1
+        assert ymin <= 0
+        assert ymax >= 1
         plt.close("all")
 
     except ImportError:
@@ -633,31 +562,10 @@ def test_contour_plot_2d_levels(contour_plot_2d, levels):
 def test_scatter_plot_2d():
     fig, ax = plt.subplots()
     np.random.seed(2)
-    data_x = np.random.randn(1000)
-    data_y = np.random.randn(1000)
+    data_x = np.random.randn(100)
+    data_y = np.random.randn(100)
     lines, = scatter_plot_2d(ax, data_x, data_y)
     assert isinstance(lines, Line2D)
-
-    xmin, xmax, ymin, ymax = -0.5, 0.5, -0.5, 0.5
-    ax = plt.gca()
-    scatter_plot_2d(ax, data_x, data_y, xmin=xmin)
-    assert ax.get_xlim()[0] >= xmin
-    plt.close()
-
-    ax = plt.gca()
-    scatter_plot_2d(ax, data_x, data_y, xmax=xmax)
-    assert ax.get_xlim()[1] <= xmax
-    plt.close()
-
-    ax = plt.gca()
-    scatter_plot_2d(ax, data_x, data_y, ymin=ymin)
-    assert ax.get_ylim()[0] >= ymin
-    plt.close()
-
-    ax = plt.gca()
-    scatter_plot_2d(ax, data_x, data_y, ymax=ymax)
-    assert ax.get_ylim()[1] <= ymax
-    plt.close()
 
     ax = plt.gca()
     points, = scatter_plot_2d(ax, data_x, data_y, color='C0', lw=1)
@@ -670,24 +578,27 @@ def test_scatter_plot_2d():
     assert (points.get_markeredgecolor() == 'C2')
     plt.close()
 
-    # Check q
+    # Check that q is ignored
     ax = plt.gca()
     scatter_plot_2d(ax, data_x, data_y, q=0)
     plt.close()
 
 
-@pytest.mark.parametrize('sigmas', [('1sigma', 0.682689492137086),
-                                    ('2sigma', 0.954499736103642),
-                                    ('3sigma', 0.997300203936740),
-                                    ('4sigma', 0.999936657516334),
-                                    ('5sigma', 0.999999426696856)])
+@pytest.mark.parametrize('sigmas', [(1, '1sigma', 0.682689492137086),
+                                    (2, '2sigma', 0.954499736103642),
+                                    (3, '3sigma', 0.997300203936740),
+                                    (4, '4sigma', 0.999936657516334),
+                                    (5, '5sigma', 0.999999426696856)])
 def test_quantile_plot_interval_str(sigmas):
-    q1, q2 = quantile_plot_interval(q=sigmas[0])
-    assert q1 == 0.5 - sigmas[1] / 2
-    assert q2 == 0.5 + sigmas[1] / 2
+    qi1, qi2 = quantile_plot_interval(q=sigmas[0])
+    qs1, qs2 = quantile_plot_interval(q=sigmas[1])
+    assert qi1 == pytest.approx(0.5 - sigmas[2] / 2)
+    assert qi2 == pytest.approx(0.5 + sigmas[2] / 2)
+    assert qs1 == pytest.approx(0.5 - sigmas[2] / 2)
+    assert qs2 == pytest.approx(0.5 + sigmas[2] / 2)
 
 
-@pytest.mark.parametrize('floats', [0, 1, 0.1, 0.9])
+@pytest.mark.parametrize('floats', [0, 0.1, 0.9])
 def test_quantile_plot_interval_float(floats):
     q1, q2 = quantile_plot_interval(q=floats)
     assert q1 == min(floats, 1 - floats)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -119,6 +119,9 @@ def test_discard_burn_in(root):
     mcmc1.plot_2d(['x0', 'x1', 'x2', 'x3', 'x4'])
     mcmc1.plot_1d(['x0', 'x1', 'x2', 'x3', 'x4'])
 
+    with pytest.raises(ValueError):
+        MCMCSamples(burn_in='spam', root='./tests/example_data/' + root)
+
 
 def test_read_fail():
     with pytest.raises(FileNotFoundError):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -89,7 +89,8 @@ def test_read_polychord():
     os.rename('./tests/example_data/pc_phys_live-birth.txt_',
               './tests/example_data/pc_phys_live-birth.txt')
 
-    ns_zero_live = NestedSamples(root='./tests/example_data/pc_zero_live')
+    with pytest.warns(UserWarning, match="input contained no data"):
+        ns_zero_live = NestedSamples(root='./tests/example_data/pc_zero_live')
 
     ns_single_live = NestedSamples(root='./tests/example_data/pc_single_live')
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -18,7 +18,6 @@ def test_read_chainreader():
     reader = ChainReader('root')
     assert reader.root == 'root'
     assert reader.paramnames() == (None, {})
-    assert reader.limits() == {}
     with pytest.raises(NotImplementedError):
         reader.samples()
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -120,8 +120,13 @@ def test_discard_burn_in(root):
     mcmc1.plot_2d(['x0', 'x1', 'x2', 'x3', 'x4'])
     mcmc1.plot_1d(['x0', 'x1', 'x2', 'x3', 'x4'])
 
-    with pytest.raises(ValueError):
-        MCMCSamples(burn_in='spam', root='./tests/example_data/' + root)
+    mcmc1 = MCMCSamples(burn_in=-1000.1, root='./tests/example_data/' + root)
+    for key in ['x0', 'x1', 'x2', 'x3', 'x4']:
+        if key in mcmc0:
+            assert key in mcmc1
+            assert_array_equal(mcmc0[key][-1000:], mcmc1[key][1000:])
+    mcmc1.plot_2d(['x0', 'x1', 'x2', 'x3', 'x4'])
+    mcmc1.plot_1d(['x0', 'x1', 'x2', 'x3', 'x4'])
 
 
 def test_read_fail():

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -89,7 +89,7 @@ def test_read_polychord():
     os.rename('./tests/example_data/pc_phys_live-birth.txt_',
               './tests/example_data/pc_phys_live-birth.txt')
 
-    with pytest.warns(UserWarning, match="input contained no data"):
+    with pytest.warns(UserWarning, match="loadtxt"):
         ns_zero_live = NestedSamples(root='./tests/example_data/pc_zero_live')
 
     ns_single_live = NestedSamples(root='./tests/example_data/pc_single_live')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,14 @@ from anesthetic.utils import (nest_level, compute_nlive, unique, is_int,
                               iso_probability_contours_from_samples,
                               logsumexp, sample_compression_1d,
                               triangular_sample_compression_2d,
-                              insertion_p_value)
+                              insertion_p_value, compress_weights)
+
+
+def test_compress_weights():
+    w = compress_weights(w=np.ones(10), u=None)
+    assert_array_equal(w, np.ones(10))
+    w = compress_weights(w=None, u=np.random.rand(10))
+    assert_array_equal(w, np.ones(10))
 
 
 def test_nest_level():
@@ -58,6 +65,7 @@ def test_unique():
                                  iso_probability_contours_from_samples])
 def test_iso_probability_contours(ipc):
     p = np.random.randn(10)
+    ipc(p)
     with pytest.raises(ValueError):
         ipc(p, contours=[0.68, 0.95])
 


### PR DESCRIPTION
This PR addresses #200 and 
1) removes the `limits` attribute of `Samples`, `MCMCSamples`, and `NestedSamples`, and
2) removes the `xmin` and `xmax` (and `ymin` and `ymax` kwargs passed to the plotting functions.

Fixes #200 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
