### PR TITLE
replace `.boxplot()`with `.plot.box()`

### DIFF
--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -763,8 +763,8 @@ def test_BoxPlot(mcmc_df, mcmc_wdf):
     mcmc_wdf.iloc[:len(mcmc_wdf)//2, -1] = 'A'
     mcmc_wdf.iloc[len(mcmc_wdf)//2:, -1] = 'B'
 
-    mcmc_df.groupby('split').plot.box()
-    mcmc_wdf.groupby('split').plot.box()
+    mcmc_df.groupby('split').boxplot()
+    mcmc_wdf.groupby('split').boxplot()
 
     for return_type in ['dict', 'both']:
         fig, ax = plt.subplots()

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -817,6 +817,8 @@ def test_AreaPlot(mcmc_df, mcmc_wdf):
 
     assert_allclose(axes_df.get_xlim(), axes_wdf.get_xlim(), rtol=1e-3)
     assert_allclose(axes_df.get_ylim(), axes_wdf.get_ylim(), rtol=1e-3)
+    assert_allclose(axes_df.get_ylim()[0], 0.0, rtol=1e-3)
+    assert_allclose(axes_wdf.get_ylim()[0], 0.0, rtol=1e-3)
 
 
 def test_BarPlot(mcmc_df, mcmc_wdf):

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -763,8 +763,8 @@ def test_BoxPlot(mcmc_df, mcmc_wdf):
     mcmc_wdf.iloc[:len(mcmc_wdf)//2, -1] = 'A'
     mcmc_wdf.iloc[len(mcmc_wdf)//2:, -1] = 'B'
 
-    mcmc_df.groupby('split').boxplot()
-    mcmc_wdf.groupby('split').boxplot()
+    mcmc_df.groupby('split').plot.box()
+    mcmc_wdf.groupby('split').plot.box()
 
     for return_type in ['dict', 'both']:
         fig, ax = plt.subplots()

--- a/tests/test_weighted_pandas.py
+++ b/tests/test_weighted_pandas.py
@@ -817,8 +817,6 @@ def test_AreaPlot(mcmc_df, mcmc_wdf):
 
     assert_allclose(axes_df.get_xlim(), axes_wdf.get_xlim(), rtol=1e-3)
     assert_allclose(axes_df.get_ylim(), axes_wdf.get_ylim(), rtol=1e-3)
-    assert_allclose(axes_df.get_ylim()[0], 0.0, rtol=1e-3)
-    assert_allclose(axes_wdf.get_ylim()[0], 0.0, rtol=1e-3)
 
 
 def test_BarPlot(mcmc_df, mcmc_wdf):


### PR DESCRIPTION
Replacing `df.groupby('split').boxplot()` with `df.groupby('split').plot.box()` in `tests/test_weighted_pandas.py::test_BoxPlot()` seems to avoid the problem where the plots in the later `test_AreaPlot()` non-deterministically believe their axes to be shared, which prevents them from setting the lower y limit to 0. The original tests only fail when this happens to only one of the two.

Seeing as this is occurring for unmodified `pandas.DataFrame`s, I don't think this is something we can fix easily in `anesthetic`

- [x] Check that this doesn't reduce coverage
- [x] @williamjameshandley @lukashergt do you think it's appropriate to explicitly check that the lower y limit is 0? (they do not)