### PR TITLE
update gui script

### DIFF
--- a/scripts/anesthetic
+++ b/scripts/anesthetic
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import matplotlib.pyplot as plt
-from anesthetic import NestedSamples
+from anesthetic import read_chains
 
 # Parse arguments
 description = "Nested sampling visualisation"
@@ -12,6 +12,6 @@ parser.add_argument('--params', '-p', nargs='*', type=str,
 args = parser.parse_args()
 
 # Generate the rhinestone plotter
-samples = NestedSamples(root=args.file_root)
+samples = read_chains(root=args.file_root)
 plotter = samples.gui(args.params)
 plt.show()


### PR DESCRIPTION
# Change import and chain reading style for command line gui script

Small changes to match new reading style for the included command line script to launch the gui

Fixes #227

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works 
