### PR TITLE
reduce CI workflow matrices

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8, '3.10']
         extras: [true, false]
+		exclude:
+		  - os: macos-latest
+			python-version: 3.8
+		  - os: windows-latest
+			python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2
@@ -64,6 +69,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8, '3.10']
+		exclude:
+		  - os: macos-latest
+			python-version: 3.8
+		  - os: windows-latest
+			python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,14 +31,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, '3.10']
+        os: [ubuntu-latest]
+        python-version: ['3.8', '3.9', '3.10']
         extras: [true, false]
-		exclude:
-		  - os: macos-latest
-			python-version: 3.8
-		  - os: windows-latest
-			python-version: 3.8
+        include:
+          - os: macos-latest
+            python-version: '3.10'
+            extras: true
+          - os: windows-latest
+            python-version: '3.10'
+            extras: true
 
     steps:
     - uses: actions/checkout@v2
@@ -67,13 +69,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, '3.10']
-		exclude:
-		  - os: macos-latest
-			python-version: 3.8
-		  - os: windows-latest
-			python-version: 3.8
+        os: [ubuntu-latest]
+        python-version: ['3.8', '3.9', '3.10']
+        include:
+          - os: macos-latest
+            python-version: '3.10'
+          - os: windows-latest
+            python-version: '3.10'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
macos and windows workflows are stuck much longer in the GitHub action queues and we might not need a quite as extensive coverage of all options. 

This PR reduces the workflow matrix such that macos and windows are only run with python version 3.10.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My code is PEP8 compliant (`flake8 anesthetic tests`)
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy anesthetic`)
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [ ] I have added tests that prove my fix is effective or that my feature works
