### PR TITLE
Issue with plot labels

### DIFF
--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -139,6 +139,7 @@ class Samples(WeightedDataFrame):
                 xlabel = self.tex[x] if x in self.tex else x
                 self[x].plot(ax=ax, xlabel=xlabel,
                              *args, **kwargs)
+                ax.set_xlabel(xlabel)
             else:
                 ax.plot([], [])
 
@@ -248,9 +249,12 @@ class Samples(WeightedDataFrame):
                         if x == y:
                             self[x].plot(ax=ax.twin, xlabel=xlabel,
                                          *args, **lkwargs)
+                            ax.set_xlabel(xlabel)
                         else:
                             self.plot(x, y, ax=ax, xlabel=xlabel,
                                       ylabel=ylabel, *args, **lkwargs)
+                            ax.set_xlabel(xlabel)
+                            ax.set_ylabel(ylabel)
                     else:
                         if x == y:
                             ax.twin.plot([], [])

--- a/anesthetic/samples.py
+++ b/anesthetic/samples.py
@@ -136,7 +136,9 @@ class Samples(WeightedDataFrame):
 
         for x, ax in axes.iteritems():
             if x in self and kwargs['kind'] is not None:
-                self[x].plot(ax=ax, *args, **kwargs)
+                xlabel = self.tex[x] if x in self.tex else x
+                self[x].plot(ax=ax, xlabel=xlabel,
+                             *args, **kwargs)
             else:
                 ax.plot([], [])
 
@@ -241,10 +243,14 @@ class Samples(WeightedDataFrame):
                     lkwargs = local_kwargs.get(pos, {})
                     lkwargs['kind'] = kind.get(pos, None)
                     if x in self and y in self and lkwargs['kind'] is not None:
+                        xlabel = self.tex[x] if x in self.tex else x
+                        ylabel = self.tex[y] if y in self.tex else y
                         if x == y:
-                            self[x].plot(ax=ax.twin, *args, **lkwargs)
+                            self[x].plot(ax=ax.twin, xlabel=xlabel,
+                                         *args, **lkwargs)
                         else:
-                            self.plot(x, y, ax=ax, *args, **lkwargs)
+                            self.plot(x, y, ax=ax, xlabel=xlabel,
+                                      ylabel=ylabel, *args, **lkwargs)
                     else:
                         if x == y:
                             ax.twin.plot([], [])

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -942,3 +942,15 @@ def test_samples_dot_plot():
         pass
 
     plt.close("all")
+
+
+def test_samples_plot_labels():
+    samples = NestedSamples(root='./tests/example_data/pc')
+    columns = ['x0', 'x1', 'x2', 'x3', 'x4']
+    fig, axes = samples.plot_2d(columns)
+
+    for col, ax in zip(columns, axes.loc['x0', :]):
+        assert samples.tex[col] == ax.get_ylabel()
+
+    for col, ax in zip(columns, axes.loc[:, 'x4']):
+        assert samples.tex[col] == ax.get_xlabel()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -949,8 +949,8 @@ def test_samples_plot_labels():
     columns = ['x0', 'x1', 'x2', 'x3', 'x4']
     fig, axes = samples.plot_2d(columns)
 
-    for col, ax in zip(columns, axes.loc['x0', :]):
+    for col, ax in zip(columns, axes.loc[:, 'x0']):
         assert samples.tex[col] == ax.get_ylabel()
 
-    for col, ax in zip(columns, axes.loc[:, 'x4']):
+    for col, ax in zip(columns, axes.loc['x4', :]):
         assert samples.tex[col] == ax.get_xlabel()


### PR DESCRIPTION
# Description

#207 introduced a bug whereby `samples.plot_2d(...)` no longer has the correct tex in all of the labels. This arises because `samples.plot(...)` defaults to using the column label, which can overwrite the labels set up by `make_2d_axes`. This fixes that by passing `xlabel` explicitly through `samples.plot` in `samples.plot_2d(...)`

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works
