### PR TITLE
Fix to non-deterministic behaviour by removing long-range side effects

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,7 +60,7 @@ jobs:
       run: python -m pip install -r requirements_extras.txt 
 
     - name: Test with pytest
-      run: python -m pytest --cov=anesthetic tests
+      run: python -m pytest --cov=anesthetic -n auto tests
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
@@ -93,7 +93,7 @@ jobs:
 
     - name: Test with pytest
       shell: bash -l {0}
-      run: python -m pytest --cov=anesthetic tests
+      run: python -m pytest --cov=anesthetic -n auto tests
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -23,9 +23,13 @@ from scipy.interpolate import interp1d
 
 @pytest.fixture(autouse=True)
 def close_figures_on_teardown():
-    plt.figure()
     yield
     plt.close("all")
+
+
+@pytest.fixture(autouse=True)
+def open_new_figure_on_setup(close_figures_on_teardown):
+    plt.figure()
 
 
 def test_AxesObjects():

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -21,6 +21,13 @@ from scipy.special import erf
 from scipy.interpolate import interp1d
 
 
+@pytest.fixture(autouse=True)
+def close_figures_on_teardown():
+    plt.figure()
+    yield
+    plt.close("all")
+
+
 def test_AxesObjects():
     paramnames = ['a', 'b', 'c']
 
@@ -112,7 +119,6 @@ def test_make_1d_axes():
     # Check unexpected kwargs
     with pytest.raises((AttributeError, TypeError)):
         make_1d_axes(paramnames, spam='ham')
-    plt.close("all")
 
 
 def test_make_2d_axes_inputs_outputs():
@@ -145,7 +151,6 @@ def test_make_2d_axes_inputs_outputs():
     assert fig is not fig0
     fig, axes = make_2d_axes(paramnames_x, fig=fig0)
     assert fig is fig0
-    plt.close("all")
 
     # Check gridspec argument
     grid = gs.GridSpec(2, 2, width_ratios=[3, 1], height_ratios=[3, 1])
@@ -203,7 +208,6 @@ def test_make_2d_axes_behaviour(diagonal, lower, upper, paramnames_y):
     assert ns['upper'] == upper * nx*(nx-1)//2
     assert ns['lower'] == lower * nx*(nx-1)//2
     assert ns['diagonal'] == diagonal * nx
-    plt.close("all")
 
     params = [paramnames_x, paramnames_y]
     all_params = paramnames_x + paramnames_y
@@ -224,7 +228,6 @@ def test_make_2d_axes_behaviour(diagonal, lower, upper, paramnames_y):
     assert ns['upper'] == upper * nu
     assert ns['lower'] == lower * nl
     assert ns['diagonal'] == diagonal * nd
-    plt.close("all")
 
 
 @pytest.mark.parametrize('upper', [False, True])
@@ -249,7 +252,6 @@ def test_make_2d_axes_ticks(upper, ticks):
                     assert np.array_equal(xticks, ax.get_xticks())
                 else:
                     assert not np.array_equal(xticks, ax.get_xticks())
-        plt.close("all")
     with pytest.raises(ValueError):
         make_2d_axes(paramnames, upper=upper, ticks='spam')
 
@@ -288,7 +290,6 @@ def test_2d_axes_axlines(axesparams, params, upper):
     kwargs = dict(c='k', ls='--', lw=0.5)
     fig, axes = make_2d_axes(axesparams, upper=upper)
     axes.axlines(params, **kwargs)
-    plt.close("all")
 
 
 @pytest.mark.parametrize('axesparams', [['A', 'B', 'C', 'D'],
@@ -302,7 +303,6 @@ def test_2d_axes_axspans(axesparams, params, upper):
     kwargs = dict(c='k', alpha=0.5)
     fig, axes = make_2d_axes(axesparams, upper=upper)
     axes.axspans(params, **kwargs)
-    plt.close("all")
 
 
 @pytest.mark.parametrize('axesparams', [['A', 'B', 'C', 'D'],
@@ -316,7 +316,6 @@ def test_2d_axes_scatter(axesparams, params, upper):
     kwargs = dict(c='k', marker='*')
     fig, axes = make_2d_axes(axesparams, upper=upper)
     axes.scatter(params, **kwargs)
-    plt.close("all")
 
 
 @pytest.mark.parametrize('plot_1d', [kde_plot_1d, fastkde_plot_1d])
@@ -356,13 +355,11 @@ def test_kde_plot_1d(plot_1d):
         line, fill = plot_1d(ax, data, fc=True, color='k', ec=None)
         assert len(fill[0].get_edgecolor()) == 0
         assert (to_rgba(line[0].get_color()) == to_rgba('k'))
-        plt.close("all")
 
         # Check levels
         with pytest.raises(ValueError):
             ax = plt.gca()
             plot_1d(ax, data, fc=True, levels=[0.68, 0.95])
-            plt.close("all")
 
         # Check xlim, Gaussian (i.e. limits reduced to relevant data range)
         fig, ax = plt.subplots()
@@ -371,7 +368,6 @@ def test_kde_plot_1d(plot_1d):
         xmin, xmax = ax.get_xlim()
         assert xmin > 0.4
         assert xmax < 0.6
-        plt.close("all")
         # Check xlim, Uniform (i.e. data and limits span entire prior boundary)
         fig, ax = plt.subplots()
         data = np.random.uniform(size=1000)
@@ -379,7 +375,6 @@ def test_kde_plot_1d(plot_1d):
         xmin, xmax = ax.get_xlim()
         assert xmin <= 0
         assert xmax >= 1
-        plt.close("all")
 
     except ImportError:
         if 'fastkde' not in sys.modules:
@@ -396,30 +391,25 @@ def test_fastkde_min_max():
         _, ax = plt.subplots()
         line, = fastkde_plot_1d(ax, data_x, xmin=xmin)
         assert (line.get_xdata() >= xmin).all()
-        plt.close("all")
 
         _, ax = plt.subplots()
         line, = fastkde_plot_1d(ax, data_x, xmax=xmax)
         assert (line.get_xdata() <= xmax).all()
-        plt.close("all")
 
         _, ax = plt.subplots()
         line, = fastkde_plot_1d(ax, data_x, xmin=xmin, xmax=xmax)
         assert (line.get_xdata() >= xmin).all()
         assert (line.get_xdata() <= xmax).all()
-        plt.close("all")
 
         _, ax = plt.subplots()
         fastkde_contour_plot_2d(ax, data_x, data_y, xmin=xmin, ymin=ymin)
         assert ax.get_xlim()[0] >= xmin
         assert ax.get_ylim()[0] >= ymin
-        plt.close()
 
         _, ax = plt.subplots()
         fastkde_contour_plot_2d(ax, data_x, data_y, xmax=xmax, ymax=ymax)
         assert ax.get_xlim()[1] <= xmax
         assert ax.get_ylim()[1] <= ymax
-        plt.close()
 
         _, ax = plt.subplots()
         fastkde_contour_plot_2d(ax, data_x, data_y,
@@ -428,7 +418,6 @@ def test_fastkde_min_max():
         assert ax.get_xlim()[1] <= xmax
         assert ax.get_ylim()[0] >= ymin
         assert ax.get_ylim()[1] <= ymax
-        plt.close()
 
     except ImportError:
         if 'fastkde' not in sys.modules:
@@ -475,7 +464,6 @@ def test_hist_plot_1d():
     polygon, = hist_plot_1d(ax, data, histtype='step', cmap=plt.cm.viridis,
                             color='r')
     assert polygon.get_ec() == ColorConverter.to_rgba('r')
-    plt.close("all")
 
 
 @pytest.mark.parametrize('bins', ['knuth', 'freedman', 'blocks'])
@@ -488,7 +476,6 @@ def test_astropyhist_plot_1d(bins):
         assert np.all([isinstance(b, Patch) for b in bars])
         assert max([b.get_height() for b in bars]) == 1.
         assert np.all(np.array([b.get_height() for b in bars]) <= 1.)
-        plt.close("all")
     except ImportError:
         if 'astropy' not in sys.modules:
             pass
@@ -553,8 +540,6 @@ def test_1d_density_kwarg(plot_1d, s):
         gauss_norm = 1 / np.sqrt(2 * np.pi * s**2)
         assert kde_height == pytest.approx(gauss_norm, rel=0.1)
 
-        plt.close("all")
-
     except ImportError:
         if 'fastkde' not in sys.modules:
             pass
@@ -595,7 +580,7 @@ def test_contour_plot_2d(contour_plot_2d):
         cf, ct = contour_plot_2d(ax, data_x, data_y, ec='C0', cmap=plt.cm.Reds)
         assert cf.get_cmap() == plt.cm.Reds
         assert ct.colors == 'C0'
-        plt.close("all")
+        plt.close()
         ax = plt.gca()
         cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None)
         assert cf is None
@@ -612,7 +597,6 @@ def test_contour_plot_2d(contour_plot_2d):
         assert cf is None
         assert ct.colors is None
         assert ct.get_cmap() == plt.cm.Reds
-        plt.close("all")
 
         # Check limits, Gaussian (i.e. limits reduced to relevant data range)
         fig, ax = plt.subplots()
@@ -625,7 +609,6 @@ def test_contour_plot_2d(contour_plot_2d):
         assert xmax < 0.6
         assert ymin > 0.4
         assert ymax < 0.6
-        plt.close("all")
         # Check limits, Uniform (i.e. data & limits span entire prior boundary)
         fig, ax = plt.subplots()
         data_x = np.random.uniform(size=1000)
@@ -643,7 +626,6 @@ def test_contour_plot_2d(contour_plot_2d):
             assert xmax == pytest.approx(1, abs=0.01)
             assert ymin == pytest.approx(0, abs=0.01)
             assert ymax == pytest.approx(1, abs=0.01)
-        plt.close("all")
 
     except ImportError:
         if 'fastkde' not in sys.modules:
@@ -656,14 +638,12 @@ def test_kde_plot_nplot():
     data = np.random.randn(1000)
     line, = kde_plot_1d(ax, data, ncompress=1000, nplot_1d=200)
     assert line.get_xdata().size == 200
-    plt.close("all")
 
     fig, ax = plt.subplots()
     np.random.seed(0)
     data_x = np.random.randn(1000)
     data_y = np.random.randn(1000)
     kde_contour_plot_2d(ax, data_x, data_y, ncompress=1000, nplot_2d=900)
-    plt.close("all")
 
 
 @pytest.mark.parametrize('contour_plot_2d', [kde_contour_plot_2d,
@@ -694,8 +674,6 @@ def test_contour_plot_2d_levels(contour_plot_2d, levels):
         color2 = ax2.collections[len(levels)-1].get_edgecolor()
         assert_array_equal(color1, color2)
 
-        plt.close("all")
-
     except ImportError:
         if 'fastkde' not in sys.modules:
             pass
@@ -718,12 +696,10 @@ def test_scatter_plot_2d():
     assert (points.get_color() == 'C0')
     assert (points.get_markerfacecolor() == 'C1')
     assert (points.get_markeredgecolor() == 'C2')
-    plt.close()
 
     # Check that q is ignored
     ax = plt.gca()
     scatter_plot_2d(ax, data_x, data_y, q=0)
-    plt.close()
 
 
 @pytest.mark.parametrize('sigmas', [(1, '1sigma', 0.682689492137086),

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -351,7 +351,7 @@ def test_kde_plot_1d(plot_1d):
 
         # Check levels
         with pytest.raises(ValueError):
-            ax = plt.gca()
+            fig, ax = plt.subplots()
             plot_1d(ax, data, fc=True, levels=[0.68, 0.95])
 
         # Check xlim, Gaussian (i.e. limits reduced to relevant data range)
@@ -542,7 +542,7 @@ def test_1d_density_kwarg(plot_1d, s):
                                              fastkde_contour_plot_2d])
 def test_contour_plot_2d(contour_plot_2d):
     try:
-        ax = plt.gca()
+        fig, ax = plt.subplots()
         np.random.seed(1)
         data_x = np.random.randn(1000)
         data_y = np.random.randn(1000)
@@ -552,17 +552,16 @@ def test_contour_plot_2d(contour_plot_2d):
 
         # Check levels
         with pytest.raises(ValueError):
-            ax = plt.gca()
+            fig, ax = plt.subplots()
             contour_plot_2d(ax, data_x, data_y, levels=[0.68, 0.95])
 
         # Check q
-        ax = plt.gca()
+        fig, ax = plt.subplots()
         contour_plot_2d(ax, data_x, data_y, q=0)
-        plt.close()
 
         # Check unfilled
         cmap = basic_cmap('C2')
-        ax = plt.gca()
+        fig, ax = plt.subplots()
         cf1, ct1 = contour_plot_2d(ax, data_x, data_y, facecolor='C2')
         cf2, ct2 = contour_plot_2d(ax, data_x, data_y, fc='None', cmap=cmap)
         # filled `contourf` and unfilled `contour` colors are the same:
@@ -573,8 +572,7 @@ def test_contour_plot_2d(contour_plot_2d):
         cf, ct = contour_plot_2d(ax, data_x, data_y, ec='C0', cmap=plt.cm.Reds)
         assert cf.get_cmap() == plt.cm.Reds
         assert ct.colors == 'C0'
-        plt.close()
-        ax = plt.gca()
+        fig, ax = plt.subplots()
         cf, ct = contour_plot_2d(ax, data_x, data_y, fc=None)
         assert cf is None
         assert ct.colors is None
@@ -652,9 +650,8 @@ def test_contour_plot_2d_levels(contour_plot_2d, levels):
         y = np.random.randn(1000)
         cmap = plt.cm.viridis
 
-        ax1 = plt.subplot(211)
+        fig, (ax1, ax2) = plt.subplots(2)
         contour_plot_2d(ax1, x, y, levels=levels, cmap=cmap)
-        ax2 = plt.subplot(212)
         contour_plot_2d(ax2, x, y, levels=levels, cmap=cmap, fc=None)
 
         # assert that color between filled and unfilled contours matches
@@ -680,7 +677,7 @@ def test_scatter_plot_2d():
     lines, = scatter_plot_2d(ax, data_x, data_y)
     assert isinstance(lines, Line2D)
 
-    ax = plt.gca()
+    fig, ax = plt.subplots()
     points, = scatter_plot_2d(ax, data_x, data_y, color='C0', lw=1)
     assert (points.get_color() == 'C0')
     points, = scatter_plot_2d(ax, data_x, data_y, cmap=plt.cm.viridis)
@@ -691,7 +688,7 @@ def test_scatter_plot_2d():
     assert (points.get_markeredgecolor() == 'C2')
 
     # Check that q is ignored
-    ax = plt.gca()
+    fig, ax = plt.subplots()
     scatter_plot_2d(ax, data_x, data_y, q=0)
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -27,11 +27,6 @@ def close_figures_on_teardown():
     plt.close("all")
 
 
-@pytest.fixture(autouse=True)
-def open_new_figure_on_setup(close_figures_on_teardown):
-    plt.figure()
-
-
 def test_AxesObjects():
     paramnames = ['a', 'b', 'c']
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -21,12 +21,6 @@ from scipy.special import erf
 from scipy.interpolate import interp1d
 
 
-@pytest.fixture(autouse=True)
-def close_figures_on_teardown():
-    yield
-    plt.close("all")
-
-
 def test_AxesObjects():
     paramnames = ['a', 'b', 'c']
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -20,6 +20,7 @@ except ImportError:
 
 @pytest.fixture(autouse=True)
 def close_figures_on_teardown():
+    plt.figure()
     yield
     plt.close("all")
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -5,7 +5,6 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from pandas.testing import assert_frame_equal
-import matplotlib.pyplot as plt
 from anesthetic import MCMCSamples, NestedSamples
 from anesthetic import read_chains
 from anesthetic.read.polychord import read_polychord

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -18,12 +18,6 @@ except ImportError:
     pass
 
 
-@pytest.fixture(autouse=True)
-def close_figures_on_teardown():
-    yield
-    plt.close("all")
-
-
 def test_read_getdist():
     np.random.seed(3)
     mcmc = read_getdist('./tests/example_data/gd')

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -18,6 +18,12 @@ except ImportError:
     pass
 
 
+@pytest.fixture(autouse=True)
+def close_figures_on_teardown():
+    yield
+    plt.close("all")
+
+
 def test_read_getdist():
     np.random.seed(3)
     mcmc = read_getdist('./tests/example_data/gd')
@@ -44,7 +50,6 @@ def test_read_getdist():
     assert_array_equal(mcmc.get_labels(), labels)
     mcmc.plot_2d(['x0', 'x1', 'x2', 'x3'])
     mcmc.plot_1d(['x0', 'x1', 'x2', 'x3'])
-    plt.close("all")
 
     os.rename('./tests/example_data/gd.paramnames',
               './tests/example_data/gd.paramnames_')
@@ -81,7 +86,6 @@ def test_read_cobayamcmc():
 
     mcmc.plot_2d(['x0', 'x1'])
     mcmc.plot_1d(['x0', 'x1'])
-    plt.close("all")
 
     # single chain file
     mcmc = read_cobaya('./tests/example_data/cb_single_chain')
@@ -144,7 +148,6 @@ def test_read_montepython():
     assert isinstance(mcmc, MCMCSamples)
     mcmc.plot_2d(['x0', 'x1', 'x2', 'x3'])
     mcmc.plot_1d(['x0', 'x1', 'x2', 'x3'])
-    plt.close("all")
 
 
 def test_read_multinest():
@@ -174,7 +177,6 @@ def test_read_multinest():
     assert isinstance(ns, NestedSamples)
     ns.plot_2d(['x0', 'x1', 'x2', 'x3'])
     ns.plot_1d(['x0', 'x1', 'x2', 'x3'])
-    plt.close("all")
 
 
 def test_read_polychord():
@@ -199,7 +201,6 @@ def test_read_polychord():
 
     ns.plot_2d(['x0', 'x1', 'x2', 'x3'])
     ns.plot_1d(['x0', 'x1', 'x2', 'x3'])
-    plt.close("all")
 
     os.rename('./tests/example_data/pc_phys_live-birth.txt',
               './tests/example_data/pc_phys_live-birth.txt_')

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -24,11 +24,6 @@ def close_figures_on_teardown():
     plt.close("all")
 
 
-@pytest.fixture(autouse=True)
-def open_new_figure_on_setup(close_figures_on_teardown):
-    plt.figure()
-
-
 def test_read_getdist():
     np.random.seed(3)
     mcmc = read_getdist('./tests/example_data/gd')

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -20,9 +20,13 @@ except ImportError:
 
 @pytest.fixture(autouse=True)
 def close_figures_on_teardown():
-    plt.figure()
     yield
     plt.close("all")
+
+
+@pytest.fixture(autouse=True)
+def open_new_figure_on_setup(close_figures_on_teardown):
+    plt.figure()
 
 
 def test_read_getdist():

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -28,11 +28,6 @@ def close_figures_on_teardown():
     plt.close("all")
 
 
-@pytest.fixture(autouse=True)
-def open_new_figure_on_setup(close_figures_on_teardown):
-    plt.figure()
-
-
 def test_build_samples():
     np.random.seed(3)
     nsamps = 1000

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1134,7 +1134,8 @@ def test_samples_dot_plot():
     samples = read_chains('./tests/example_data/pc')
     axes = samples[['x0', 'x1', 'x2', 'x3', 'x4']].plot.hist()
     assert len(axes.containers) == 5
-    axes = samples.x0.plot.kde(subplots=True)
+    fig, ax = plt.subplots()
+    axes = samples.x0.plot.kde(subplots=True, ax=ax)
     assert len(axes) == 1
     axes = samples[['x0', 'x1']].plot.kde(subplots=True)
     assert len(axes) == 2
@@ -1149,10 +1150,11 @@ def test_samples_dot_plot():
     assert axes.get_ylabel() == 'x0'
     axes = samples.plot.scatter_2d('x2', 'x3')
     assert len(axes.lines) == 1
-    plt.close("all")
-    axes = samples.x1.plot.kde_1d()
+    fig, ax = plt.subplots()
+    axes = samples.x1.plot.kde_1d(ax=ax)
     assert len(axes.lines) == 1
-    axes = samples.x2.plot.hist_1d()
+    fig, ax = plt.subplots()
+    axes = samples.x2.plot.hist_1d(ax=ax)
     assert len(axes.containers) == 1
 
     try:

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -24,9 +24,13 @@ from wedding_cake import WeddingCake
 
 @pytest.fixture(autouse=True)
 def close_figures_on_teardown():
-    plt.figure()
     yield
     plt.close("all")
+
+
+@pytest.fixture(autouse=True)
+def open_new_figure_on_setup(close_figures_on_teardown):
+    plt.figure()
 
 
 def test_build_samples():

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -22,12 +22,6 @@ from scipy.stats import ks_2samp, kstest, norm
 from wedding_cake import WeddingCake
 
 
-@pytest.fixture(autouse=True)
-def close_figures_on_teardown():
-    yield
-    plt.close("all")
-
-
 def test_build_samples():
     np.random.seed(3)
     nsamps = 1000

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -22,6 +22,12 @@ from scipy.stats import ks_2samp, kstest, norm
 from wedding_cake import WeddingCake
 
 
+@pytest.fixture(autouse=True)
+def close_figures_on_teardown():
+    yield
+    plt.close("all")
+
+
 def test_build_samples():
     np.random.seed(3)
     nsamps = 1000
@@ -101,7 +107,6 @@ def test_different_parameters():
     ns.plot_2d(axes)
     fig, axes = make_2d_axes([params_x, params_y])
     ns.plot_2d(axes)
-    plt.close('all')
 
 
 def test_manual_columns():
@@ -178,8 +183,6 @@ def test_plot_2d_kinds():
     with pytest.raises(ValueError):
         ns.plot_2d(params, kind='eggs')
 
-    plt.close("all")
-
 
 def test_plot_2d_kinds_multiple_calls():
     np.random.seed(3)
@@ -195,7 +198,6 @@ def test_plot_2d_kinds_multiple_calls():
     ns.plot_2d(axes, kind={'diagonal': 'kde_1d',
                            'lower': 'kde_2d',
                            'upper': 'scatter_2d'})
-    plt.close('all')
 
 
 def test_root_and_label():
@@ -241,8 +243,6 @@ def test_plot_2d_legend():
                 else:
                     assert all([isinstance(h, Rectangle) for h in handles])
 
-    plt.close('all')
-
     # Test label kwarg for hist and scatter
     fig, axes = make_2d_axes(params, lower=False)
     ns.plot_2d(axes, label='l1', kind=dict(diagonal='hist_1d',
@@ -263,7 +263,6 @@ def test_plot_2d_legend():
                 else:
                     assert all([isinstance(h, Line2D)
                                 for h in handles])
-    plt.close('all')
 
     # test default labelling
     fig, axes = make_2d_axes(params, upper=False)
@@ -275,7 +274,6 @@ def test_plot_2d_legend():
             if ax is not None:
                 handles, labels = ax.get_legend_handles_labels()
                 assert labels == ['pc', 'gd']
-    plt.close('all')
 
     # Test label kwarg to constructors
     ns = read_chains('./tests/example_data/pc', label='l1')
@@ -291,7 +289,6 @@ def test_plot_2d_legend():
             if ax is not None:
                 handles, labels = ax.get_legend_handles_labels()
                 assert labels == ['l1', 'l2']
-    plt.close('all')
 
 
 def test_plot_2d_colours():
@@ -338,7 +335,6 @@ def test_plot_2d_colours():
         assert len(set(gd_colors)) == 1
         assert len(set(mn_colors)) == 1
         assert len(set(pc_colors)) == 1
-        plt.close("all")
 
 
 def test_plot_1d_colours():
@@ -381,7 +377,6 @@ def test_plot_1d_colours():
         assert len(set(gd_colors)) == 1
         assert len(set(mn_colors)) == 1
         assert len(set(pc_colors)) == 1
-        plt.close("all")
 
 
 @pytest.mark.xfail('astropy' not in sys.modules,
@@ -391,7 +386,6 @@ def test_astropyhist():
     np.random.seed(3)
     ns = read_chains('./tests/example_data/pc')
     ns.plot_1d(['x0', 'x1', 'x2', 'x3'], kind='hist_1d', bins='knuth')
-    plt.close("all")
 
 
 def test_hist_levels():
@@ -399,7 +393,6 @@ def test_hist_levels():
     ns = read_chains('./tests/example_data/pc')
     ns.plot_2d(['x0', 'x1', 'x2', 'x3'], kind={'lower': 'hist_2d'},
                levels=[0.95, 0.68], bins=20)
-    plt.close("all")
 
 
 def test_logX():
@@ -774,7 +767,6 @@ def test_weighted_merging():
         prior_samples.append(tmp)
     merge_prior = merge_samples_weighted(prior_samples, weights=np.ones(3))
     merge_prior.plot_2d(["x", "y"])
-    plt.close('all')
 
     # Test if correct exceptions are raised:
     # MCMCSamples are passed without weights
@@ -1142,7 +1134,6 @@ def test_logL_list():
 
     samples = NestedSamples(data=data, logL=logL, logL_birth=logL_birth)
     assert_array_equal(default, samples)
-    plt.close("all")
 
 
 def test_samples_dot_plot():
@@ -1153,39 +1144,30 @@ def test_samples_dot_plot():
     assert len(axes) == 1
     axes = samples[['x0', 'x1']].plot.kde(subplots=True)
     assert len(axes) == 2
-    plt.close("all")
 
     axes = samples.plot.kde_2d('x0', 'x1')
     assert len(axes.collections) == 5
     assert axes.get_xlabel() == 'x0'
     assert axes.get_ylabel() == 'x1'
-    plt.close("all")
     axes = samples.plot.hist_2d('x1', 'x0')
     assert len(axes.collections) == 1
     assert axes.get_xlabel() == 'x1'
     assert axes.get_ylabel() == 'x0'
-    plt.close("all")
     axes = samples.plot.scatter_2d('x2', 'x3')
     assert len(axes.lines) == 1
     plt.close("all")
     axes = samples.x1.plot.kde_1d()
     assert len(axes.lines) == 1
-    plt.close("all")
     axes = samples.x2.plot.hist_1d()
     assert len(axes.containers) == 1
-    plt.close("all")
 
     try:
         axes = samples.plot.fastkde_2d('x0', 'x1')
         assert len(axes.collections) == 5
-        plt.close("all")
         axes = samples.plot.fastkde_1d()
         assert len(axes.lines) == 1
-        plt.close("all")
     except ImportError:
         pass
-
-    plt.close("all")
 
 
 def test_fixed_width():

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -24,6 +24,7 @@ from wedding_cake import WeddingCake
 
 @pytest.fixture(autouse=True)
 def close_figures_on_teardown():
+    plt.figure()
     yield
     plt.close("all")
 

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -763,7 +763,6 @@ def test_BoxPlot(mcmc_df, mcmc_wdf):
     mcmc_wdf.iloc[:len(mcmc_wdf)//2, -1] = 'A'
     mcmc_wdf.iloc[len(mcmc_wdf)//2:, -1] = 'B'
 
-
     for return_type in ['dict', 'both']:
         mcmc_wdf.plot.box(return_type=return_type)
         mcmc_wdf.boxplot(return_type=return_type)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -763,8 +763,12 @@ def test_BoxPlot(mcmc_df, mcmc_wdf):
     mcmc_wdf.iloc[:len(mcmc_wdf)//2, -1] = 'A'
     mcmc_wdf.iloc[len(mcmc_wdf)//2:, -1] = 'B'
 
-    mcmc_df.groupby('split').boxplot()
-    mcmc_wdf.groupby('split').boxplot()
+    axes_df = mcmc_df.groupby('split').boxplot()
+    axes_wdf = mcmc_wdf.groupby('split').boxplot()
+    for ax in axes_df:
+        plt.close(ax.get_figure())
+    for ax in axes_wdf:
+        plt.close(ax.get_figure())
 
     for return_type in ['dict', 'both']:
         mcmc_wdf.plot.box(return_type=return_type)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -746,8 +746,8 @@ def test_BoxPlot(mcmc_df, mcmc_wdf):
     fig, ax = plt.subplots()
     mcmc_wdf.x.plot.box(ax=ax)
 
-    axes_df = mcmc_df.plot.box(subplots=True)
-    axes_wdf = mcmc_wdf.plot.box(subplots=True)
+    mcmc_df.plot.box(subplots=True)
+    mcmc_wdf.plot.box(subplots=True)
 
     mcmc_df['split'] = ''
     mcmc_df.loc[:len(mcmc_df)//2, 'split'] = 'A'
@@ -820,19 +820,19 @@ def test_BarPlot(mcmc_df, mcmc_wdf):
 
 
 def test_PiePlot(mcmc_df, mcmc_wdf):
-    mcmc_wdf[5:10].x.plot.pie()
+    fig, ax = plt.subplots()
+    mcmc_wdf[5:10].x.plot.pie(ax=ax)
     mcmc_wdf[5:10].plot.pie(subplots=True)
 
 
 def test_LinePlot(mcmc_df, mcmc_wdf):
-    plt.figure()
-    df_axes = mcmc_df.x.plot.line()
+    fig, ax = plt.subplots()
+    df_axes = mcmc_df.x.plot.line(ax=ax)
     assert_array_equal(mcmc_df.index, df_axes.lines[0].get_xdata())
-    plt.close()
-    wdf_axes = mcmc_wdf.x.plot.line()
+    fig, ax = plt.subplots()
+    wdf_axes = mcmc_wdf.x.plot.line(ax=ax)
     assert_array_equal(mcmc_wdf.index.droplevel('weights'),
                        wdf_axes.lines[0].get_xdata())
-    plt.close()
     wdf_axes = mcmc_wdf.plot.line()
     assert len(wdf_axes.lines) == len(mcmc_wdf.columns)
 

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -12,6 +12,12 @@ from pandas.plotting._matplotlib.misc import (
 )
 
 
+@pytest.fixture(autouse=True)
+def close_figures_on_teardown():
+    yield
+    plt.close("all")
+
+
 @pytest.fixture
 def series():
     np.random.seed(0)
@@ -655,8 +661,6 @@ def test_WeightedDataFrame_hist(mcmc_df, mcmc_wdf):
     wdf_xys = [p.get_xy() for ax in wdf_axes for p in ax.patches]
     assert df_xys == wdf_xys
 
-    plt.close("all")
-
 
 def test_WeightedSeries_hist(mcmc_df, mcmc_wdf):
 
@@ -692,8 +696,6 @@ def test_WeightedSeries_hist(mcmc_df, mcmc_wdf):
     wdf_xys = [p.get_xy() for p in axes[1].patches]
     assert df_xys == wdf_xys
 
-    plt.close("all")
-
 
 def test_KdePlot(mcmc_df, mcmc_wdf):
     bw_method = 0.3
@@ -703,8 +705,6 @@ def test_KdePlot(mcmc_df, mcmc_wdf):
     df_line, wdf_line = axes[0].lines[0], axes[1].lines[0]
     assert (df_line.get_xdata() == wdf_line.get_xdata()).all()
     assert_allclose(df_line.get_ydata(),  wdf_line.get_ydata(), atol=1e-4)
-
-    plt.close("all")
 
 
 def test_scatter_matrix(mcmc_df, mcmc_wdf):
@@ -730,13 +730,10 @@ def test_scatter_matrix(mcmc_df, mcmc_wdf):
     n = len(axes[0, 1].collections[0].get_offsets().data)
     assert_allclose(n, 50, atol=np.sqrt(n))
 
-    plt.close("all")
-
 
 def test_bootstrap_plot(mcmc_df, mcmc_wdf):
     bootstrap_plot(mcmc_wdf.x)
     bootstrap_plot(mcmc_wdf.x, ncompress=500)
-    plt.close("all")
 
 
 def test_BoxPlot(mcmc_df, mcmc_wdf):
@@ -765,8 +762,6 @@ def test_BoxPlot(mcmc_df, mcmc_wdf):
     mcmc_df.groupby('split').boxplot()
     mcmc_wdf.groupby('split').boxplot()
 
-    plt.close("all")
-
     for return_type in ['dict', 'both']:
         mcmc_wdf.plot.box(return_type=return_type)
         mcmc_wdf.boxplot(return_type=return_type)
@@ -776,8 +771,6 @@ def test_BoxPlot(mcmc_df, mcmc_wdf):
 
     mcmc_wdf.boxplot(vert=False)
     mcmc_wdf.boxplot(fontsize=30)
-
-    plt.close("all")
 
 
 def test_ScatterPlot(mcmc_df, mcmc_wdf):
@@ -791,8 +784,6 @@ def test_ScatterPlot(mcmc_df, mcmc_wdf):
     ax = mcmc_wdf.plot.scatter('x', 'y', ncompress=50)
     n = len(ax.collections[0].get_offsets().data)
     assert_allclose(n, 50, atol=np.sqrt(50))
-
-    plt.close("all")
 
 
 def test_HexBinPlot(mcmc_df, mcmc_wdf):
@@ -815,8 +806,6 @@ def test_AreaPlot(mcmc_df, mcmc_wdf):
     assert_allclose(axes_df.get_xlim(), axes_wdf.get_xlim(), rtol=1e-3)
     assert_allclose(axes_df.get_ylim(), axes_wdf.get_ylim(), rtol=1e-3)
 
-    plt.close("all")
-
 
 def test_BarPlot(mcmc_df, mcmc_wdf):
     axes_bar = mcmc_wdf[5:10].plot.bar()
@@ -824,27 +813,22 @@ def test_BarPlot(mcmc_df, mcmc_wdf):
     assert_array_equal(axes_bar.get_xticks(), axes_barh.get_yticks())
     assert_array_equal(axes_bar.get_yticks(), axes_barh.get_xticks())
 
-    plt.close("all")
-
 
 def test_PiePlot(mcmc_df, mcmc_wdf):
     mcmc_wdf[5:10].x.plot.pie()
     mcmc_wdf[5:10].plot.pie(subplots=True)
 
-    plt.close("all")
-
 
 def test_LinePlot(mcmc_df, mcmc_wdf):
     df_axes = mcmc_df.x.plot.line()
     assert_array_equal(mcmc_df.index, df_axes.lines[0].get_xdata())
-    plt.close("all")
+    plt.close()
     wdf_axes = mcmc_wdf.x.plot.line()
     assert_array_equal(mcmc_wdf.index.droplevel('weights'),
                        wdf_axes.lines[0].get_xdata())
-    plt.close("all")
+    plt.close()
     wdf_axes = mcmc_wdf.plot.line()
     assert len(wdf_axes.lines) == len(mcmc_wdf.columns)
-    plt.close("all")
 
 
 def test_multiindex(mcmc_wdf):

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -801,6 +801,8 @@ def test_HexBinPlot(mcmc_df, mcmc_wdf):
 
 
 def test_AreaPlot(mcmc_df, mcmc_wdf):
+    plt.figure()
+    
     axes_wdf = mcmc_wdf.plot.area()
     axes_df = mcmc_df.plot.area()
 

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -18,11 +18,6 @@ def close_figures_on_teardown():
     plt.close("all")
 
 
-@pytest.fixture(autouse=True)
-def open_new_figure_on_setup(close_figures_on_teardown):
-    plt.figure()
-
-
 @pytest.fixture
 def series():
     np.random.seed(0)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -12,12 +12,6 @@ from pandas.plotting._matplotlib.misc import (
 )
 
 
-@pytest.fixture(autouse=True)
-def close_figures_on_teardown():
-    yield
-    plt.close("all")
-
-
 @pytest.fixture
 def series():
     np.random.seed(0)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -14,6 +14,7 @@ from pandas.plotting._matplotlib.misc import (
 
 @pytest.fixture(autouse=True)
 def close_figures_on_teardown():
+    plt.figure()
     yield
     plt.close("all")
 

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -734,20 +734,20 @@ def test_BoxPlot(mcmc_df, mcmc_wdf):
     mcmc_df.plot.box()
     mcmc_wdf.plot.box()
 
-    mcmc_df.boxplot()
-    mcmc_wdf.boxplot()
+    fig, ax = plt.subplots()
+    mcmc_df.boxplot(ax=ax)
 
-    plt.close("all")
-    mcmc_df.x.plot.box()
-    plt.close("all")
-    mcmc_wdf.x.plot.box()
+    fig, ax = plt.subplots()
+    mcmc_wdf.boxplot(ax=ax)
+
+    fig, ax = plt.subplots()
+    mcmc_df.x.plot.box(ax=ax)
+
+    fig, ax = plt.subplots()
+    mcmc_wdf.x.plot.box(ax=ax)
 
     axes_df = mcmc_df.plot.box(subplots=True)
     axes_wdf = mcmc_wdf.plot.box(subplots=True)
-    for ax in axes_df:
-        plt.close(ax.get_figure())
-    for ax in axes_wdf:
-        plt.close(ax.get_figure())
 
     mcmc_df['split'] = ''
     mcmc_df.loc[:len(mcmc_df)//2, 'split'] = 'A'
@@ -757,15 +757,25 @@ def test_BoxPlot(mcmc_df, mcmc_wdf):
     mcmc_wdf.iloc[:len(mcmc_wdf)//2, -1] = 'A'
     mcmc_wdf.iloc[len(mcmc_wdf)//2:, -1] = 'B'
 
+    mcmc_df.groupby('split').boxplot()
+    mcmc_wdf.groupby('split').boxplot()
+
     for return_type in ['dict', 'both']:
-        mcmc_wdf.plot.box(return_type=return_type)
-        mcmc_wdf.boxplot(return_type=return_type)
+        fig, ax = plt.subplots()
+        mcmc_wdf.plot.box(return_type=return_type, ax=ax)
+        fig, ax = plt.subplots()
+        mcmc_wdf.boxplot(return_type=return_type, ax=ax)
 
-    mcmc_wdf.boxplot(xlabel='xlabel')
-    mcmc_wdf.boxplot(ylabel='ylabel')
+    fig, ax = plt.subplots()
+    mcmc_wdf.boxplot(xlabel='xlabel', ax=ax)
+    fig, ax = plt.subplots()
+    mcmc_wdf.boxplot(ylabel='ylabel', ax=ax)
 
-    mcmc_wdf.boxplot(vert=False)
-    mcmc_wdf.boxplot(fontsize=30)
+    fig, ax = plt.subplots()
+    mcmc_wdf.boxplot(vert=False, ax=ax)
+
+    fig, ax = plt.subplots()
+    mcmc_wdf.boxplot(fontsize=30, ax=ax)
 
 
 def test_ScatterPlot(mcmc_df, mcmc_wdf):

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -14,9 +14,13 @@ from pandas.plotting._matplotlib.misc import (
 
 @pytest.fixture(autouse=True)
 def close_figures_on_teardown():
-    plt.figure()
     yield
     plt.close("all")
+
+
+@pytest.fixture(autouse=True)
+def open_new_figure_on_setup(close_figures_on_teardown):
+    plt.figure()
 
 
 @pytest.fixture
@@ -801,7 +805,6 @@ def test_HexBinPlot(mcmc_df, mcmc_wdf):
 
 
 def test_AreaPlot(mcmc_df, mcmc_wdf):
-    plt.figure()
     axes_wdf = mcmc_wdf.plot.area()
     axes_df = mcmc_df.plot.area()
 

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -753,8 +753,12 @@ def test_BoxPlot(mcmc_df, mcmc_wdf):
     plt.close("all")
     mcmc_wdf.x.plot.box()
 
-    mcmc_df.plot.box(subplots=True)
-    mcmc_wdf.plot.box(subplots=True)
+    axes_df = mcmc_df.plot.box(subplots=True)
+    axes_wdf = mcmc_wdf.plot.box(subplots=True)
+    for ax in axes_df:
+        plt.close(ax.get_figure())
+    for ax in axes_wdf:
+        plt.close(ax.get_figure())
 
     mcmc_df['split'] = ''
     mcmc_df.loc[:len(mcmc_df)//2, 'split'] = 'A'

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -802,7 +802,6 @@ def test_HexBinPlot(mcmc_df, mcmc_wdf):
 
 def test_AreaPlot(mcmc_df, mcmc_wdf):
     plt.figure()
-    
     axes_wdf = mcmc_wdf.plot.area()
     axes_df = mcmc_df.plot.area()
 

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -763,12 +763,6 @@ def test_BoxPlot(mcmc_df, mcmc_wdf):
     mcmc_wdf.iloc[:len(mcmc_wdf)//2, -1] = 'A'
     mcmc_wdf.iloc[len(mcmc_wdf)//2:, -1] = 'B'
 
-    axes_df = mcmc_df.groupby('split').boxplot()
-    axes_wdf = mcmc_wdf.groupby('split').boxplot()
-    for ax in axes_df:
-        plt.close(ax.get_figure())
-    for ax in axes_wdf:
-        plt.close(ax.get_figure())
 
     for return_type in ['dict', 'both']:
         mcmc_wdf.plot.box(return_type=return_type)

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -815,6 +815,7 @@ def test_PiePlot(mcmc_df, mcmc_wdf):
 
 
 def test_LinePlot(mcmc_df, mcmc_wdf):
+    plt.figure()
     df_axes = mcmc_df.x.plot.line()
     assert_array_equal(mcmc_df.index, df_axes.lines[0].get_xdata())
     plt.close()

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -805,8 +805,9 @@ def test_HexBinPlot(mcmc_df, mcmc_wdf):
 
 
 def test_AreaPlot(mcmc_df, mcmc_wdf):
-    axes_wdf = mcmc_wdf.plot.area()
-    axes_df = mcmc_df.plot.area()
+    fig, (ax1, ax2) = plt.subplots(1, 2)
+    axes_df = mcmc_df.plot.area(ax=ax1)
+    axes_wdf = mcmc_wdf.plot.area(ax=ax2)
 
     assert_allclose(axes_df.get_xlim(), axes_wdf.get_xlim(), rtol=1e-3)
     assert_allclose(axes_df.get_ylim(), axes_wdf.get_ylim(), rtol=1e-3)


### PR DESCRIPTION
# Description

This PR achieve two things
1) It streamlines the CI so that we test [osx,windows]x[pip,conda]x[3.10] + [linux]x[pip,conda]x[3.8,3.9,3.10]. This reduces build times since osx and windows are reduced by a factor of 3, and expands the (much faster) linux builds to include 3.9.
2) We aim to remove all side effects from pandas plotting functions

(2) is an insidious bug which has been affecting all current PRs non-deterministically. Tests pass on local machines, but when lifted to the CI servers sometimes break in certain functions. The hypothesis is that pandas plotting is very inconsistent, for example `.plot.box()` creates a new axis, whilst `.boxplot()` uses the 'current axis' with e.g. `plt.gca()`. It is the latter functions which cause the problem by potentially getting a current axis somewhere else in the test suite, which depends on how fast/parallel/ordered the builds are. Failing tests can thus arise in either function depending on the current axis and the effect of both things writing to it simultaneously, so apparently healthy functions can fail. We aimed to control this by copious `plt.close()` commands, but this only partially solves the issue since presumably a new axis can be created in between the last `plt.close()` and the next `plt.gca()`.

The solution is to go through the test suite and find any functions which have `plt.gca()` functionality, and to explicitly pass them a newly created axis. I have done this, and removed all `plt.close()` commands.

This has been re-visited in #235 #221 #222

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [X] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [X] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [X] I have added tests that prove my fix is effective or that my feature works
