### PR TITLE
`.to_numpy()`

### DIFF
--- a/anesthetic/examples/perfect_ns.py
+++ b/anesthetic/examples/perfect_ns.py
@@ -53,8 +53,10 @@ def gaussian(nlive, ndims, sigma=0.1, R=1, logLmin=-1e-2):
         r = (points**2).sum(axis=-1, keepdims=True)**0.5
 
     samples = merge_nested_samples(samples)
-    logLend = samples[samples.nlive >= nlive].logL.max()
-    return samples[samples.logL_birth < logLend].recompute()
+    print("here0")
+    logLend = samples[(samples.nlive >= nlive).to_numpy()].logL.max()
+    print("here1")
+    return samples[(samples.logL_birth < logLend).to_numpy()].recompute()
 
 
 def correlated_gaussian(nlive, mean, cov, bounds=None):

--- a/anesthetic/examples/perfect_ns.py
+++ b/anesthetic/examples/perfect_ns.py
@@ -53,9 +53,7 @@ def gaussian(nlive, ndims, sigma=0.1, R=1, logLmin=-1e-2):
         r = (points**2).sum(axis=-1, keepdims=True)**0.5
 
     samples = merge_nested_samples(samples)
-    print("here0")
     logLend = samples[(samples.nlive >= nlive).to_numpy()].logL.max()
-    print("here1")
     return samples[(samples.logL_birth < logLend).to_numpy()].recompute()
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -57,7 +57,9 @@ def test_perfect_ns_gaussian():
 
     samples = gaussian(nlive, ndims, sigma, R)
 
+    print("here0")
     assert (samples[:-nlive].nlive == nlive).all()
+    print("here")
 
     mean = samples[np.arange(ndims)].mean()
     assert_allclose(mean, 0, atol=1e-2)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -57,9 +57,7 @@ def test_perfect_ns_gaussian():
 
     samples = gaussian(nlive, ndims, sigma, R)
 
-    print("here0")
     assert (samples[:-nlive].nlive == nlive).all()
-    print("here")
 
     mean = samples[np.arange(ndims)].mean()
     assert_allclose(mean, 0, atol=1e-2)


### PR DESCRIPTION
Use `to_numpy()` on boolean mask in Gaussian example to prevent `UserWarnings`

I seriously think we need to have something which resists PRs introducing new warnings...