### PR TITLE
pass labels argument through when reading chains

### DIFF
--- a/anesthetic/read/cobaya.py
+++ b/anesthetic/read/cobaya.py
@@ -61,6 +61,7 @@ def read_cobaya(root, *args, **kwargs):
 
     params, labels = read_paramnames(root)
     columns = kwargs.pop('columns', params)
+    labels = kwargs.pop("labels", labels)
     kwargs['label'] = kwargs.get('label', os.path.basename(root))
 
     samples = []

--- a/anesthetic/read/cobaya.py
+++ b/anesthetic/read/cobaya.py
@@ -61,7 +61,7 @@ def read_cobaya(root, *args, **kwargs):
 
     columns, labels = read_paramnames(root)
     columns = kwargs.pop('columns', columns)
-    labels = kwargs.pop("labels", labels)
+    labels = kwargs.pop('labels', labels)
     kwargs['label'] = kwargs.get('label', os.path.basename(root))
 
     samples = []

--- a/anesthetic/read/cobaya.py
+++ b/anesthetic/read/cobaya.py
@@ -59,8 +59,8 @@ def read_cobaya(root, *args, **kwargs):
     if not chains_files:
         raise FileNotFoundError(dirname + '/' + regex + " not found.")
 
-    params, labels = read_paramnames(root)
-    columns = kwargs.pop('columns', params)
+    columns, labels = read_paramnames(root)
+    columns = kwargs.pop('columns', columns)
     labels = kwargs.pop("labels", labels)
     kwargs['label'] = kwargs.get('label', os.path.basename(root))
 

--- a/anesthetic/read/getdist.py
+++ b/anesthetic/read/getdist.py
@@ -68,8 +68,9 @@ def read_getdist(root, *args, **kwargs):
     if not chains_files:
         raise FileNotFoundError(dirname + '/' + regex + " not found.")
 
-    params, labels = read_paramnames(root)
-    columns = kwargs.pop('columns', params)
+    columns, labels = read_paramnames(root)
+    columns = kwargs.pop('columns', columns)
+    labels = kwargs.pop('labels', labels)
     kwargs['label'] = kwargs.get('label', os.path.basename(root))
 
     samples = []

--- a/anesthetic/read/multinest.py
+++ b/anesthetic/read/multinest.py
@@ -38,6 +38,8 @@ def read_multinest(root, *args, **kwargs):
 
     kwargs['label'] = kwargs.get('label', os.path.basename(root))
     columns, labels = read_paramnames(root)
+    columns = kwargs.pop('columns', columns)
+    labels = kwargs.pop("labels", labels)
     data = samples
 
     return NestedSamples(data=data, logL=logL, logL_birth=logL_birth,

--- a/anesthetic/read/multinest.py
+++ b/anesthetic/read/multinest.py
@@ -39,7 +39,7 @@ def read_multinest(root, *args, **kwargs):
     kwargs['label'] = kwargs.get('label', os.path.basename(root))
     columns, labels = read_paramnames(root)
     columns = kwargs.pop('columns', columns)
-    labels = kwargs.pop("labels", labels)
+    labels = kwargs.pop('labels', labels)
     data = samples
 
     return NestedSamples(data=data, logL=logL, logL_birth=logL_birth,

--- a/anesthetic/read/polychord.py
+++ b/anesthetic/read/polychord.py
@@ -24,7 +24,7 @@ def read_polychord(root, *args, **kwargs):
     columns, labels = read_paramnames(root)
 
     columns = kwargs.pop('columns', columns)
-    labels = kwargs.pop("labels", labels)
+    labels = kwargs.pop('labels', labels)
     kwargs['label'] = kwargs.get('label', os.path.basename(root))
 
     return NestedSamples(data=data, columns=columns,

--- a/anesthetic/read/polychord.py
+++ b/anesthetic/read/polychord.py
@@ -21,9 +21,9 @@ def read_polychord(root, *args, **kwargs):
     except IOError:
         pass
     data, logL, logL_birth = np.split(data, [-2, -1], axis=1)
-    params, labels = read_paramnames(root)
+    columns, labels = read_paramnames(root)
 
-    columns = kwargs.pop('columns', params)
+    columns = kwargs.pop('columns', columns)
     labels = kwargs.pop("labels", labels)
     kwargs['label'] = kwargs.get('label', os.path.basename(root))
 

--- a/anesthetic/read/polychord.py
+++ b/anesthetic/read/polychord.py
@@ -24,6 +24,7 @@ def read_polychord(root, *args, **kwargs):
     params, labels = read_paramnames(root)
 
     columns = kwargs.pop('columns', params)
+    labels = kwargs.pop("labels", labels)
     kwargs['label'] = kwargs.get('label', os.path.basename(root))
 
     return NestedSamples(data=data, columns=columns,


### PR DESCRIPTION
I noticed that `labels` isn't passed along in the same way as `columns` when reading chains.